### PR TITLE
Add apiVersion param to webhook processing/tests/docs

### DIFF
--- a/packages/shopify-app-express/docs/reference/processWebhooks.md
+++ b/packages/shopify-app-express/docs/reference/processWebhooks.md
@@ -36,7 +36,7 @@ const webhookHandlers = {
   CUSTOMERS_DATA_REQUEST: {
     deliveryMethod: DeliveryMethod.Http,
     callbackUrl: shopify.config.webhooks.path,
-    callback: async (topic, shop, body) => {
+    callback: async (topic, shop, body, webhookId, apiVersion) => {
       const payload = JSON.parse(body);
       // prepare customers data to send to customer
     },
@@ -52,7 +52,7 @@ const webhookHandlers = {
   SHOP_REDACT: {
     deliveryMethod: DeliveryMethod.Http,
     callbackUrl: shopify.config.webhooks.path,
-    callback: async (topic, shop, body) => {
+    callback: async (topic, shop, body, webhookId, apiVersion) => {
       const payload = JSON.parse(body);
       // remove shop data
     },

--- a/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
@@ -1,7 +1,11 @@
 import request from 'supertest';
 import express, {Express} from 'express';
 import jwt from 'jsonwebtoken';
-import {ConfigParams, LogSeverity} from '@shopify/shopify-api';
+import {
+  ConfigParams,
+  LATEST_API_VERSION,
+  LogSeverity,
+} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../..';
 import {WebhookHandlersParam} from '../../webhooks/types';
@@ -119,6 +123,7 @@ describe('OAuth integration tests', () => {
         TEST_SHOP,
         body,
         TEST_WEBHOOK_ID,
+        LATEST_API_VERSION,
       );
 
       await installedRequest(app, config, installedMock);

--- a/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express, {Express} from 'express';
-import {LogSeverity} from '@shopify/shopify-api';
+import {LATEST_API_VERSION, LogSeverity} from '@shopify/shopify-api';
 
 import {AppInstallations} from '../../app-installations';
 import {
@@ -148,6 +148,7 @@ describe('webhook integration', () => {
               TEST_SHOP,
               '{}',
               TEST_WEBHOOK_ID,
+              LATEST_API_VERSION,
             );
           }
         });

--- a/packages/shopify-app-express/src/__tests__/test-helper.ts
+++ b/packages/shopify-app-express/src/__tests__/test-helper.ts
@@ -176,6 +176,7 @@ export function validWebhookHeaders(
     'X-Shopify-Shop-Domain': TEST_SHOP,
     'X-Shopify-Hmac-Sha256': hmac,
     'X-Shopify-Webhook-Id': TEST_WEBHOOK_ID,
+    'X-Shopify-Api-Version': LATEST_API_VERSION,
   };
 }
 

--- a/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
+++ b/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
@@ -1,6 +1,10 @@
 import request from 'supertest';
 import express from 'express';
-import {DeliveryMethod, LogSeverity} from '@shopify/shopify-api';
+import {
+  DeliveryMethod,
+  LATEST_API_VERSION,
+  LogSeverity,
+} from '@shopify/shopify-api';
 
 import {
   shopify,
@@ -50,6 +54,7 @@ describe('process', () => {
       TEST_SHOP,
       body,
       TEST_WEBHOOK_ID,
+      LATEST_API_VERSION,
     );
 
     expect(shopify.api.config.logger.log as jest.Mock).toHaveBeenCalledWith(
@@ -125,6 +130,7 @@ describe('process', () => {
       TEST_SHOP,
       body,
       TEST_WEBHOOK_ID,
+      LATEST_API_VERSION,
     );
     expect(shopify.api.config.logger.log as jest.Mock).toHaveBeenCalledWith(
       LogSeverity.Error,


### PR DESCRIPTION
### WHY are these changes introduced?

Version 6.0.1 of `@shopify/shopify-api-js` adds an optional `apiVersion` parameter to the calls of the webhook handlers.

### WHAT is this pull request doing?

Update webhook processing/tests/docs align with v6.0.1 of API library

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
