### PR TITLE
Improve github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -6,30 +6,41 @@ labels: 'Type: Bug 🐛'
 
 # Issue summary
 
-Write a short description of the issue here ↓
+<!--
+
+Write a short description of the issue here. Please provide any details or logs that
+can help us debug it.
+
+To increase logging, change these settings when calling shopifyApp:
+  api: {
+    logger: {
+      level: LogSeverity.Debug,
+      httpRequests: true, // if the error seems to be related to requests
+    }
+  }
+
+Learn more: https://github.com/Shopify/shopify-api-js/blob/main/docs/reference/shopifyApi.md#logger
+
+-->
+
+- `@shopify/shopify-app-*` package and version:
+- Node version:
+- Operating system:
+
+```
+// Paste any relevant logs here
+```
 
 ## Expected behavior
 
-What do you think should happen?
+<!-- What do you think should happen? -->
 
 ## Actual behavior
 
-What actually happens?
-
-Tip: include an error message (in a `<details></details>` tag) if your issue is related to an error
+<!-- What actually happens? -->
 
 ## Steps to reproduce the problem
 
 1.
 1.
 1.
-
-## Reduced test case
-
-The best way to get your bug fixed is to provide a [reduced test case](https://webkit.org/test-case-reduction/).
-
----
-
-## Checklist
-
-- [ ] I have described this issue in a way that is actionable (if possible)

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.md
@@ -6,20 +6,4 @@ labels: 'Type: Enhancement 📈'
 
 ## Overview/summary
 
-...
-
-## Motivation
-
-> What inspired this enhancement?
-
-...
-
-### Area
-
-- [ ] Add any relevant `Area: <area>` labels to this issue
-
----
-
-## Checklist
-
-- [ ] I have described this enhancement in a way that is actionable (if possible)
+<!-- Write a short description of the enhancement here ↓ -->

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -6,25 +6,4 @@ labels: 'Type: Feature Request :raised_hands:'
 
 ## Overview
 
-...
-
-## Type
-
-- [ ] New feature
-- [ ] Changes to existing features
-
-## Motivation
-
-> What inspired this feature request? What problems were you facing?
-
-...
-
-### Area
-
-- [ ] Add any relevant `Area: <area>` labels to this issue
-
----
-
-## Checklist
-
-- [ ] I have described this feature request in a way that is actionable (if possible)
+<!-- Write a short description of the request here ↓ -->


### PR DESCRIPTION
Now that we provide better logging capabilities in the library package, we should encourage folks to increase log verboseness before opening an issue, so that we can get as much information as possible upfront.

This PR also tweaks the templates' general wording so they're simpler / less condescending, and makes the comments actual comments so they don't show up in created issues.