### PR TITLE
Allow both token types simultaneously

### DIFF
--- a/.changeset/rude-spiders-fold.md
+++ b/.changeset/rude-spiders-fold.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Allow both online and offline tokens with a single package instance

--- a/packages/shopify-app-express/docs/reference/shopifyApp.md
+++ b/packages/shopify-app-express/docs/reference/shopifyApp.md
@@ -44,7 +44,8 @@ This must match the path of the route that uses `shopify.processWebhooks`.
 
 `boolean` | Defaults to `false`
 
-Whether the OAuth process should produce online access tokens. Learn more about [access modes in Shopify APIs](https://shopify.dev/apps/auth/oauth/access-modes).
+Whether the OAuth process should produce online access tokens as well as offline ones (created by default).
+Learn more about [access modes in Shopify APIs](https://shopify.dev/apps/auth/oauth/access-modes).
 
 ### exitIframePath
 

--- a/packages/shopify-app-express/src/auth/auth-callback.ts
+++ b/packages/shopify-app-express/src/auth/auth-callback.ts
@@ -39,7 +39,7 @@ export async function authCallback({
     // If we're completing an offline OAuth process, immediately kick off the online one
     if (config.useOnlineTokens && !callbackResponse.session.isOnline) {
       await config.logger.debug(
-        'Completing offline OAuth, redirecting to online OAuth',
+        'Completing offline token OAuth, redirecting to online token OAuth',
         {shop: callbackResponse.session.shop},
       );
 
@@ -54,6 +54,7 @@ export async function authCallback({
 
     await config.logger.debug('Completed OAuth callback', {
       shop: callbackResponse.session.shop,
+      isOnline: callbackResponse.session.isOnline,
     });
 
     return true;

--- a/packages/shopify-app-express/src/auth/index.ts
+++ b/packages/shopify-app-express/src/auth/index.ts
@@ -16,14 +16,16 @@ export function auth({api, config}: ApiAndConfigParams): AuthMiddleware {
       return async (req: Request, res: Response, next: NextFunction) => {
         await config.logger.info('Handling request to complete OAuth process');
 
-        await authCallback({
+        const oauthCompleted = await authCallback({
           req,
           res,
           api,
           config,
         });
 
-        next();
+        if (oauthCompleted) {
+          next();
+        }
       };
     },
   };

--- a/packages/shopify-app-express/src/redirect-to-auth.ts
+++ b/packages/shopify-app-express/src/redirect-to-auth.ts
@@ -9,13 +9,14 @@ export async function redirectToAuth({
   res,
   api,
   config,
+  isOnline = false,
 }: RedirectToAuthParams) {
   const shop = api.utils.sanitizeShop(req.query.shop as string);
   if (shop) {
     if (req.query.embedded === '1') {
       await clientSideRedirect(api, config, shop, req, res);
     } else {
-      await serverSideRedirect(api, config, shop, req, res);
+      await serverSideRedirect(api, config, shop, req, res, isOnline);
     }
   } else {
     await config.logger.error('No shop provided to redirect to auth');
@@ -62,16 +63,17 @@ async function serverSideRedirect(
   shop: string,
   req: Request,
   res: Response,
+  isOnline: boolean,
 ): Promise<void> {
   await config.logger.debug(
     `Redirecting to auth at ${config.auth.path}, with callback ${config.auth.callbackPath}`,
-    {shop, isOnline: config.useOnlineTokens},
+    {shop, isOnline},
   );
 
   await api.auth.begin({
     callbackPath: config.auth.callbackPath,
     shop,
-    isOnline: config.useOnlineTokens,
+    isOnline,
     rawRequest: req,
     rawResponse: res,
   });

--- a/packages/shopify-app-express/src/types.ts
+++ b/packages/shopify-app-express/src/types.ts
@@ -11,6 +11,7 @@ export interface ApiAndConfigParams {
 export interface RedirectToAuthParams extends ApiAndConfigParams {
   req: Request;
   res: Response;
+  isOnline?: boolean;
 }
 
 export interface ReturnTopLevelRedirectionParams {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2985,9 +2985,9 @@
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
 "@shopify/shopify-api@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.0.tgz#bd1e9b44c60cc79e25922bc19b6d5199b48a0d82"
-  integrity sha512-b8zj9uQIUACgsP0k/zF2wykv3tVwBGdZz5h4BT/tYq60KMmukGrWy+rS3V0p7B5ddswlbJZvdncBRYiDthotkQ==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.1.tgz#cc0b730cc0037db0f5f4fafd4fdb577b1e18295e"
+  integrity sha512-1suH2MUReEBY8N5nOFRvaih0qqMe1Lxs743dcaXjaclD/Ekn6jZtZWEHMdqrtK8QdDU3+Ms31E8XfzV7DDpH4w==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/node-fetch" "^2.5.7"


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/first-party-library-planning/issues/507
Closes #28

Currently, when using online tokens, the oauth process won't generate offline sessions, which prevents apps using online tokens from handling things such as webhooks that require an offline token.

### WHAT is this pull request doing?

We're addressing that issue by ensuring that all apps have offline tokens, so that `useOnlineTokens` tells the package to _add_ an online session rather than _replace_ the offline one, so that apps have access to everything.

We still default to using the online token when validating requests with the `validateAuthenticatedSession` middleware, so that user interactions rely on the online token automatically when configured to do so.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
