### PR TITLE
Bump shopify-api from 7.0.0 to 7.1.0

### DIFF
--- a/.changeset/spicy-foxes-boil.md
+++ b/.changeset/spicy-foxes-boil.md
@@ -1,0 +1,14 @@
+---
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-express': patch
+---
+
+Bumps [@shopify/shopify-api](https://github.com/Shopify/shopify-api-js) from 7.0.0 to 7.1.0. See `@shopify/shopify-api`'s [changelog](https://github.com/Shopify/shopify-api-js/blob/main/CHANGELOG.md) for more details.

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2",
     "@shopify/shopify-app-session-storage-memory": "^1.0.5",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -37,7 +37,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -39,7 +39,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0",
+    "@shopify/shopify-api": "^7.1.0",
     "@shopify/shopify-app-session-storage": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.0.0"
+    "@shopify/shopify-api": "^7.1.0"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",


### PR DESCRIPTION
### WHY are these changes introduced?

`@shopify/shopify-api@7.1.0` released ...

### WHAT is this pull request doing?

... update these packages to latest version

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- not applicable ~I have added/updated tests for this change~
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
