### PR TITLE
Fix: session table created if it doesn't already exist

### DIFF
--- a/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
@@ -151,7 +151,7 @@ export class PostgreSQLSessionStorage implements SessionStorage {
     const hasSessionTable = await this.hasSessionTable();
     if (!hasSessionTable) {
       const query = `
-        CREATE TABLE ${this.options.sessionTableName} (
+        CREATE TABLE IF NOT EXISTS ${this.options.sessionTableName} (
           id varchar(255) NOT NULL PRIMARY KEY,
           shop varchar(255) NOT NULL,
           state varchar(255) NOT NULL,


### PR DESCRIPTION


### WHY are these changes introduced?

Fixes #74 
Fixes [#412](https://github.com/Shopify/shopify-api-js/issues/412)

When initializing, then SQL command doesn't account for the `shopify_sessions` table already existing. At the moment, the app just crashes because the table already exists.

### WHAT is this pull request doing?

Adding `IF NOT EXISTS` to the SQL command in order to account for `shopify_sessions` table already existing

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
