### PR TITLE
Fix #81: Handle ensureInstalledOnShop throwing and crashing the entire app

### DIFF
--- a/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -53,6 +53,18 @@ describe('ensureInstalledOnShop', () => {
     );
   });
 
+  it('returns 400 if no host provided', async () => {
+    mockShopifyResponse({data: {shop: {name: TEST_SHOP}}});
+
+    await shopify.config.sessionStorage.storeSession(session);
+
+    const response = await request(app)
+      .get(`/test/shop?shop=${TEST_SHOP}`)
+      .expect(400);
+
+    expect(response.text).toEqual('Invalid request');
+  });
+
   it('returns 422 if no shop provided', async () => {
     await request(app).get(`/test/shop`).expect(422);
   });


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify-app-js/issues/81
Easier to review if you look at https://github.com/Shopify/shopify-app-js/pull/123/files?w=1

### WHY are these changes introduced?

Fix #81. This could be a pretty bad bug, because it can cause people's entire app servers to crash by one easily spammed `GET` to `/?shop=someshop.shopify.com`. Lacking the `host` parameter, the app throws an error. For me on fly.io, this causes DoS and lack of service for like 15s until it starts up a new container

It wasn't 100% clear to me whether there was an existing pattern for this. I tried `next(err)` and this seems to have written out a stacktrace to the HTML response, so that didn't seem desirable given I didn't know whether it could be a prod data leak.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
