### PR TITLE
Add shopify-api package as a peerDependency to each package in this repo

### DIFF
--- a/.changeset/hip-cooks-pump.md
+++ b/.changeset/hip-cooks-pump.md
@@ -1,5 +1,4 @@
 ---
-'@shopify/shopify-app-express': patch
 '@shopify/shopify-app-session-storage': patch
 '@shopify/shopify-app-session-storage-kv': patch
 '@shopify/shopify-app-session-storage-memory': patch
@@ -11,4 +10,4 @@
 '@shopify/shopify-app-session-storage-test-utils': patch
 ---
 
-Add @shopify/shopify-api as a peerDependencies entry for each package, to avoid library conflicts
+Add @shopify/shopify-api as a peerDependencies entry for each session-storage package, to avoid API library conflicts (e.g., scopesArray.map error). Should help avoid issues like #93

--- a/.changeset/hip-cooks-pump.md
+++ b/.changeset/hip-cooks-pump.md
@@ -1,0 +1,14 @@
+---
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+---
+
+Add @shopify/shopify-api as a peerDependencies entry for each package, to avoid library conflicts

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -38,9 +38,6 @@
     "semver": "^7.5.0",
     "tslib": "^2.4.0"
   },
-  "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
-  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -38,6 +38,9 @@
     "semver": "^7.5.0",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -32,13 +32,12 @@
     "CloudFlare"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "semver": "^7.5.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -37,6 +37,9 @@
     "semver": "^7.5.0",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230419.0",
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -34,6 +34,9 @@
     "@shopify/shopify-app-session-storage": "^1.1.2",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -30,12 +30,11 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -36,6 +36,9 @@
     "mongodb": "^5.4.0",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -31,13 +31,12 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "mongodb": "^5.4.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -37,6 +37,9 @@
     "mysql2": "^3.2.4",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -32,13 +32,12 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "mysql2": "^3.2.4",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -38,6 +38,9 @@
     "pg-connection-string": "^2.5.0",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -32,14 +32,13 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "pg": "^8.10.0",
     "pg-connection-string": "^2.5.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -32,13 +32,12 @@
     "Redis"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "redis": "^4.6.6",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -37,6 +37,9 @@
     "redis": "^4.6.6",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -37,6 +37,9 @@
     "sqlite3": "^5.1.6",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -32,13 +32,12 @@
     "sqlite"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "sqlite3": "^5.1.6",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -34,14 +34,13 @@
     "test utilities"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
-    "@shopify/shopify-app-session-storage": "^1.1.2",
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -40,6 +40,9 @@
     "jest-fetch-mock": "^3.0.3",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -31,11 +31,10 @@
     "session storage"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^6.1.0"
+    "@shopify/shopify-api": "^7.0.0"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -34,6 +34,9 @@
     "@shopify/shopify-api": "^7.0.0",
     "tslib": "^2.4.0"
   },
+  "peerDependencies": {
+    "@shopify/shopify-api": "^6.1.0"
+  },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",


### PR DESCRIPTION
### WHY are these changes introduced?

In apps that use the packages in this repo, sometimes each package can end up with its own copy of `shopify-api` in a sub-`node_modules` directory ... this creates conflict with the `shopify-api` package in the apps `node_modules` directory, resulting in issues with `Session.isActive()` resulting from the conflict.

### WHAT is this pull request doing?

Setting `@shopify/shopify-api` as a `peerDependencies` entry in the respective `package.json` files, so that only one copy of `@shopify/shopify-api` will be installed and used in an app.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have added a changelog entry, prefixed by the type of change noted above
- not applicable ~I have added/updated tests for this change~
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
