### PR TITLE
Bumping @shopify/shopify-api to 7.4.0

### DIFF
--- a/.changeset/quick-socks-raise.md
+++ b/.changeset/quick-socks-raise.md
@@ -1,0 +1,16 @@
+---
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+'@shopify/shopify-app-session-storage-dynamodb': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-prisma': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-express': patch
+---
+
+Updating @shopify/shopify-api dependency

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4",
     "@shopify/shopify-app-session-storage-memory": "^1.0.7",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-session-storage-dynamodb/package.json
+++ b/packages/shopify-app-session-storage-dynamodb/package.json
@@ -37,13 +37,13 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4",
     "@shopify/shopify-app-session-storage-test-utils": "^0.1.4",
     "eslint": "^8.40.0",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -37,7 +37,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-prisma/package.json
+++ b/packages/shopify-app-session-storage-prisma/package.json
@@ -35,13 +35,13 @@
   },
   "peerDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^7.1.0",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.3",
     "prisma": "^4.13.0"
   },
   "devDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^7.1.0",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.3",
     "prisma": "^4.13.0",
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -38,7 +38,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1",
+    "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.3.1"
+    "@shopify/shopify-api": "^7.4.0"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3038,10 +3038,10 @@
   resolved "https://registry.yarnpkg.com/@shopify/prettier-config/-/prettier-config-1.1.2.tgz#612f87c0cd1196e8b43c85425e587d0fa7f1172d"
   integrity sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==
 
-"@shopify/shopify-api@^7.1.0", "@shopify/shopify-api@^7.3.1":
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-7.3.1.tgz#fa488f7f17e30280db42f0270471f5186ca2f6dd"
-  integrity sha512-r72cUOisXu1dCK+PiTEuLWJQ+SviXw5TRcEBAUjyOcB3NUUV8K66VTPL53mTEjc/qq8MwHKqP067KdlOK7d1WA==
+"@shopify/shopify-api@^7.4.0":
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-7.4.0.tgz#def55d83c259eef8c3502ba1f9590634c26bc31c"
+  integrity sha512-ktUeqOerTAZFoZsuEZjyMZ2hF4QnXxVjKsphL1lANHPhLDk75q1yMFyoThv/M6YcVg0kc6DTzZ2MRBKkMMzjyA==
   dependencies:
     "@shopify/network" "^3.2.1"
     compare-versions "^5.0.3"


### PR DESCRIPTION
This PR is just bumping the dependency on `@shopify/shopify-api` to the latest version.