### PR TITLE
Allow database as argument to SQLiteSessionStorage

### DIFF
--- a/.changeset/cuddly-seas-wink.md
+++ b/.changeset/cuddly-seas-wink.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-sqlite': minor
+---
+
+Allow sqlite3.Database object as argument for SQLiteSessionStorage constructor

--- a/packages/shopify-app-session-storage-sqlite/README.md
+++ b/packages/shopify-app-session-storage-sqlite/README.md
@@ -5,9 +5,17 @@ This package implements the `SessionStorage` interface that works with an instan
 ```js
 import {shopifyApp} from '@shopify/shopify-app-express';
 import {SQLiteSessionStorage} from '@shopify/shopify-app-session-storage-sqlite';
+import sqlite3 from 'sqlite3';
+
+// You can construct using either a filename...
+const storage = new SQLiteSessionStorage('/path/to/your.db');
+
+// or an existing sqlite3.Database
+const database = new sqlite3.Database('/path/to/your.db');
+const storage = new SQLiteSessionStorage(database);
 
 const shopify = shopifyApp({
-  sessionStorage: new SQLiteSessionStorage('/path/to/your.db'),
+  sessionStorage: storage,
   // ...
 });
 ```

--- a/packages/shopify-app-session-storage-sqlite/src/__tests__/sqlite.test.ts
+++ b/packages/shopify-app-session-storage-sqlite/src/__tests__/sqlite.test.ts
@@ -1,20 +1,36 @@
 import * as fs from 'fs/promises';
 
+import {Session} from '@shopify/shopify-api';
 import {batteryOfTests} from '@shopify/shopify-app-session-storage-test-utils';
+import sqlite3 from 'sqlite3';
 
 import {SQLiteSessionStorage} from '../sqlite';
 
-const sqliteDbFile = './sqlite.testDb';
 describe('SQLiteSessionStorage', () => {
+  const sqliteDbFile = './sqlite.testDb';
   let storage: SQLiteSessionStorage;
+
   beforeAll(async () => {
-    await fs.unlink(sqliteDbFile).catch(() => {});
-    storage = new SQLiteSessionStorage(sqliteDbFile);
+    await fs.rm(sqliteDbFile, {force: true});
   });
 
   afterAll(async () => {
-    await fs.unlink(sqliteDbFile).catch(() => {});
+    await fs.rm(sqliteDbFile, {force: true});
   });
 
-  batteryOfTests(async () => storage);
+  describe('with string constructor', () => {
+    beforeEach(async () => {
+      storage = new SQLiteSessionStorage(sqliteDbFile);
+    });
+
+    batteryOfTests(async () => storage);
+  });
+
+  describe('with database constructor', () => {
+    beforeEach(async () => {
+      storage = new SQLiteSessionStorage(new sqlite3.Database(sqliteDbFile));
+    });
+
+    batteryOfTests(async () => storage);
+  });
 });

--- a/packages/shopify-app-session-storage-sqlite/src/sqlite-connection.ts
+++ b/packages/shopify-app-session-storage-sqlite/src/sqlite-connection.ts
@@ -6,9 +6,12 @@ export class SqliteConnection implements RdbmsConnection {
   private ready: Promise<void>;
   private db: sqlite3.Database;
 
-  constructor(filename: string, sessionStorageIdentifier: string) {
+  constructor(
+    database: string | sqlite3.Database,
+    sessionStorageIdentifier: string,
+  ) {
     this.sessionStorageIdentifier = sessionStorageIdentifier;
-    this.ready = this.init(filename);
+    this.ready = this.init(database);
   }
 
   async query(query: string, params: any[] = []): Promise<any[]> {
@@ -70,7 +73,8 @@ export class SqliteConnection implements RdbmsConnection {
     return Promise.resolve();
   }
 
-  private async init(filename: string): Promise<void> {
-    this.db = new sqlite3.Database(filename);
+  private async init(database: string | sqlite3.Database): Promise<void> {
+    this.db =
+      typeof database === 'string' ? new sqlite3.Database(database) : database;
   }
 }

--- a/packages/shopify-app-session-storage-sqlite/src/sqlite.ts
+++ b/packages/shopify-app-session-storage-sqlite/src/sqlite.ts
@@ -4,6 +4,7 @@ import {
   RdbmsSessionStorageOptions,
   RdbmsSessionStorageMigratorOptions,
 } from '@shopify/shopify-app-session-storage';
+import sqlite3 from 'sqlite3';
 
 import {SqliteConnection} from './sqlite-connection';
 import {migrationList} from './migrations';
@@ -29,11 +30,11 @@ export class SQLiteSessionStorage implements SessionStorage {
   private migrator: SqliteSessionStorageMigrator;
 
   constructor(
-    filename: string,
+    database: string | sqlite3.Database,
     opts: Partial<SQLiteSessionStorageOptions> = {},
   ) {
     this.options = {...defaultSQLiteSessionStorageOptions, ...opts};
-    this.db = new SqliteConnection(filename, this.options.sessionTableName);
+    this.db = new SqliteConnection(database, this.options.sessionTableName);
     this.internalInit = this.init();
     this.ready = this.initMigrator(this.options.migratorOptions);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, it is only possible to create an `SQLiteSessionStorage` object by giving it a string, which makes it difficult to reuse a pre-existing database connection from an app.

### WHAT is this pull request doing?

Allowing the constructor object to be _either_ a string or an instance of `sqlite3.Database`, so we keep the behaviour to make it easy to connect to the database, but also make it easy for apps to access the database in other ways.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
