### PR TITLE
Optimize findSessionsByShop

### DIFF
--- a/.changeset/warm-dots-applaud.md
+++ b/.changeset/warm-dots-applaud.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-redis': patch
+---
+
+Optimize findSessionsByShop with additional shop-based key, listing array of corresponding session ids

--- a/packages/shopify-app-express/docs/reference/processWebhooks.md
+++ b/packages/shopify-app-express/docs/reference/processWebhooks.md
@@ -15,7 +15,7 @@ Make sure you use this middleware on a `.post()` route.
 
 `{[topic: string]: WebhookHandler | WebhookHandler[]}`
 
-Defines the webhooks your app will listen to, and how to handle them. See [the `@shopify/shopify-api` documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/usage/webhooks.md) for the allowed values.
+Defines the webhooks your app will listen to, and how to handle them. See [the `@shopify/shopify-api` documentation](https://github.com/Shopify/shopify-api-js/blob/main/docs/guides/webhooks.md) for the allowed values.
 
 > **Note**: for HTTP webhook handlers, the `callbackUrl` value must match the route where you use this middleware.
 

--- a/packages/shopify-app-session-storage-redis/src/__tests__/migration-test-data.ts
+++ b/packages/shopify-app-session-storage-redis/src/__tests__/migration-test-data.ts
@@ -1,0 +1,46 @@
+import {Session} from '@shopify/shopify-api';
+
+const expiryDate = new Date();
+expiryDate.setMilliseconds(0);
+expiryDate.setMinutes(expiryDate.getMinutes() + 60);
+
+const testScopes = ['test_scope'];
+
+export const v1_0_0SessionData = [
+  new Session({
+    id: 'abcde-12345',
+    shop: 'shop1.myshopify.com',
+    state: 'state',
+    isOnline: false,
+    scope: testScopes.toString(),
+    accessToken: 'abcde-12345-123',
+  }),
+  new Session({
+    id: 'abcde-67890',
+    shop: 'shop1.myshopify.com',
+    state: 'state',
+    isOnline: true,
+    expires: expiryDate,
+    onlineAccessInfo: {associated_user: {id: 67890}} as any,
+    scope: testScopes.toString(),
+    accessToken: 'abcde-67890-678',
+  }),
+  new Session({
+    id: 'vwxyz-12345',
+    shop: 'shop2.myshopify.com',
+    state: 'state',
+    isOnline: false,
+    scope: testScopes.toString(),
+    accessToken: 'vwxyz-12345-123',
+  }),
+  new Session({
+    id: 'vwxyz-67890',
+    shop: 'shop2.myshopify.com',
+    state: 'state',
+    isOnline: true,
+    expires: expiryDate,
+    onlineAccessInfo: {associated_user: {id: 67890}} as any,
+    scope: testScopes.toString(),
+    accessToken: 'vwxyz-67890-678',
+  }),
+];

--- a/packages/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
+++ b/packages/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
@@ -7,19 +7,22 @@ import {
   batteryOfTests,
   wait,
 } from '@shopify/shopify-app-session-storage-test-utils';
+import {Session} from '@shopify/shopify-api';
 
 import {RedisSessionStorage} from '../redis';
+
+import {v1_0_0SessionData} from './migration-test-data';
 
 const exec = promisify(child_process.exec);
 
 const dbURL = new URL('redis://shopify:passify@localhost/1');
 
 type RedisClient = ReturnType<typeof createClient>;
-let client: RedisClient;
 
 describe('RedisSessionStorage', () => {
-  let storage: RedisSessionStorage | undefined;
   let containerId: string | undefined;
+  let client: RedisClient;
+
   beforeAll(async () => {
     const configPath = resolve(__dirname, './redis.conf');
     const runCommand = await exec(
@@ -31,27 +34,125 @@ describe('RedisSessionStorage', () => {
     // Give the container a lot of time to set up since polling is ineffective with podman
     await wait(10000);
 
-    storage = new RedisSessionStorage(dbURL);
-
-    // Add different non-Session objects into the DB
-    await initWithNonSessionData();
-
-    await storage.ready;
+    client = createClient({url: dbURL.toString()});
+    await client.connect();
   });
 
   afterAll(async () => {
-    await storage?.disconnect();
     await client.disconnect();
     if (containerId) await exec(`podman rm -f ${containerId}`);
   });
 
-  batteryOfTests(async () => storage!);
+  describe('batteryOfTests', () => {
+    let storage: RedisSessionStorage | undefined;
+    beforeAll(async () => {
+      // flush the DB
+      await client.flushDb();
+      await initWithNonSessionData(client);
+
+      storage = new RedisSessionStorage(dbURL);
+      await storage.ready;
+    });
+
+    afterAll(async () => {
+      await storage?.disconnect();
+    });
+
+    batteryOfTests(async () => storage!);
+  });
+
+  describe('migrateToVersion1_0_1 tests', () => {
+    let storage: RedisSessionStorage | undefined;
+    beforeAll(async () => {
+      // flush the DB
+      await client.flushDb();
+      await initWithNonSessionData(client);
+      await initWithVersion1_0_0Data(client);
+    });
+
+    afterEach(async () => {
+      await storage?.disconnect();
+    });
+
+    it('initially satisfies pre-2.0.0 conditions', async () => {
+      const shop1SessionIds = await client.get(
+        'shopify_sessions_shop1.myshopify.com',
+      );
+      expect(shop1SessionIds).toBeNull();
+
+      const shop2SessionIds = await client.get(
+        'shopify_sessions_shop2.myshopify.com',
+      );
+      expect(shop2SessionIds).toBeNull();
+    });
+
+    it('migrates previous data to 2.0.0', async () => {
+      storage = new RedisSessionStorage(dbURL);
+      await storage.ready;
+
+      const shop1SessionIds = await client.get(
+        'shopify_sessions_shop1.myshopify.com',
+      );
+      expect(shop1SessionIds).toBeDefined();
+      const shop1SessionIdsArray = JSON.parse(shop1SessionIds as string);
+      expect(shop1SessionIdsArray).toContain('shopify_sessions_abcde-12345');
+      expect(shop1SessionIdsArray).toContain('shopify_sessions_abcde-67890');
+
+      const shop2SessionIds = await client.get(
+        'shopify_sessions_shop2.myshopify.com',
+      );
+      expect(shop2SessionIds).toBeDefined();
+      const shop2SessionIdsArray = JSON.parse(shop2SessionIds as string);
+      expect(shop2SessionIdsArray).toContain('shopify_sessions_vwxyz-12345');
+      expect(shop2SessionIdsArray).toContain('shopify_sessions_vwxyz-67890');
+    });
+
+    it('manipulates 2.0.0 data structures correctly', async () => {
+      storage = new RedisSessionStorage(dbURL);
+      await storage.ready;
+
+      await storage.deleteSession('abcde-12345');
+      const shop1SessionIds = await client.get(
+        'shopify_sessions_shop1.myshopify.com',
+      );
+      expect(shop1SessionIds).toBeDefined();
+      const shop1SessionIdsArray = JSON.parse(shop1SessionIds as string);
+      expect(shop1SessionIdsArray).not.toContain(
+        'shopify_sessions_abcde-12345',
+      );
+      expect(shop1SessionIdsArray).toContain('shopify_sessions_abcde-67890');
+      const shop1Sessions = await storage.findSessionsByShop(
+        'shop1.myshopify.com',
+      );
+      expect(shop1Sessions).toHaveLength(1);
+      expect(shop1Sessions[0].id).toBe('abcde-67890');
+
+      const newSession = new Session({
+        id: 'vwxyz-abcde',
+        shop: 'shop2.myshopify.com',
+        state: 'state',
+        isOnline: false,
+        scope: ['test_scope2'].toString(),
+        accessToken: 'vwxyz-abcde-678',
+      });
+      await storage.storeSession(newSession);
+      const shop2SessionIds = await client.get(
+        'shopify_sessions_shop2.myshopify.com',
+      );
+      expect(shop2SessionIds).toBeDefined();
+      const shop2SessionIdsArray = JSON.parse(shop2SessionIds as string);
+      expect(shop2SessionIdsArray).toContain('shopify_sessions_vwxyz-12345');
+      expect(shop2SessionIdsArray).toContain('shopify_sessions_vwxyz-67890');
+      expect(shop2SessionIdsArray).toContain('shopify_sessions_vwxyz-abcde');
+      const shop2Sessions = await storage.findSessionsByShop(
+        'shop2.myshopify.com',
+      );
+      expect(shop2Sessions).toHaveLength(3);
+    });
+  });
 });
 
-async function initWithNonSessionData() {
-  client = createClient({url: dbURL.toString()});
-  await client.connect();
-
+async function initWithNonSessionData(client: RedisClient) {
   // Json type different from json array contrary to what is expected by Session.fromPropertyArray
   await client.set(
     'this_is_not_a_session_id',
@@ -63,4 +164,13 @@ async function initWithNonSessionData() {
 
   // Not a json value
   await client.set('256647', 'any random value really');
+}
+
+async function initWithVersion1_0_0Data(client: RedisClient) {
+  for (const session of v1_0_0SessionData) {
+    await client.set(
+      `shopify_sessions_${session.id}`,
+      JSON.stringify(session.toPropertyArray()),
+    );
+  }
 }

--- a/packages/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
+++ b/packages/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
@@ -2,6 +2,7 @@ import * as child_process from 'child_process';
 import {promisify} from 'util';
 import {resolve} from 'path';
 
+import {createClient} from 'redis';
 import {
   batteryOfTests,
   wait,
@@ -12,6 +13,9 @@ import {RedisSessionStorage} from '../redis';
 const exec = promisify(child_process.exec);
 
 const dbURL = new URL('redis://shopify:passify@localhost/1');
+
+type RedisClient = ReturnType<typeof createClient>;
+let client: RedisClient;
 
 describe('RedisSessionStorage', () => {
   let storage: RedisSessionStorage | undefined;
@@ -28,13 +32,35 @@ describe('RedisSessionStorage', () => {
     await wait(10000);
 
     storage = new RedisSessionStorage(dbURL);
+
+    // Add different non-Session objects into the DB
+    await initWithNonSessionData();
+
     await storage.ready;
   });
 
   afterAll(async () => {
     await storage?.disconnect();
+    await client.disconnect();
     if (containerId) await exec(`podman rm -f ${containerId}`);
   });
 
   batteryOfTests(async () => storage!);
 });
+
+async function initWithNonSessionData() {
+  client = createClient({url: dbURL.toString()});
+  await client.connect();
+
+  // Json type different from json array contrary to what is expected by Session.fromPropertyArray
+  await client.set(
+    'this_is_not_a_session_id',
+    JSON.stringify('{"key": "with a random value"}'),
+  );
+
+  // Type json array as expected by the the Session.fromPropertyArray but does not contain session data
+  await client.set('12563', '["Ford", "BMW", "Fiat"]');
+
+  // Not a json value
+  await client.set('256647', 'any random value really');
+}

--- a/packages/shopify-app-session-storage-redis/src/migrations.ts
+++ b/packages/shopify-app-session-storage-redis/src/migrations.ts
@@ -1,0 +1,30 @@
+import {createClient} from 'redis';
+import {Session} from '@shopify/shopify-api';
+
+type RedisClient = ReturnType<typeof createClient>;
+
+// need to add shop keys with list of associated session keys to support
+// the new findSessionsByShop in v2.x.x
+export async function migrateToVersion1_0_1(
+  client: RedisClient,
+  sessionKeyPrefix: string,
+  fullKey: (name: string) => string,
+) {
+  const shopsAndSessions: {[key: string]: string[]} = {};
+  const keys = await client.keys('*');
+  for (const key of keys) {
+    if (key.startsWith(sessionKeyPrefix)) {
+      const session = Session.fromPropertyArray(
+        JSON.parse((await client.get(key)) as string),
+      );
+      if (!shopsAndSessions[session.shop]) {
+        shopsAndSessions[session.shop] = [];
+      }
+      shopsAndSessions[session.shop].push(key);
+    }
+  }
+  // eslint-disable-next-line guard-for-in
+  for (const shop in shopsAndSessions) {
+    await client.set(fullKey(shop), JSON.stringify(shopsAndSessions[shop]));
+  }
+}

--- a/packages/shopify-app-session-storage-redis/src/redis.ts
+++ b/packages/shopify-app-session-storage-redis/src/redis.ts
@@ -51,6 +51,7 @@ export class RedisSessionStorage implements SessionStorage {
       this.fullKey(session.id),
       JSON.stringify(session.toPropertyArray()),
     );
+    await this.addKeyToShopList(session);
     return true;
   }
 
@@ -67,27 +68,34 @@ export class RedisSessionStorage implements SessionStorage {
 
   public async deleteSession(id: string): Promise<boolean> {
     await this.ready;
-    await this.client.del(this.fullKey(id));
+    const session = await this.loadSession(id);
+    if (session) {
+      await this.removeKeyFromShopList(session.shop, id);
+      await this.client.del(this.fullKey(id));
+    }
     return true;
   }
 
   public async deleteSessions(ids: string[]): Promise<boolean> {
     await this.ready;
-    await this.client.del(ids.map((id) => this.fullKey(id)));
+    await Promise.all(ids.map((id) => this.deleteSession(id)));
     return true;
   }
 
   public async findSessionsByShop(shop: string): Promise<Session[]> {
     await this.ready;
 
-    const keys = await this.client.keys('*');
+    const idKeysArrayString = await this.client.get(this.fullKey(shop));
+    if (!idKeysArrayString) return [];
+
+    const idKeysArray = JSON.parse(idKeysArrayString);
     const results: Session[] = [];
-    for (const key of keys) {
-      const rawResult = await this.client.get(key);
+    for (const idKey of idKeysArray) {
+      const rawResult = await this.client.get(idKey);
       if (!rawResult) continue;
 
       const session = Session.fromPropertyArray(JSON.parse(rawResult));
-      if (session.shop === shop) results.push(session);
+      results.push(session);
     }
 
     return results;
@@ -99,6 +107,39 @@ export class RedisSessionStorage implements SessionStorage {
 
   private fullKey(name: string): string {
     return `${this.options.sessionKeyPrefix}_${name}`;
+  }
+
+  private async addKeyToShopList(session: Session) {
+    const shopKey = this.fullKey(session.shop);
+    const idKey = this.fullKey(session.id);
+    const idKeysArrayString = await this.client.get(shopKey);
+
+    if (idKeysArrayString) {
+      const idKeysArray = JSON.parse(idKeysArrayString);
+
+      if (!idKeysArray.includes(idKey)) {
+        idKeysArray.push(idKey);
+        await this.client.set(shopKey, JSON.stringify(idKeysArray));
+      }
+    } else {
+      await this.client.set(shopKey, JSON.stringify([idKey]));
+    }
+  }
+
+  private async removeKeyFromShopList(shop: string, id: string) {
+    const shopKey = this.fullKey(shop);
+    const idKey = this.fullKey(id);
+    const idKeysArrayString = await this.client.get(shopKey);
+
+    if (idKeysArrayString) {
+      const idKeysArray = JSON.parse(idKeysArrayString);
+      const index = idKeysArray.indexOf(idKey);
+
+      if (index > -1) {
+        idKeysArray.splice(index, 1);
+        await this.client.set(shopKey, JSON.stringify(idKeysArray));
+      }
+    }
   }
 
   private async init() {


### PR DESCRIPTION
### WHY are these changes introduced?

If the Redis store is being used for store objects other than of type `Session`, `findSessionsByShop` breaks because it iterates over _all_ keys to find the ones specific for a shop, assuming that all objects are of type `Session`.

### WHAT is this pull request doing?

For each session added to the redis store, we add a key based on the shop name and add the session id key to a set of all session ids for that shop.

This allows us to quickly find all sessions for a given shop, and avoids having to iterate over all sessions in the store to find the ones for a given shop.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- [ ] ~I have added/updated tests for this change~ - not applicable
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ - not applicable
