### PR TITLE
Allow URL string for new MySQLSessionStorage()

### DIFF
--- a/.changeset/wise-books-mix.md
+++ b/.changeset/wise-books-mix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-mysql': patch
+---
+
+In 1.0.2 of MySQLSessionStorage, the constructor could accept either a URL object or a URL string. The string option was accidentally removed, starting 1.1.0. This patch adds it back in. Fixes #204

--- a/packages/shopify-app-session-storage-mysql/README.md
+++ b/packages/shopify-app-session-storage-mysql/README.md
@@ -17,6 +17,16 @@ const shopify = shopifyApp({
 // OR
 
 const shopify = shopifyApp({
+  sessionStorage: new MySQLSessionStorage(
+    new URL('mysql://username:password@host/database'),
+    {connectionPoolLimit: 10}, // optional
+  ),
+  // ...
+});
+
+// OR
+
+const shopify = shopifyApp({
   sessionStorage: MySQLSessionStorage.withCredentials(
     'host.com',
     'thedatabase',

--- a/packages/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -119,4 +119,19 @@ describe('MySQLSessionStorage', () => {
     expect(await storage.deleteSession(sessionId)).toBeTruthy();
     await storage.disconnect();
   });
+
+  it(`can successfully connect with a url string instead of a URL object`, async () => {
+    const storage = new MySQLSessionStorage(dbURL.toString());
+    await storage.ready;
+    const session = new Session({
+      id: '456',
+      shop: 'test-shop.myshopify.com',
+      state: 'test-state',
+      isOnline: false,
+      scope: 'fake_scope',
+    });
+
+    expect(await storage.storeSession(session)).toBeTruthy();
+    await storage.disconnect();
+  });
 });

--- a/packages/shopify-app-session-storage-mysql/src/mysql.ts
+++ b/packages/shopify-app-session-storage-mysql/src/mysql.ts
@@ -45,9 +45,14 @@ export class MySQLSessionStorage implements SessionStorage {
   private connection: MySqlConnection;
   private migrator: MySqlSessionStorageMigrator;
 
-  constructor(dbUrl: URL, opts: Partial<MySQLSessionStorageOptions> = {}) {
+  constructor(
+    dbUrl: URL | string,
+    opts: Partial<MySQLSessionStorageOptions> = {},
+  ) {
     this.options = {...defaultMySQLSessionStorageOptions, ...opts};
-    this.internalInit = this.init(dbUrl);
+    this.internalInit = this.init(
+      typeof dbUrl === 'string' ? new URL(dbUrl) : dbUrl,
+    );
     this.migrator = new MySqlSessionStorageMigrator(
       this.connection,
       this.options.migratorOptions,


### PR DESCRIPTION
### WHY are these changes introduced?

In `1.0.2` and earlier of `MySQLSessionStorage`, the constructor could accept either a URL object or a URL string. The string option was accidentally removed, starting `1.1.0`.

Fixes #204

### WHAT is this pull request doing?

Allow `new MySQLSessionStorage()` to accept either a `URL` object or a string, e.g.,
```ts
const dbString = 'mysql://username:password@host/database';
const sessionStorage = new MySQLSessionStorage(dbString);
// OR
const sessionStorage = new MySQLSessionStorage(new URL(dbString));
```

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
