### PR TITLE
[Fix] Catch error when host is missing, return 400

### DIFF
--- a/.changeset/perfect-glasses-build.md
+++ b/.changeset/perfect-glasses-build.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+ensureInstalledOnShop - catch error if host param is missing, return 400

--- a/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -53,12 +53,19 @@ describe('ensureInstalledOnShop', () => {
     );
   });
 
-  it('returns 422 if no shop provided', async () => {
-    await request(app).get(`/test/shop`).expect(422);
+  it('returns 401 if no shop provided', async () => {
+    await request(app).get(`/test/shop`).expect(401);
   });
 
   it('returns 422 if invalid shop provided', async () => {
     await request(app).get(`/test/shop?shop=invalid-shop`).expect(422);
+  });
+
+  it('returns 401 if no host provided', async () => {
+    mockShopifyResponse({data: {shop: {name: TEST_SHOP}}});
+    await shopify.config.sessionStorage.storeSession(session);
+
+    await request(app).get(`/test/shop?shop=${TEST_SHOP}`).expect(401);
   });
 
   it('redirects to auth via exit iFrame if shop NOT installed', async () => {

--- a/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -53,19 +53,19 @@ describe('ensureInstalledOnShop', () => {
     );
   });
 
-  it('returns 401 if no shop provided', async () => {
-    await request(app).get(`/test/shop`).expect(401);
+  it('returns 400 if no shop provided', async () => {
+    await request(app).get(`/test/shop`).expect(400);
   });
 
   it('returns 422 if invalid shop provided', async () => {
     await request(app).get(`/test/shop?shop=invalid-shop`).expect(422);
   });
 
-  it('returns 401 if no host provided', async () => {
+  it('returns 400 if no host provided', async () => {
     mockShopifyResponse({data: {shop: {name: TEST_SHOP}}});
     await shopify.config.sessionStorage.storeSession(session);
 
-    await request(app).get(`/test/shop?shop=${TEST_SHOP}`).expect(401);
+    await request(app).get(`/test/shop?shop=${TEST_SHOP}`).expect(400);
   });
 
   it('redirects to auth via exit iFrame if shop NOT installed', async () => {

--- a/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -100,7 +100,7 @@ function getRequestShop(
       {shop: req.query.shop},
     );
 
-    res.status(422);
+    res.status(401);
     res.send('No shop provided');
     return undefined;
   }
@@ -150,10 +150,22 @@ async function embedAppIntoShopify(
   res: Response,
   shop: string,
 ): Promise<void> {
-  const embeddedUrl = await api.auth.getEmbeddedAppUrl({
-    rawRequest: req,
-    rawResponse: res,
-  });
+  let embeddedUrl: string;
+  try {
+    embeddedUrl = await api.auth.getEmbeddedAppUrl({
+      rawRequest: req,
+      rawResponse: res,
+    });
+  } catch (error) {
+    config.logger.error(
+      `ensureInstalledOnShop did not receive a host query argument`,
+      {shop},
+    );
+
+    res.status(401);
+    res.send('No host provided');
+    return;
+  }
 
   config.logger.debug(
     `Request is not embedded but app is. Redirecting to ${embeddedUrl} to embed the app`,

--- a/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -100,7 +100,7 @@ function getRequestShop(
       {shop: req.query.shop},
     );
 
-    res.status(401);
+    res.status(400);
     res.send('No shop provided');
     return undefined;
   }
@@ -162,7 +162,7 @@ async function embedAppIntoShopify(
       {shop},
     );
 
-    res.status(401);
+    res.status(400);
     res.send('No host provided');
     return;
   }


### PR DESCRIPTION
### WHY are these changes introduced?

If host param is missing from the request, the app may crash when trying to redirect.

Fixes #81

### WHAT is this pull request doing?

This commit adds a try/catch block to catch the error and return a 400 status code (bad request) instead.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ not applicable
