### PR TITLE
fix: preload app bridge as script

### DIFF
--- a/packages/shopify-app-remix/src/__tests__/test-helper.ts
+++ b/packages/shopify-app-remix/src/__tests__/test-helper.ts
@@ -206,7 +206,9 @@ export function expectSecurityHeaders(
     expect(headers.get('Access-Control-Expose-Headers')).toEqual(
       REAUTH_URL_HEADER,
     );
-    expect(headers.get('Link')).toEqual(`<${APP_BRIDGE_URL}>; rel="preload"`);
+    expect(headers.get('Link')).toEqual(
+      `<${APP_BRIDGE_URL}>; rel="preload"; as="script"`,
+    );
   } else {
     expect(headers.get('Content-Security-Policy')).toEqual(
       `frame-ancestors 'none';`,

--- a/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
@@ -68,7 +68,10 @@ export function installGlobalResponseHeaders(isEmbeddedApp: boolean) {
         }
 
         if (!headers.get('Link')) {
-          headers.set('Link', `<${APP_BRIDGE_URL}>; rel="preload"; as="script"`);
+          headers.set(
+            'Link',
+            `<${APP_BRIDGE_URL}>; rel="preload"; as="script"`,
+          );
         }
       } catch (err) {
         // Do nothing, this is not a standard Response object.

--- a/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
@@ -68,7 +68,7 @@ export function installGlobalResponseHeaders(isEmbeddedApp: boolean) {
         }
 
         if (!headers.get('Link')) {
-          headers.set('Link', `<${APP_BRIDGE_URL}>; rel="preload"`);
+          headers.set('Link', `<${APP_BRIDGE_URL}>; rel="preload"; as="script"`);
         }
       } catch (err) {
         // Do nothing, this is not a standard Response object.


### PR DESCRIPTION
Without this, the cache entry will be ignored.

<img width="392" alt="Screenshot 2023-07-14 at 4 47 54 PM" src="https://github.com/Shopify/shopify-app-js/assets/105127/e30071d7-01da-4c12-9345-23cdd79bb66e">
