### PR TITLE
Add webhookId to app_uninstalled handler

### DIFF
--- a/.changeset/loud-dragons-dream.md
+++ b/.changeset/loud-dragons-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Add webhookId to app_uninstalled handler, to align with latest api library rc version

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*       @shopify/learn-libs-superteam
+*       @shopify/client-libraries-app-templates

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc10",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "@shopify/shopify-app-session-storage-memory": "^1.0.0-rc.0",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "^6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "@shopify/shopify-app-session-storage-memory": "^1.0.0-rc.0",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
@@ -4,7 +4,6 @@ import jwt from 'jsonwebtoken';
 import {ConfigParams, LogSeverity} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../..';
-import {ShopifyApp} from '../../types';
 import {WebhookHandlersParam} from '../../webhooks/types';
 import {AppInstallations} from '../../app-installations';
 import {
@@ -15,6 +14,7 @@ import {
   mockShopifyResponses,
   testConfig,
   TEST_SHOP,
+  TEST_WEBHOOK_ID,
   validWebhookHeaders,
 } from '../test-helper';
 
@@ -118,6 +118,7 @@ describe('OAuth integration tests', () => {
         'TEST_TOPIC',
         TEST_SHOP,
         body,
+        TEST_WEBHOOK_ID,
       );
 
       await installedRequest(app, config, installedMock);

--- a/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
@@ -8,6 +8,7 @@ import {
   mockShopifyResponses,
   shopify,
   TEST_SHOP,
+  TEST_WEBHOOK_ID,
   validWebhookHeaders,
 } from '../test-helper';
 
@@ -146,6 +147,7 @@ describe('webhook integration', () => {
               'APP_UNINSTALLED',
               TEST_SHOP,
               '{}',
+              TEST_WEBHOOK_ID,
             );
           }
         });

--- a/packages/shopify-app-express/src/__tests__/test-helper.ts
+++ b/packages/shopify-app-express/src/__tests__/test-helper.ts
@@ -22,6 +22,7 @@ export let shopify: ShopifyApp;
 export const SHOPIFY_HOST = 'totally-real-host';
 export const BASE64_HOST = Buffer.from(SHOPIFY_HOST).toString('base64');
 export const TEST_SHOP = 'test-shop.myshopify.io';
+export const TEST_WEBHOOK_ID = '1234567890';
 
 let currentCall: number;
 beforeEach(() => {
@@ -164,6 +165,7 @@ export function validWebhookHeaders(
     'X-Shopify-Topic': topic,
     'X-Shopify-Shop-Domain': TEST_SHOP,
     'X-Shopify-Hmac-Sha256': hmac,
+    'X-Shopify-Webhook-Id': TEST_WEBHOOK_ID,
   };
 }
 

--- a/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -86,10 +86,11 @@ export function deleteAppInstallationHandler(
   appInstallations: AppInstallations,
   config: AppConfigInterface,
 ) {
-  return async function deleteAppInstallationHandler(
+  return async function (
     _topic: string,
     shop: string,
     _body: any,
+    _webhookId: string,
   ) {
     await config.logger.debug('Deleting shop sessions', {shop});
 

--- a/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
+++ b/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
@@ -5,6 +5,7 @@ import {DeliveryMethod, LogSeverity} from '@shopify/shopify-api';
 import {
   shopify,
   TEST_SHOP,
+  TEST_WEBHOOK_ID,
   validWebhookHeaders,
 } from '../../__tests__/test-helper';
 import {process} from '../process';
@@ -44,7 +45,12 @@ describe('process', () => {
       .send(body)
       .expect(200);
 
-    expect(mockHandler).toHaveBeenCalledWith('TEST_TOPIC', TEST_SHOP, body);
+    expect(mockHandler).toHaveBeenCalledWith(
+      'TEST_TOPIC',
+      TEST_SHOP,
+      body,
+      TEST_WEBHOOK_ID,
+    );
 
     expect(shopify.api.config.logger.log as jest.Mock).toHaveBeenCalledWith(
       LogSeverity.Info,
@@ -114,7 +120,12 @@ describe('process', () => {
       .send(body)
       .expect(500);
 
-    expect(mockHandler).toHaveBeenCalledWith('TEST_TOPIC', TEST_SHOP, body);
+    expect(mockHandler).toHaveBeenCalledWith(
+      'TEST_TOPIC',
+      TEST_SHOP,
+      body,
+      TEST_WEBHOOK_ID,
+    );
     expect(shopify.api.config.logger.log as jest.Mock).toHaveBeenCalledWith(
       LogSeverity.Error,
       expect.stringContaining('test-error'),

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -30,7 +30,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "tslib": "^2.4.0"
   },

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -31,7 +31,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "mongodb": "^4.11.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -32,7 +32,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "mysql2": "^2.3.3",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -32,7 +32,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "pg": "^8.8.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -32,7 +32,7 @@
     "Redis"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "redis": "^4.5.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -32,7 +32,7 @@
     "sqlite"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "sqlite3": "^5.0.8",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -34,7 +34,7 @@
     "test utilities"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "@shopify/shopify-app-session-storage": "^1.0.0-rc.0",
     "jest": "^28.1.3",
     "jest-fetch-mock": "^3.0.3",

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -31,7 +31,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.0-rc9",
+    "@shopify/shopify-api": "6.0.0-rc10",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
-"@shopify/shopify-api@^6.0.0-rc9":
-  version "6.0.0-rc9"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc9.tgz#1e5327cab5073bcb9e7bbe09bd24fc1c59dd081d"
-  integrity sha512-vwaJGMmR6F1Zvang/OvubXnXB3IwkApT0+JPqN/dj3Gskz9HFUQUH39OFbrki9FdFX56+ysNpmf22D3LOAoHBQ==
+"@shopify/shopify-api@6.0.0-rc10":
+  version "6.0.0-rc10"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0-rc10.tgz#6b3de51619d8745a9384320889865326db51a641"
+  integrity sha512-YXU6DWwTA8gwteX1TL09OBFSrgSqgoee0v81Ff3RPJiGilnPrkj6k2ZcoYr/qlseFHyQSEE613d2Lm6Us/5v6w==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/node-fetch" "^2.5.7"


### PR DESCRIPTION
### WHAT is this pull request doing?

`rc10` of `@shopify/shopify-api` adds a mandatory `webhookId` parameter to the webhook handlers, hence need to update the internal `APP_UNINSTALLED` hander in the express package