### PR TITLE
Remove `canUseLoginForm` and fix docs

### DIFF
--- a/packages/shopify-app-remix/src/__tests__/index.test.ts
+++ b/packages/shopify-app-remix/src/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import {
   LogSeverity,
   DeliveryMethod,
   BillingInterval,
+  AppDistribution,
 } from '../index';
 import {AppConfigArg} from '../config-types';
 
@@ -28,15 +29,34 @@ describe('shopifyApp', () => {
 
   it('can create shopify object', () => {
     // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // THEN
+    expect(shopify).toBeDefined();
+  });
+
+  it('has login function when distribution is not ShopifyAdmin', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // THEN
+    expect(shopify.login).toBeDefined();
+  });
+
+  it('does not have login function when distribution is ShopifyAdmin', () => {
+    // GIVEN
     const config = testConfig({
       userAgentPrefix: 'test',
     });
 
     // WHEN
-    const shopify = shopifyApp(config);
+    const shopify = shopifyApp({
+      ...config,
+      distribution: AppDistribution.ShopifyAdmin,
+    });
 
     // THEN
-    expect(shopify).toBeDefined();
+    expect(shopify).not.toHaveProperty('login');
   });
 
   it('fails with an invalid config', () => {

--- a/packages/shopify-app-remix/src/auth/login/login.ts
+++ b/packages/shopify-app-remix/src/auth/login/login.ts
@@ -6,13 +6,6 @@ export function loginFactory(params: BasicParams) {
   const {api, config, logger} = params;
 
   return async function login(request: Request): Promise<LoginError | never> {
-    if (!config.canUseLoginForm) {
-      logger.debug(
-        'Login endpoint not available for Shopify Admin custom apps',
-      );
-      throw new Response(undefined, {status: 404});
-    }
-
     const url = new URL(request.url);
     const shopParam = url.searchParams.get('shop');
 

--- a/packages/shopify-app-remix/src/index.ts
+++ b/packages/shopify-app-remix/src/index.ts
@@ -84,10 +84,8 @@ export function shopifyApp<
 
   return {
     sessionStorage: config.sessionStorage,
-    canUseLoginForm: config.canUseLoginForm,
     addResponseHeaders: addResponseHeadersFactory(params),
     registerWebhooks: registerWebhooksFactory(params),
-    login: loginFactory(params),
     authenticate: {
       admin: oauth.authenticateAdmin.bind(oauth),
       public: authenticatePublicFactory(params),
@@ -96,7 +94,16 @@ export function shopifyApp<
         keyof Config['webhooks'] | MandatoryTopics
       >(params),
     },
-  };
+    ...(isAdminApp(appConfig.distribution)
+      ? {}
+      : {login: loginFactory(params)}),
+  } as ShopifyApp<Config>;
+}
+
+function isAdminApp<Config extends AppConfigArg>(
+  distribution: Config['distribution'],
+): distribution is AppDistribution.ShopifyAdmin {
+  return distribution === AppDistribution.ShopifyAdmin;
 }
 
 function deriveApi<Resources extends ShopifyRestResources>(


### PR DESCRIPTION
### WHY are these changes introduced?

The `canUseLoginForm` export we use is unnecessary, because we can simply type `ShopifyApp` in a way that it only includes the login capability if it's allowed, thus making it easier for developers to know whether they can use it or not by simply checking if the function is there.

Or better yet, it'll never come up if they set their distribution to `ShopifyAdmin` so that they won't even try it in the first place.

### WHAT is this pull request doing?

Removing the property and changing the return type so that login won't be included for `ShopifyAdmin` distributed apps.