### PR TITLE
Allow App Bridge URL override

### DIFF
--- a/packages/shopify-app-remix/src/adapters/node/__tests__/node-app-bridge-url.test.ts
+++ b/packages/shopify-app-remix/src/adapters/node/__tests__/node-app-bridge-url.test.ts
@@ -1,0 +1,18 @@
+import {appBridgeUrl} from '../../../auth/helpers/app-bridge-url';
+import {APP_BRIDGE_URL} from '../../../auth/const';
+
+describe('node setup import', () => {
+  /* eslint-disable no-process-env */
+  it('overwrites the App Bridge URL from the env var when present', async () => {
+    // GIVEN
+    expect(appBridgeUrl()).toEqual(APP_BRIDGE_URL);
+    process.env.APP_BRIDGE_URL = 'http://localhost:9876/app-bridge.js';
+
+    // WHEN
+    await require('../index');
+
+    // THEN
+    expect(appBridgeUrl()).toEqual(process.env.APP_BRIDGE_URL);
+  });
+  /* eslint-enable no-process-env */
+});

--- a/packages/shopify-app-remix/src/adapters/node/index.ts
+++ b/packages/shopify-app-remix/src/adapters/node/index.ts
@@ -5,8 +5,16 @@ import {
   setCrypto,
 } from '@shopify/shopify-api/runtime';
 
+import {setAppBridgeUrlOverride} from '../../auth/helpers/app-bridge-url';
+
 setCrypto(crypto as any);
 
 setAbstractRuntimeString(() => {
   return `Remix (Node)`;
 });
+
+/* eslint-disable no-process-env */
+if (process.env.APP_BRIDGE_URL) {
+  setAppBridgeUrlOverride(process.env.APP_BRIDGE_URL);
+}
+/* eslint-enable no-process-env */

--- a/packages/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -32,7 +32,7 @@ import {
   validateSessionToken,
   rejectBotRequest,
 } from '../helpers';
-import {APP_BRIDGE_URL} from '../const';
+import {appBridgeUrl} from '../helpers/app-bridge-url';
 
 import type {AdminContext} from './types';
 import {graphqlClientFactory} from './graphql-client';
@@ -502,7 +502,9 @@ export class AuthStrategy<
 
     throw new Response(
       `
-        <script data-api-key="${config.apiKey}" src="${APP_BRIDGE_URL}"></script>
+        <script data-api-key="${
+          config.apiKey
+        }" src="${appBridgeUrl()}"></script>
         ${redirectToScript}
       `,
       {headers: {'content-type': 'text/html;charset=utf-8'}},

--- a/packages/shopify-app-remix/src/auth/helpers/__tests__/app-bridge-url.test.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/__tests__/app-bridge-url.test.ts
@@ -1,0 +1,21 @@
+import {APP_BRIDGE_URL} from '../../const';
+import {appBridgeUrl, setAppBridgeUrlOverride} from '../app-bridge-url';
+
+describe('appBridgeUrl', () => {
+  it('defaults to returning the const APP_BRIDGE_URL', () => {
+    // GIVEN
+    setAppBridgeUrlOverride(undefined as any as string);
+
+    // THEN
+    expect(appBridgeUrl()).toEqual(APP_BRIDGE_URL);
+  });
+
+  it('returns the override value when set', () => {
+    // GIVEN
+    const override = 'http://localhost:9876/app-bridge.js';
+    setAppBridgeUrlOverride(override);
+
+    // THEN
+    expect(appBridgeUrl()).toEqual(override);
+  });
+});

--- a/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/add-response-headers.ts
@@ -1,5 +1,7 @@
 import type {BasicParams} from '../../types';
-import {APP_BRIDGE_HEADERS, APP_BRIDGE_URL, DEFAULT_CSP_VALUE} from '../const';
+import {APP_BRIDGE_HEADERS, DEFAULT_CSP_VALUE} from '../const';
+
+import {appBridgeUrl} from './app-bridge-url';
 
 const ORIGINAL_HEADERS = Symbol.for('originalHeaders');
 
@@ -70,7 +72,7 @@ export function installGlobalResponseHeaders(isEmbeddedApp: boolean) {
         if (!headers.get('Link')) {
           headers.set(
             'Link',
-            `<${APP_BRIDGE_URL}>; rel="preload"; as="script"`,
+            `<${appBridgeUrl()}>; rel="preload"; as="script"`,
           );
         }
       } catch (err) {

--- a/packages/shopify-app-remix/src/auth/helpers/app-bridge-url.ts
+++ b/packages/shopify-app-remix/src/auth/helpers/app-bridge-url.ts
@@ -1,0 +1,10 @@
+import {APP_BRIDGE_URL} from '../const';
+
+let appBridgeUrlOverride: string | undefined;
+export function setAppBridgeUrlOverride(url: string) {
+  appBridgeUrlOverride = url;
+}
+
+export function appBridgeUrl() {
+  return appBridgeUrlOverride || APP_BRIDGE_URL;
+}


### PR DESCRIPTION
### WHY are these changes introduced?

Currently it isn't possible to test App Bridge locally with this package because it hardcodes the URL - which is fine since it will be evergreen in production.

### WHAT is this pull request doing?

Allowing an override env var to be set so that the internal references in this package can be overriden.