### PR TITLE
Fix typing, add export of types

### DIFF
--- a/packages/shopify-app-session-storage-prisma/src/prisma.ts
+++ b/packages/shopify-app-session-storage-prisma/src/prisma.ts
@@ -64,6 +64,7 @@ export class PrismaSessionStorage<T extends PrismaClient>
 
   private sessionToRow(session: Session): Row {
     const sessionParams = session.toObject();
+
     return {
       id: session.id,
       shop: session.shop,
@@ -72,7 +73,9 @@ export class PrismaSessionStorage<T extends PrismaClient>
       scope: session.scope || null,
       expires: session.expires || null,
       accessToken: session.accessToken || '',
-      userId: sessionParams.onlineAccessInfo?.associated_user.id || null,
+      userId:
+        (sessionParams.onlineAccessInfo?.associated_user
+          .id as unknown as bigint) || null,
     };
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     {"path": "./packages/shopify-app-session-storage-mongodb"},
     {"path": "./packages/shopify-app-session-storage-mysql"},
     {"path": "./packages/shopify-app-session-storage-postgresql"},
+    {"path": "./packages/shopify-app-session-storage-prisma"},
     {"path": "./packages/shopify-app-session-storage-redis"},
     {"path": "./packages/shopify-app-session-storage-sqlite"},
     {"path": "./packages/shopify-app-session-storage-kv"},

--- a/yarn.lock
+++ b/yarn.lock
@@ -2519,7 +2519,7 @@
     jest-matcher-utils "^27.0.0"
     pretty-format "^27.0.0"
 
-"@types/jest@^29.1.0", "@types/jest@^29.5.1":
+"@types/jest@^29.5.1":
   version "29.5.1"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-29.5.1.tgz#83c818aa9a87da27d6da85d3378e5a34d2f31a47"
   integrity sha512-tEuVcHrpaixS36w7hpsfLBLpjtMRJUE09/MHXn923LOVojDwyC14cWcfc0rDs0VEfUyYmt/+iX1kxxp+gZMcaQ==
@@ -4373,7 +4373,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.1.tgz#c22c48f48942d08ca824cc526211ae400478a994"
   integrity sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==
 
-eslint@^8.40.0:
+eslint@^8.38.0, eslint@^8.40.0:
   version "8.40.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.40.0.tgz#a564cd0099f38542c4e9a2f630fa45bf33bc42a4"
   integrity sha512-bvR+TsP9EHL3TqNtj9sCNJVAFK3fBN8Q7g5waghxyRsPLIMwL73XSKnZFK0hk/O2ANC+iAoq6PWMQ+IfBAJIiQ==


### PR DESCRIPTION
### WHY are these changes introduced?

TypeScript types were not being included in Prisma build

### WHAT is this pull request doing?

- Adding the types to the Prisma package
- Fixing the conversion of a `number` to `bigint` associated with type mismatch

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- not applicable ~I have added/updated tests for this change~
- not applicable ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~
