### PR TITLE
Update shopify-api

### DIFF
--- a/.changeset/light-experts-greet.md
+++ b/.changeset/light-experts-greet.md
@@ -1,0 +1,14 @@
+---
+'@shopify/shopify-app-express': minor
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+---
+
+Updating @shopify/shopify-api to v6.1.0

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "@shopify/shopify-app-session-storage-memory": "^1.0.1",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/oauth.test.ts
@@ -338,7 +338,7 @@ function assertOAuthRequests(
   webhookQueries.forEach((query) =>
     expect({
       method: 'POST',
-      url: `https://${TEST_SHOP}/admin/api/2022-10/graphql.json`,
+      url: `https://${TEST_SHOP}/admin/api/${LATEST_API_VERSION}/graphql.json`,
       body: expect.stringContaining(query),
     }).toMatchMadeHttpRequest(),
   );

--- a/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
+++ b/packages/shopify-app-express/src/__tests__/integration/webhooks.test.ts
@@ -99,7 +99,12 @@ describe('webhook integration', () => {
           } else {
             expect(
               shopify.api.config.logger.log as jest.Mock,
-            ).not.toHaveBeenCalled();
+            ).not.toHaveBeenCalledWith(
+              LogSeverity.Info,
+              expect.stringContaining(
+                "Detected multiple handlers for 'APP_UNINSTALLED', webhooks.process will call them sequentially",
+              ),
+            );
 
             responses.push([config.mockResponse]);
           }
@@ -121,7 +126,7 @@ describe('webhook integration', () => {
           webhookQueries.forEach((query) =>
             expect({
               method: 'POST',
-              url: `https://${TEST_SHOP}/admin/api/2022-10/graphql.json`,
+              url: `https://${TEST_SHOP}/admin/api/${LATEST_API_VERSION}/graphql.json`,
               body: expect.stringContaining(query),
             }).toMatchMadeHttpRequest(),
           );

--- a/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express, {Express} from 'express';
-import {LogSeverity, Session} from '@shopify/shopify-api';
+import {LATEST_API_VERSION, LogSeverity, Session} from '@shopify/shopify-api';
 
 import {
   createTestHmac,
@@ -170,7 +170,7 @@ describe('ensureInstalledOnShop', () => {
 
     expect({
       method: 'POST',
-      url: 'https://test-shop.myshopify.io/admin/api/2022-10/graphql.json',
+      url: `https://test-shop.myshopify.io/admin/api/${LATEST_API_VERSION}/graphql.json`,
     }).toMatchMadeHttpRequest();
 
     expect(shopify.api.config.logger.log).toHaveBeenCalledWith(

--- a/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express, {Express} from 'express';
-import {Session} from '@shopify/shopify-api';
+import {LATEST_API_VERSION, Session} from '@shopify/shopify-api';
 import jwt from 'jsonwebtoken';
 
 import {
@@ -260,7 +260,7 @@ describe('validateAuthenticatedSession', () => {
 
       expect({
         method: 'POST',
-        url: `https://my-shop.myshopify.io/admin/api/2022-10/graphql.json`,
+        url: `https://my-shop.myshopify.io/admin/api/${LATEST_API_VERSION}/graphql.json`,
       }).toMatchMadeHttpRequest();
 
       expect(response.body).toEqual({

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -32,7 +32,7 @@
     "CloudFlare"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "semver": "^7.3.8",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -30,7 +30,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "tslib": "^2.4.0"
   },

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -31,7 +31,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "mongodb": "^4.11.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -32,7 +32,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "mysql2": "^2.3.3",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -32,7 +32,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "pg": "^8.8.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -32,7 +32,7 @@
     "Redis"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "redis": "^4.5.0",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -32,7 +32,7 @@
     "sqlite"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "sqlite3": "^5.0.8",
     "tslib": "^2.4.0"

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -34,7 +34,7 @@
     "test utilities"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "@shopify/shopify-app-session-storage": "^1.0.1",
     "jest": "^28.1.3",
     "jest-fetch-mock": "^3.0.3",

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -31,7 +31,7 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^6.0.2",
+    "@shopify/shopify-api": "^6.1.0",
     "tslib": "^2.4.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2984,10 +2984,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
-"@shopify/shopify-api@^6.0.2":
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.0.2.tgz#ff8ab166f35d3fcf078b6e3e87b5eb31f600f099"
-  integrity sha512-Ci2exdvEh7F0eSmROtQ6ajBJ27mNOYA5tOO/hHO8mZCQwF/PUG7/dUFxjOzxC1tnBmEZWL6seSVu4T+tiNS/OQ==
+"@shopify/shopify-api@^6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-6.1.0.tgz#779ad3855e6f3e5eecaa207a149f97092cdc4696"
+  integrity sha512-XUyeqqRLsp8L24allGlezw2ILQ9ej9LvWS0A6GIE6k4Ku3fQDnSDIOVI2LRRkrZG92ZO3CLoM0Lblq0K9Z8RMg==
   dependencies:
     "@shopify/network" "^1.5.1"
     "@types/node-fetch" "^2.5.7"


### PR DESCRIPTION
This PR simply updates the dependency on `@shopify/shopify-api` to the latest version, 6.1.0.