### PR TITLE
Properly type API object

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@shopify/shopify-api": "*"
   },
   "dependencies": {
-    "@shopify/shopify-api": "6.0.0-rc4",
+    "@shopify/shopify-api": "6.0.0-rc5",
     "compression": "^1.7.4",
     "cookie-parser": "^1.4.6",
     "express": "^4.18.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,9 @@ import '@shopify/shopify-api/adapters/node';
 import {
   shopifyApi,
   ConfigParams as ApiConfigParams,
+  SessionStorage,
+  ShopifyRestResources,
+  LATEST_API_VERSION,
 } from '@shopify/shopify-api';
 
 import {
@@ -12,14 +15,18 @@ import {
 
 export * from './types';
 
-export function shopifyApp(config: AppConfigParams): ShopifyApp {
-  const shopify = shopifyApi(apiConfigWithDefaults(config.api));
+export function shopifyApp<
+  T extends ShopifyRestResources,
+  S extends SessionStorage = SessionStorage,
+>(config: AppConfigParams<T, S>): ShopifyApp<T, S> {
+  const api = shopifyApi<T, S>(apiConfigWithDefaults<T, S>(config.api));
 
-  return {api: shopify};
+  return {api};
 }
 
-function apiConfigWithDefaults(
-  apiConfig: ApiConfigParamsWithoutDefaults,
-): ApiConfigParams {
-  return {isEmbeddedApp: true, ...apiConfig};
+function apiConfigWithDefaults<
+  T extends ShopifyRestResources,
+  S extends SessionStorage = SessionStorage,
+>(apiConfig: ApiConfigParamsWithoutDefaults<T, S>): ApiConfigParams<T, S> {
+  return {isEmbeddedApp: true, apiVersion: LATEST_API_VERSION, ...apiConfig};
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,16 +1,29 @@
-import {ConfigParams as ApiConfigParams, Shopify} from '@shopify/shopify-api';
+import {
+  ConfigParams as ApiConfigParams,
+  SessionStorage,
+  ShopifyRestResources,
+  Shopify,
+  ApiVersion,
+} from '@shopify/shopify-api';
 
-export interface ShopifyApp {
-  api: Shopify;
+export interface ShopifyApp<
+  T extends ShopifyRestResources = ShopifyRestResources,
+  S extends SessionStorage = SessionStorage,
+> {
+  api: Shopify<T, S>;
 }
 
-export type ApiConfigParamsWithoutDefaults = Omit<
-  ApiConfigParams,
-  'isEmbeddedApp'
-> & {
+export type ApiConfigParamsWithoutDefaults<
+  T extends ShopifyRestResources = any,
+  S extends SessionStorage = SessionStorage,
+> = Omit<ApiConfigParams<T, S>, 'isEmbeddedApp' | 'apiVersion'> & {
   isEmbeddedApp?: boolean;
+  apiVersion?: ApiVersion;
 };
 
-export interface AppConfigParams {
-  api: ApiConfigParamsWithoutDefaults;
+export interface AppConfigParams<
+  T extends ShopifyRestResources = any,
+  S extends SessionStorage = SessionStorage,
+> {
+  api: ApiConfigParamsWithoutDefaults<T, S>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,10 +787,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
-"@shopify/shopify-api@6.0.0-rc4":
-  version "6.0.0-rc4"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc4.tgz#3544a5ab1d02e23639c3f34bc2855c9c660cda0f"
-  integrity sha512-rpcqQy0DSPmohBIvsCfYbifkeD3imrIaUAiXTv+Hbw+ZL1tzWB8zLs3MXJtrUY4U6p4/ndeKSFHuLb53JcZRsA==
+"@shopify/shopify-api@6.0.0-rc5":
+  version "6.0.0-rc5"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc5.tgz#8ad1c91273f0d7e91feb1b9118297bd11e221967"
+  integrity sha512-bdW2XrAiABU3LNsE/csGmlUeuHRPovEycB+qBAfSzvpdGdyA4Q0HJCX4ShSDJ7f8EpyRmVjtMfFUiCYayfaPOg==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/node-fetch" "^2.5.7"


### PR DESCRIPTION
### WHY are these changes introduced?

The library object wasn't being properly typed with the selected SessionStorage and REST resources, which reduces the value we can get from intellisense (particularly for REST).

### WHAT is this pull request doing?

Properly passing the given types along to the library object, so that everything is fully typed.