### PR TITLE
Add `await` to addHandlers calls

### DIFF
--- a/.changeset/dull-jokes-begin.md
+++ b/.changeset/dull-jokes-begin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Add missing await to calls to api.webhooks.addHandlers

--- a/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
+++ b/packages/shopify-app-express/src/webhooks/__tests__/process.test.ts
@@ -22,8 +22,8 @@ describe('process', () => {
 
   const mockHandler = jest.fn();
 
-  beforeEach(() => {
-    shopify.api.webhooks.addHandlers({
+  beforeEach(async () => {
+    await shopify.api.webhooks.addHandlers({
       TEST_TOPIC: {
         deliveryMethod: DeliveryMethod.Http,
         callbackUrl: '/webhooks',

--- a/packages/shopify-app-express/src/webhooks/index.ts
+++ b/packages/shopify-app-express/src/webhooks/index.ts
@@ -18,7 +18,9 @@ export function processWebhooks({
   config,
 }: ApiAndConfigParams): ProcessWebhooksMiddleware {
   return function ({webhookHandlers}: ProcessWebhooksMiddlewareParams) {
-    mountWebhooks(api, config, webhookHandlers);
+    (async () => {
+      await mountWebhooks(api, config, webhookHandlers);
+    })();
 
     return [
       express.text({type: '*/*'}),
@@ -34,17 +36,17 @@ export function processWebhooks({
   };
 }
 
-function mountWebhooks(
+async function mountWebhooks(
   api: Shopify,
   config: AppConfigInterface,
   handlers: WebhookHandlersParam,
 ) {
-  api.webhooks.addHandlers(handlers as AddHandlersParams);
+  await api.webhooks.addHandlers(handlers as AddHandlersParams);
 
   // Add our custom app uninstalled webhook
   const appInstallations = new AppInstallations(config);
 
-  api.webhooks.addHandlers({
+  await api.webhooks.addHandlers({
     APP_UNINSTALLED: {
       deliveryMethod: DeliveryMethod.Http,
       callbackUrl: config.webhooks.path,


### PR DESCRIPTION
### WHY are these changes introduced?

Calls to `api.webhooks.addHandlers` should be awaited.

Fixes https://github.com/Shopify/shopify-api-js/issues/761

### WHAT is this pull request doing?

Adds `await` to any calls to `api.webhooks.addHandlers`

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ not applicable
