### PR TITLE
Run OAuth flow from login page

### DIFF
--- a/packages/shopify-app-remix/src/auth/login/__tests__/login.test.ts
+++ b/packages/shopify-app-remix/src/auth/login/__tests__/login.test.ts
@@ -107,10 +107,9 @@ describe('login helper', () => {
       );
 
       // THEN
-      const shopWithoutDomain = TEST_SHOP.replace('.myshopify.com', '');
       expect(response.status).toEqual(302);
       expect(response.headers.get('location')).toEqual(
-        `https://admin.shopify.com/store/${shopWithoutDomain}/apps/${config.apiKey}`,
+        `${APP_URL}/auth?shop=${TEST_SHOP}`,
       );
     },
   );

--- a/packages/shopify-app-remix/src/auth/login/login.ts
+++ b/packages/shopify-app-remix/src/auth/login/login.ts
@@ -40,8 +40,7 @@ export function loginFactory(params: BasicParams) {
       return {shop: LoginErrorType.InvalidShop};
     }
 
-    const [shopWithoutDot] = sanitizedShop.split('.');
-    const redirectUrl = `https://admin.shopify.com/store/${shopWithoutDot}/apps/${config.apiKey}`;
+    const redirectUrl = `${config.appUrl}${config.auth.path}?shop=${sanitizedShop}`;
 
     logger.info(`Redirecting login request to ${redirectUrl}`, {
       shop: sanitizedShop,


### PR DESCRIPTION
### WHY are these changes introduced?

Previously, the `shopify.login` call led the user to `/admin/store/<shop>/apps/<app>`, which meant that the user might see a 404 page when they add a new shop.

### WHAT is this pull request doing?

Always triggering an OAuth flow at this point (i.e. going to `/admin/oauth/authorize`) instead so that core can determine whether to take the user to the app store, or the app itself (if it's already installed).