### PR TITLE
[Fix] Get shop from token if present

### DIFF
--- a/.changeset/eleven-seas-change.md
+++ b/.changeset/eleven-seas-change.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Attempt to set shop from token, if present and if no shop param provided or no session found in database. Fixes #94

--- a/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -111,6 +111,24 @@ describe('validateAuthenticatedSession', () => {
       ).toBe(`/api/auth?shop=my-shop.myshopify.io`);
     });
 
+    it('no session, no shop param, with auth header, returns 403 with correct headers', async () => {
+      jest
+        .spyOn(shopify.api.session, 'getCurrentId')
+        .mockResolvedValueOnce(undefined);
+
+      const response = await request(app)
+        .get('/test/shop')
+        .set({Authorization: `Bearer ${validJWT}`})
+        .expect(403);
+
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize'],
+      ).toBe('1');
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize-url'],
+      ).toBe(`/api/auth?shop=my-shop.myshopify.io`);
+    });
+
     it('no session, without auth header redirects to auth', async () => {
       const response = await request(app)
         .get('/test/shop?shop=my-shop.myshopify.io')


### PR DESCRIPTION
### WHY are these changes introduced?

If no shop param is provided and no session is found (e.g., app just uninstalled), user is being redirected to auth with a `shop=undefined` query parameter.

Fixes #94

### WHAT is this pull request doing?

If no shop param is provided and no session is found, then try to get the shop from the token if it's present. If it's there, use it to redirect to auth, which should lead the user back to the app install screen.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have added a changelog entry, prefixed by the type of change noted above
- [x] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ not applicable
