### PR TITLE
Fix deno issues

### DIFF
--- a/packages/shopify-app-remix/package.json
+++ b/packages/shopify-app-remix/package.json
@@ -51,7 +51,6 @@
     "@remix-run/server-runtime": "^1.17.1",
     "@shopify/shopify-api": "^7.4.0",
     "@shopify/shopify-app-session-storage": "^1.1.2",
-    "@shopify/shopify-app-session-storage-sqlite": "^1.2.2",
     "isbot": "^3.6.5",
     "semver": "^7.5.0",
     "tslib": "^2.5.0"

--- a/packages/shopify-app-remix/src/__tests__/index.test.ts
+++ b/packages/shopify-app-remix/src/__tests__/index.test.ts
@@ -88,21 +88,12 @@ describe('shopifyApp', () => {
     [APP_LATEST_API_VERSION, LogSeverity, DeliveryMethod, BillingInterval];
   });
 
-  it('defaults sessionStorage', () => {
+  it('fails if no session storage is given', () => {
     // GIVEN
     const config: AppConfigArg = testConfig({sessionStorage: undefined});
-    delete config.sessionStorage;
-    delete config.isEmbeddedApp;
-    delete config.apiVersion;
-
-    if (fs.existsSync(path.join(__dirname, '../../database.sqlite'))) {
-      fs.unlinkSync(path.join(__dirname, '../../database.sqlite'));
-    }
-
-    // WHEN
-    const shopify = shopifyApp(config);
+    delete (config as any).sessionStorage;
 
     // THEN
-    expect(shopify.sessionStorage).toBeInstanceOf(SQLiteSessionStorage);
+    expect(() => shopifyApp(config)).toThrowError(ShopifyError);
   });
 });

--- a/packages/shopify-app-remix/src/auth/helpers/__tests__/add-response-headers.test.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/__tests__/add-response-headers.test.ts
@@ -1,5 +1,4 @@
 import {shopifyApp} from '../../..';
-import {APP_BRIDGE_NEXT_URL} from '../../const';
 import {
   APP_URL,
   TEST_SHOP,

--- a/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
@@ -50,28 +50,32 @@ export function installGlobalResponseHeaders(isEmbeddedApp: boolean) {
       // Note: this is not an empty Headers, it will contain any headers passed to new Response():
       const headers = headersDescriptor.get!.call(this);
 
-      // Inject CORS headers required by both Embedded Apps and UI Extensions:
-      if (isEmbeddedApp) {
-        for (const key in APP_BRIDGE_HEADERS) {
-          if (!headers.get(key)) {
-            const value =
-              APP_BRIDGE_HEADERS[key as keyof typeof APP_BRIDGE_HEADERS];
+      try {
+        // Inject CORS headers required by both Embedded Apps and UI Extensions:
+        if (isEmbeddedApp) {
+          for (const key in APP_BRIDGE_HEADERS) {
+            if (!headers.get(key)) {
+              const value =
+                APP_BRIDGE_HEADERS[key as keyof typeof APP_BRIDGE_HEADERS];
 
-            headers.set(key, value);
+              headers.set(key, value);
+            }
           }
         }
-      }
 
-      // Apply a default CSP unless a more specific one (no wildcard) is present:
-      if (!headers.get('Content-Security-Policy')) {
-        headers.set(
-          'Content-Security-Policy',
-          isEmbeddedApp ? DEFAULT_CSP_VALUE : `frame-ancestors 'none';`,
-        );
-      }
+        // Apply a default CSP unless a more specific one (no wildcard) is present:
+        if (!headers.get('Content-Security-Policy')) {
+          headers.set(
+            'Content-Security-Policy',
+            isEmbeddedApp ? DEFAULT_CSP_VALUE : `frame-ancestors 'none';`,
+          );
+        }
 
-      if (!headers.get('Link')) {
-        headers.set('Link', `<${APP_BRIDGE_NEXT_URL}>; rel="preload"`);
+        if (!headers.get('Link')) {
+          headers.set('Link', `<${APP_BRIDGE_NEXT_URL}>; rel="preload"`);
+        }
+      } catch (err) {
+        // Do nothing, this is not a standard Response object.
       }
 
       return headers;

--- a/packages/shopify-app-remix/src/config-types.ts
+++ b/packages/shopify-app-remix/src/config-types.ts
@@ -33,9 +33,7 @@ export interface AppConfigArg<
   /**
    * An adaptor for storing sessions in your database of choice.
    *
-   * Shopify provides multiple session storage adaptors ans you can create your own. {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}
-   *
-   * @defaultValue `new SQLiteSessionStorage("database.sqlite")`
+   * Shopify provides multiple session storage adaptors and you can create your own. {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}
    *
    * @example
    * Using Prisma
@@ -51,7 +49,7 @@ export interface AppConfigArg<
    * });
    * ```
    */
-  sessionStorage?: Storage;
+  sessionStorage: Storage;
 
   /**
    * Does your app use online or just offline tokens.

--- a/packages/shopify-app-remix/src/index.ts
+++ b/packages/shopify-app-remix/src/index.ts
@@ -10,7 +10,6 @@ import {
 } from '@shopify/shopify-api';
 import {setAbstractRuntimeString} from '@shopify/shopify-api/runtime';
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
-import {SQLiteSessionStorage} from '@shopify/shopify-app-session-storage-sqlite';
 
 import {type AppConfig, type AppConfigArg} from './config-types';
 import {
@@ -140,6 +139,12 @@ function deriveConfig<Storage extends SessionStorage>(
   appConfig: AppConfigArg,
   apiConfig: ApiConfig,
 ): AppConfig<Storage> {
+  if (!appConfig.sessionStorage) {
+    throw new ShopifyError(
+      'Please provide a valid session storage. See https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options for options.',
+    );
+  }
+
   const authPathPrefix = appConfig.authPathPrefix || '/auth';
   const distribution = appConfig.distribution ?? AppDistribution.AppStore;
 
@@ -149,8 +154,7 @@ function deriveConfig<Storage extends SessionStorage>(
     canUseLoginForm: distribution !== AppDistribution.ShopifyAdmin,
     useOnlineTokens: appConfig.useOnlineTokens ?? false,
     hooks: appConfig.hooks ?? {},
-    sessionStorage: (appConfig.sessionStorage ??
-      new SQLiteSessionStorage('database.sqlite')) as unknown as Storage,
+    sessionStorage: appConfig.sessionStorage as Storage,
     auth: {
       path: authPathPrefix,
       callbackPath: `${authPathPrefix}/callback`,


### PR DESCRIPTION
### WHY are these changes introduced?

When running on Deno (or any non-Node runtime), we won't be able to default the session storage to SQLite, because it uses the filesystem using node-specific libraries.

Also, some `Response` implementation in deno's fetch doesn't use the standard `Headers` object, which causes it to fail when we try to `set` the CSP / CORS headers. If that happens, we can just ignore the error it throws because it's not a Remix response, so we don't care about setting headers for it.

### WHAT is this pull request doing?

Removing the fallback to SQLite, instead making the configuration option mandatory, and ignoring the error message when setting the headers.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
