### PR TITLE
Name internal package GraphQL queries

### DIFF
--- a/.changeset/fuzzy-students-cough.md
+++ b/.changeset/fuzzy-students-cough.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+[Internal] Improved tracking of GraphQL calls made by the package

--- a/packages/shopify-app-express/src/middlewares/has-valid-access-token.ts
+++ b/packages/shopify-app-express/src/middlewares/has-valid-access-token.ts
@@ -1,7 +1,6 @@
 import {HttpResponseError, Session, Shopify} from '@shopify/shopify-api';
 
-const TEST_GRAPHQL_QUERY = `
-{
+const TEST_GRAPHQL_QUERY = `query shopifyAppShopName {
   shop {
     name
   }


### PR DESCRIPTION
### WHY are these changes introduced?

This PR names the GraphQL query we use to check if the session is still valid, to make it easier to tell from app-created calls.

### WHAT is this pull request doing?

Just adding a name to the query.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
