### PR TITLE
Add event handlers to redis client

### DIFF
--- a/.changeset/sixty-suns-brush.md
+++ b/.changeset/sixty-suns-brush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-redis': patch
+---
+
+Add event handlers to redis client to prevent crashing on disconnect event. Fixes #129, #160 (Thanks to @davidhollenbeckx for linking to issue and solution.)

--- a/packages/shopify-app-session-storage-redis/src/__tests__/redis.conf
+++ b/packages/shopify-app-session-storage-redis/src/__tests__/redis.conf
@@ -1,1 +1,2 @@
 user shopify on +@all allkeys  >passify
+timeout 2

--- a/packages/shopify-app-session-storage-redis/src/redis-connection.ts
+++ b/packages/shopify-app-session-storage-redis/src/redis-connection.ts
@@ -7,18 +7,9 @@ export class RedisConnection implements DBConnection {
   sessionStorageIdentifier: string;
   private client: RedisClient;
 
-  constructor(
-    dbUrl: string,
-    options: RedisClientOptions,
-    keyPrefix: string,
-    onError?: (...args: any[]) => void,
-  ) {
+  constructor(dbUrl: string, options: RedisClientOptions, keyPrefix: string) {
     this.init(dbUrl, options);
     this.sessionStorageIdentifier = keyPrefix;
-
-    if (onError) {
-      this.client.on('error', onError);
-    }
   }
 
   query(_query: string, _params: any[]): Promise<any[]> {
@@ -62,5 +53,12 @@ export class RedisConnection implements DBConnection {
       ...options,
       url: dbUrl,
     });
+
+    this.client.on('error', this.eventHandler);
+    this.client.on('connect', this.eventHandler);
+    this.client.on('reconnecting', this.eventHandler);
+    this.client.on('ready', this.eventHandler);
   }
+
+  private eventHandler = (..._args: any[]) => {};
 }


### PR DESCRIPTION
### WHY are these changes introduced?

If certain event handlers aren't defined on the client before connecting, the app will crash on disconnect event (e.g., timeout).

Issue [comment](https://github.com/redis/node-redis/issues/2032#issuecomment-1116883257) regarding implementation details from node-redis repo.

Fixes #129
Fixes #160

### WHAT is this pull request doing?

Adding empty (non-acting) event handlers for `connect`, `reconnecting` and `ready` events, per the comment linked above.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
