### PR TITLE
Use pg.Pool instead of pg.Client

### DIFF
--- a/.changeset/real-books-unite.md
+++ b/.changeset/real-books-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-postgresql': patch
+---
+
+PostgreSQL session storage to use a connection pool instead of a single client connection. Fixes #156, #168

--- a/packages/shopify-app-session-storage-postgresql/src/__tests__/postgresql.test.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/__tests__/postgresql.test.ts
@@ -6,6 +6,7 @@ import {
   batteryOfTests,
   poll,
 } from '@shopify/shopify-app-session-storage-test-utils';
+import {Session} from '@shopify/shopify-api';
 
 import {PostgreSQLSessionStorage} from '../postgresql';
 
@@ -80,5 +81,28 @@ describe('PostgreSQLSessionStorage', () => {
 
     storageClone1.disconnect();
     storageClone2.disconnect();
+  });
+
+  it(`can disconnect and reconnect to make queries with the pooling clients`, async () => {
+    const storage = new PostgreSQLSessionStorage(dbURL);
+    await storage.ready;
+    const sessionId = '123';
+    const session = new Session({
+      id: sessionId,
+      shop: 'test-shop.myshopify.com',
+      state: 'test-state',
+      isOnline: false,
+      scope: 'fake_scope',
+    });
+
+    expect(await storage.storeSession(session)).toBeTruthy();
+    await storage.disconnect();
+
+    const loadedSession = await storage.loadSession(sessionId);
+    expect(loadedSession).toEqual(session);
+    await storage.disconnect();
+
+    expect(await storage.deleteSession(sessionId)).toBeTruthy();
+    await storage.disconnect();
   });
 });

--- a/packages/shopify-app-session-storage-postgresql/src/migrations.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/migrations.ts
@@ -65,14 +65,6 @@ export async function migrateToCaseSensitivity(
     queries.unshift(`BEGIN`);
     queries.push(`COMMIT`);
 
-    try {
-      for (const query of queries) {
-        await connection.query(query);
-      }
-    } catch (error) {
-      // rollback if any of the queries fail
-      await connection.query(`ROLLBACK`);
-      throw error;
-    }
+    await connection.transaction(queries);
   }
 }

--- a/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
@@ -60,7 +60,7 @@ export class PostgresConnection implements RdbmsConnection {
   }
 
   public getDatabase(): string | undefined {
-    return this.dbUrl.pathname.replace(/^\//, '');
+    return this.dbUrl.pathname.slice(1);
   }
 
   async hasTable(tablename: string): Promise<boolean> {

--- a/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
@@ -4,37 +4,70 @@ import {RdbmsConnection} from '@shopify/shopify-app-session-storage';
 export class PostgresConnection implements RdbmsConnection {
   sessionStorageIdentifier: string;
   private ready: Promise<void>;
-  private client: pg.Client;
+  private pool: pg.Pool;
+  private dbUrl: URL;
 
   constructor(dbUrl: string, sessionStorageIdentifier: string) {
-    this.ready = this.init(dbUrl);
+    this.dbUrl = new URL(dbUrl);
+    this.ready = this.init();
     this.sessionStorageIdentifier = sessionStorageIdentifier;
   }
 
   async query(query: string, params: any[] = []): Promise<any[]> {
     await this.ready;
-    return (await this.client.query(query, params)).rows;
+    return (await this.pool.query(query, params)).rows;
+  }
+
+  /**
+   * Runs a series of queries in a transaction - requires the use of a SINGLE client,
+   * hence we can't use the query method above.
+   *
+   * @param queries an array of SQL queries to execute in a transaction
+   */
+  async transaction(queries: string[]): Promise<void> {
+    await this.ready;
+
+    // check if the first and last queries are BEGIN and COMMIT, if not, add them
+    if (queries[0] !== 'BEGIN') {
+      queries.unshift('BEGIN');
+    }
+    if (queries[queries.length - 1] !== 'COMMIT') {
+      queries.push('COMMIT');
+    }
+    const client = await this.pool.connect();
+    try {
+      for (const query of queries) {
+        await client.query(query);
+      }
+    } catch (error) {
+      // rollback if any of the queries fail
+      await client.query(`ROLLBACK`);
+      throw error;
+    } finally {
+      client.release();
+    }
   }
 
   async disconnect(): Promise<void> {
+    // Since no longer using individual client, use disconnect to reset the pool.
     await this.ready;
-    await this.client.end();
+    await this.pool.end();
+    this.ready = this.init();
   }
 
   async connect(): Promise<void> {
     await this.ready;
-    await this.client.connect();
   }
 
   public getDatabase(): string | undefined {
-    return this.client.database;
+    return this.dbUrl.pathname.replace(/^\//, '');
   }
 
   async hasTable(tablename: string): Promise<boolean> {
     await this.ready;
     const query = `
       SELECT EXISTS (
-        SELECT tablename FROM pg_catalog.pg_tables 
+        SELECT tablename FROM pg_catalog.pg_tables
           WHERE tablename = ${this.getArgumentPlaceholder(1)}
       )
   `;
@@ -49,7 +82,7 @@ export class PostgresConnection implements RdbmsConnection {
     return `$${position}`;
   }
 
-  private async init(dbUrl: string): Promise<void> {
-    this.client = new pg.Client({connectionString: dbUrl.toString()});
+  private async init(): Promise<void> {
+    this.pool = new pg.Pool({connectionString: this.dbUrl.toString()});
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?

Keeping an open client connection to the database is not recommended, as it can result in a timeout and subsequent query failure.

Fixes #156
Fixes #168 

### WHAT is this pull request doing?

This PR changes the PostgreSQL session storage to use a connection pool instead of a single client connection.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~ not applicable
