### PR TITLE
Set up CI, CLA and templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @shopify/learn-libs-superteam

--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -1,0 +1,35 @@
+---
+name: '🐛 Bug Report'
+about: Something isn't working
+labels: 'Type: Bug 🐛'
+---
+
+# Issue summary
+
+Write a short description of the issue here ↓
+
+## Expected behavior
+
+What do you think should happen?
+
+## Actual behavior
+
+What actually happens?
+
+Tip: include an error message (in a `<details></details>` tag) if your issue is related to an error
+
+## Steps to reproduce the problem
+
+1.
+1.
+1.
+
+## Reduced test case
+
+The best way to get your bug fixed is to provide a [reduced test case](https://webkit.org/test-case-reduction/).
+
+---
+
+## Checklist
+
+- [ ] I have described this issue in a way that is actionable (if possible)

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
@@ -1,0 +1,25 @@
+---
+name: '📈 Enhancement'
+about: Enhancement to our codebase that isn't a adding or changing a feature
+labels: 'Type: Enhancement 📈'
+---
+
+## Overview/summary
+
+...
+
+## Motivation
+
+> What inspired this enhancement?
+
+...
+
+### Area
+
+- [ ] Add any relevant `Area: <area>` labels to this issue
+
+---
+
+## Checklist
+
+- [ ] I have described this enhancement in a way that is actionable (if possible)

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,30 @@
+---
+name: '🙌 Feature Request'
+about: Suggest a new feature, or changes to an existing one
+labels: 'Type: Feature Request :raised_hands:'
+---
+
+## Overview
+
+...
+
+## Type
+
+- [ ] New feature
+- [ ] Changes to existing features
+
+## Motivation
+
+> What inspired this feature request? What problems were you facing?
+
+...
+
+### Area
+
+- [ ] Add any relevant `Area: <area>` labels to this issue
+
+---
+
+## Checklist
+
+- [ ] I have described this feature request in a way that is actionable (if possible)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+<!--
+  ☝️How to write a good PR title:
+  - Prefix it with [Feature] (if applicable)
+  - Start with a verb, for example: Add, Delete, Improve, Fix…
+  - Give as much context as necessary and as little as possible
+  - Prefix it with [WIP] while it’s a work in progress
+-->
+
+### WHY are these changes introduced?
+
+Fixes #0000 <!-- link to issue if one exists -->
+
+<!--
+  Context about the problem that’s being addressed.
+-->
+
+### WHAT is this pull request doing?
+
+<!--
+  Summary of the changes committed.
+  Before / after screenshots appreciated for UI changes, if applicable.
+-->
+
+## Type of change
+
+- [ ] Patch: Bug (non-breaking change which fixes an issue)
+- [ ] Minor: New feature (non-breaking change which adds functionality)
+- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)
+
+## Checklist
+
+- [ ] I have added a changelog entry, prefixed by the type of change noted above
+- [ ] I have added/updated tests for this change
+- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,42 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Issues or Pull Requests with these labels will never be considered stale.
+# Set to `[]` to disable
+exemptLabels:
+  - Security
+
+# Label to use when marking as stale
+staleLabel: Stale
+
+pulls:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  daysUntilStale: 90
+
+  # Number of days of inactivity before a Pull Request with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually,
+  # but will remain marked as stale.
+  daysUntilClose: 14
+
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    activity in 90 days. It will be closed if no further activity occurs.
+
+issues:
+  # Number of days of inactivity before an Issue or Pull Request becomes stale
+  # TO-DO: the real value will be 90, this version is for testing
+  daysUntilStale: 1
+
+  # Issues labeled `Confirmed` are ignored
+  exemptLabels:
+    - Confirmed
+
+  # Number of days of inactivity before an Issue with the stale label is closed.
+  # Set to false to disable. If disabled, issues still need to be closed manually,
+  # but will remain marked as stale.
+  daysUntilClose: 14
+
+  # Comment to post when marking as stale. Set to `false` to disable
+  markComment: >
+    This issue has been automatically marked as stale because it has not had
+    activity in 90 days. It will be closed if no further activity occurs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: CI
+jobs:
+  CI:
+    name: CI (${{ matrix.version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [14, 16, 18]
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.version }}
+      - name: Install
+        run: yarn install
+      - name: Run tests
+        run: yarn test:all

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,22 @@
+name: Contributor License Agreement (CLA)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+  issue_comment:
+    types: [created]
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    if: |
+      (github.event.issue.pull_request
+        && !github.event.issue.pull_request.merged_at
+        && contains(github.event.comment.body, 'signed')
+      )
+      || (github.event.pull_request && !github.event.pull_request.merged)
+    steps:
+      - uses: Shopify/shopify-cla-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          cla-token: ${{ secrets.CLA_TOKEN }}

--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,0 +1,12 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: '.github/workflows/markdown_link_checker_config.json'

--- a/.github/workflows/markdown_link_checker_config.json
+++ b/.github/workflows/markdown_link_checker_config.json
@@ -1,0 +1,4 @@
+{
+  "retryOn429": true,
+  "fallbackRetryDelay": "1s"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## Unreleased

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all
+people who contribute through reporting issues, posting feature
+requests, updating documentation, submitting pull requests or patches,
+and other activities.
+
+We are committed to making participation in this project a
+harassment-free experience for everyone, regardless of level of
+experience, gender, gender identity and expression, sexual orientation,
+disability, personal appearance, body size, race, ethnicity, age,
+religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+- The use of sexualized language or imagery
+- Personal attacks
+- Trolling or insulting/derogatory comments
+- Public or private harassment
+- Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+- Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that they
+deem inappropriate, threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves
+to fairly and consistently applying these principles to every aspect of
+managing this project. Project maintainers who do not follow or enforce
+the Code of Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by contacting a project maintainer at <opensource@shopify.com>.
+All complaints will be reviewed and investigated and will result in a response
+that is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an incident.
+
+This Code of Conduct is adapted from the Contributor Covenant, version
+1.3.0, available from http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+# Contributing
+
+We welcome your contributions to the project. There are a few steps to take when looking to make a contribution.
+
+- Open an issue to discuss the feature/bug
+- If feature/bug is deemed valid then fork repo.
+- Implement patch to resolve issue.
+- Include tests to prevent regressions and validate the patch.
+- Update the docs for any API changes.
+- Submit a pull request.
+
+# Bug Reporting
+
+Shopify App Express package for Node uses GitHub issue tracking to manage bugs, please open an issue there.
+
+# Feature Request
+
+You can open a new issue on the GitHub issues and describe the feature you would like to see.
+
+# Developing the package
+
+Requirements:
+
+- [Node](https://nodejs.org/en/) v14 or above
+- [Yarn](https://yarnpkg.com/) v1.22 or above
+
+You can set up your development environment by running the following:
+
+```
+git clone git@github.com:Shopify/shopify-app-express.git # get the code
+cd shopify-app-express                                   # change into the source directory
+yarn install                                             # install dependencies
+yarn build                                               # build package
+```
+
+Helpful commands
+
+- `yarn lint` will run linting to make sure your code is of high standard
+- `yarn test` will run testing to ensure your code is covered by test cases

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+MIT License
+
+Copyright (c) 2022-present, Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -17,9 +17,10 @@
   "prettier": "@shopify/prettier-config",
   "scripts": {
     "build": "tsc",
+    "test:all": "jest",
     "test": "jest --selectProjects package",
-    "lint": "jest --selectProjects lint",
     "test:dev": "jest --selectProjects package lint",
+    "lint": "jest --selectProjects lint",
     "clean": "rimraf ./dist tsconfig.tsbuildinfo",
     "prepublishOnly": "yarn run build",
     "preversion": "yarn run test",
@@ -29,7 +30,7 @@
     "@shopify/shopify-api": "*"
   },
   "dependencies": {
-    "@shopify/shopify-api": "6.0.0-rc3",
+    "@shopify/shopify-api": "6.0.0-rc4",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.1",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -8,6 +8,6 @@ describe('shopifyApp', () => {
 
     expect(shopify).toBeDefined();
     expect(shopify.api).toBeDefined();
-    expect(shopify.api.config.apiKey).toBe(testConfig.apiKey);
+    expect(shopify.api.config.apiKey).toBe(testConfig.api.apiKey);
   });
 });

--- a/src/__tests__/test-helper.ts
+++ b/src/__tests__/test-helper.ts
@@ -1,13 +1,15 @@
 import {LATEST_API_VERSION} from '@shopify/shopify-api';
 import {MemorySessionStorage} from '@shopify/shopify-api/session-storage/memory';
 
-import {ConfigParams} from '../types';
+import {AppConfigParams} from '../types';
 
-export const testConfig: ConfigParams = {
-  apiKey: 'testApiKey',
-  apiSecretKey: 'testApiSecretKey',
-  scopes: ['testScope'],
-  apiVersion: LATEST_API_VERSION,
-  hostName: 'my-test-shop.myshopify.io',
-  sessionStorage: new MemorySessionStorage(),
+export const testConfig: AppConfigParams = {
+  api: {
+    apiKey: 'testApiKey',
+    apiSecretKey: 'testApiSecretKey',
+    scopes: ['testScope'],
+    apiVersion: LATEST_API_VERSION,
+    hostName: 'my-test-shop.myshopify.io',
+    sessionStorage: new MemorySessionStorage(),
+  },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,10 +787,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
-"@shopify/shopify-api@6.0.0-rc3":
-  version "6.0.0-rc3"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc3.tgz#70cab6a1d621c1a47ded52a7303109a232207fb9"
-  integrity sha512-gMSTX/P98BtnNJ17vUlv5L98K0PG0JscbTevKb5Axx1eZ0bhh7ap2ji5ma6uDQFRWFF0+w/7kH6UfHscu0vYAA==
+"@shopify/shopify-api@6.0.0-rc4":
+  version "6.0.0-rc4"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc4.tgz#3544a5ab1d02e23639c3f34bc2855c9c660cda0f"
+  integrity sha512-rpcqQy0DSPmohBIvsCfYbifkeD3imrIaUAiXTv+Hbw+ZL1tzWB8zLs3MXJtrUY4U6p4/ndeKSFHuLb53JcZRsA==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/node-fetch" "^2.5.7"


### PR DESCRIPTION
Now that we have a couple of tests, we can actually run CI.

This PR artfully borrows the `.github` folder from the API lib repo.