### PR TITLE
Boundary headers export

### DIFF
--- a/packages/shopify-app-remix/README.md
+++ b/packages/shopify-app-remix/README.md
@@ -185,7 +185,8 @@ To load your app within the Shopify Admin, you need to:
 
 ## Authenticating admin requests
 
-`shopifyApp` provides methods for authenticating admin requests. To authenticate admin requests you can call `shopify.authenticate.admin(request)` in a loader or an action:
+`shopifyApp` provides methods for authenticating admin requests.
+To authenticate admin requests you can call `shopify.authenticate.admin(request)` in a loader or an action:
 
 ```ts
 // app/routes/**/*.tsx
@@ -196,7 +197,30 @@ export const loader = async ({request}: LoaderArgs) => {
 };
 ```
 
-If there is a session for this user, this loader will return null. If there is no session for the user, the loader will throw the appropriate redirect Response.
+If there is a session for this user, this loader will return null.
+If there is no session for the user, the loader will throw the appropriate redirect Response.
+
+> **Note**: If you are authenticating more than one route, we recommend using [Remix layout routes](https://remix.run/docs/en/1.18.1/file-conventions/routes-files#layout-routes) to automatically authenticate them.
+
+### Headers
+
+It's important to note that the authentication functions in this package rely on throwing `Response` objects, which must be handled in your Remix routes using them.
+
+To do that, you can set up a [Remix `ErrorBoundary`](https://remix.run/docs/en/main/guides/errors).
+We provide some abstractions for the error and headers boundaries to make it easier for apps to set those up.
+
+```ts
+// app/routes/**/*.tsx
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};
+```
+
+> **Note**: You can also add this to a layout if you want to authenticate more than one route.
 
 ### Using the Shopify admin GraphQL API
 

--- a/packages/shopify-app-remix/README.md
+++ b/packages/shopify-app-remix/README.md
@@ -211,6 +211,8 @@ We provide some abstractions for the error and headers boundaries to make it eas
 
 ```ts
 // app/routes/**/*.tsx
+import {boundary} from '@shopify/shopify-app-remix';
+
 export function ErrorBoundary() {
   return boundary.error(useRouteError());
 }

--- a/packages/shopify-app-remix/src/boundary/__tests__/error.test.ts
+++ b/packages/shopify-app-remix/src/boundary/__tests__/error.test.ts
@@ -1,0 +1,26 @@
+import {shopifyApp} from '../../index';
+import {testConfig} from '../../__tests__/test-helper';
+
+describe('Error boundary', () => {
+  it('returns a string when handling a response', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const result = shopify.boundary.error(new Response());
+
+    // THEN
+    expect(result).toEqual('Handling response');
+  });
+
+  it('throws an error when handling an unknown error', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const result = () => shopify.boundary.error(new Error());
+
+    // THEN
+    expect(result).toThrowError();
+  });
+});

--- a/packages/shopify-app-remix/src/boundary/__tests__/error.test.ts
+++ b/packages/shopify-app-remix/src/boundary/__tests__/error.test.ts
@@ -2,12 +2,12 @@ import {shopifyApp} from '../../index';
 import {testConfig} from '../../__tests__/test-helper';
 
 describe('Error boundary', () => {
-  it('returns a string when handling a response', () => {
+  it('returns a string when handling an ErrorResponse', () => {
     // GIVEN
     const shopify = shopifyApp(testConfig());
 
     // WHEN
-    const result = shopify.boundary.error(new Response());
+    const result = shopify.boundary.error(new ErrorResponse());
 
     // THEN
     expect(result).toEqual('Handling response');
@@ -24,3 +24,5 @@ describe('Error boundary', () => {
     expect(result).toThrowError();
   });
 });
+
+class ErrorResponse extends Error {}

--- a/packages/shopify-app-remix/src/boundary/__tests__/headers.test.ts
+++ b/packages/shopify-app-remix/src/boundary/__tests__/headers.test.ts
@@ -1,0 +1,65 @@
+import {shopifyApp} from '../../index';
+import {testConfig} from '../../__tests__/test-helper';
+
+describe('Headers boundary', () => {
+  it('ignores non-error headers if errors are present', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const headers = {
+      parentHeaders: new Headers([['parent', 'header']]),
+      loaderHeaders: new Headers([['loader', 'header']]),
+      actionHeaders: new Headers([['action', 'header']]),
+      errorHeaders: new Headers([['error', 'header']]),
+    };
+
+    // WHEN
+    const result = shopify.boundary.headers(headers);
+
+    // THEN
+    expect(result.get('parent')).toBeNull();
+    expect(result.get('loader')).toBeNull();
+    expect(result.get('action')).toBeNull();
+    expect(result.get('error')).toEqual('header');
+  });
+
+  it('merges all headers if no errors are present', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const headers = {
+      parentHeaders: new Headers([
+        ['parent', 'header'],
+        ['common', 'parent'],
+      ]),
+      loaderHeaders: new Headers([
+        ['loader', 'header'],
+        ['common', 'loader'],
+      ]),
+      actionHeaders: new Headers([
+        ['action', 'header'],
+        ['common', 'action'],
+      ]),
+      errorHeaders: new Headers(),
+    };
+
+    // WHEN
+    const result = shopify.boundary.headers(headers);
+
+    // THEN
+    expect(result.get('parent')).toEqual('header');
+    expect(result.get('loader')).toEqual('header');
+    expect(result.get('action')).toEqual('header');
+    expect(result.get('common')).toEqual('parent, loader, action');
+  });
+
+  it('returns an empty headers object if no headers are present', () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const headers = {};
+
+    // WHEN
+    const result = shopify.boundary.headers(headers as any);
+
+    // THEN
+    expect(result).toEqual(new Headers());
+  });
+});

--- a/packages/shopify-app-remix/src/boundary/__tests__/headers.test.ts
+++ b/packages/shopify-app-remix/src/boundary/__tests__/headers.test.ts
@@ -2,7 +2,7 @@ import {shopifyApp} from '../../index';
 import {testConfig} from '../../__tests__/test-helper';
 
 describe('Headers boundary', () => {
-  it('ignores non-error headers if errors are present', () => {
+  it('returns only error headers if error headers are present', () => {
     // GIVEN
     const shopify = shopifyApp(testConfig());
     const headers = {
@@ -22,7 +22,7 @@ describe('Headers boundary', () => {
     expect(result.get('error')).toEqual('header');
   });
 
-  it('merges all headers if no errors are present', () => {
+  it('merges parent, loader & action headers if no error headers are present', () => {
     // GIVEN
     const shopify = shopifyApp(testConfig());
     const headers = {

--- a/packages/shopify-app-remix/src/boundary/error.ts
+++ b/packages/shopify-app-remix/src/boundary/error.ts
@@ -1,0 +1,7 @@
+export function errorBoundary(error: unknown): string | never {
+  if (error instanceof Response) {
+    return 'Handling response';
+  }
+
+  throw error;
+}

--- a/packages/shopify-app-remix/src/boundary/error.ts
+++ b/packages/shopify-app-remix/src/boundary/error.ts
@@ -1,5 +1,5 @@
-export function errorBoundary(error: unknown): string | never {
-  if (error instanceof Response) {
+export function errorBoundary(error: any): string | never {
+  if (error.constructor.name === 'ErrorResponse') {
     return 'Handling response';
   }
 

--- a/packages/shopify-app-remix/src/boundary/headers.ts
+++ b/packages/shopify-app-remix/src/boundary/headers.ts
@@ -1,0 +1,15 @@
+import {HeadersArgs} from '@remix-run/server-runtime';
+
+export function headersBoundary(headers: HeadersArgs): Headers {
+  const {parentHeaders, loaderHeaders, actionHeaders, errorHeaders} = headers;
+
+  if (errorHeaders && Array.from(errorHeaders.entries()).length > 0) {
+    return errorHeaders;
+  }
+
+  return new Headers([
+    ...(parentHeaders ? Array.from(parentHeaders.entries()) : []),
+    ...(loaderHeaders ? Array.from(loaderHeaders.entries()) : []),
+    ...(actionHeaders ? Array.from(actionHeaders.entries()) : []),
+  ]);
+}

--- a/packages/shopify-app-remix/src/boundary/types.ts
+++ b/packages/shopify-app-remix/src/boundary/types.ts
@@ -1,0 +1,4 @@
+import {HeadersArgs} from '@remix-run/server-runtime';
+
+export type ErrorBoundary = (error: unknown) => string | never;
+export type HeadersBoundary = (headers: HeadersArgs) => Headers;

--- a/packages/shopify-app-remix/src/index.ts
+++ b/packages/shopify-app-remix/src/index.ts
@@ -33,6 +33,8 @@ import {
   installGlobalResponseHeaders,
 } from './auth/helpers/add-response-headers';
 import {loginFactory} from './auth/login/login';
+import {headersBoundary} from './boundary/headers';
+import {errorBoundary} from './boundary/error';
 
 export type {ShopifyApp, LoginError} from './types';
 export {LoginErrorType, AppDistribution} from './types';
@@ -101,6 +103,10 @@ export function shopifyApp<
         keyof Config['webhooks'] | MandatoryTopics
       >(params),
     },
+    boundary: {
+      error: errorBoundary,
+      headers: headersBoundary,
+    },
   };
 
   if (
@@ -114,17 +120,17 @@ export function shopifyApp<
 }
 
 function isAppStoreApp<Config extends AppConfigArg>(
-  shopify: ShopifyAppBase<Config>,
+  _shopify: ShopifyAppBase<Config>,
   config: Config,
-): shopify is AppStoreApp<Config> {
-  return config.distribution === AppDistribution.ShopifyAdmin;
+): _shopify is AppStoreApp<Config> {
+  return config.distribution === AppDistribution.AppStore;
 }
 
 function isSingleMerchantApp<Config extends AppConfigArg>(
-  shopify: ShopifyAppBase<Config>,
+  _shopify: ShopifyAppBase<Config>,
   config: Config,
-): shopify is SingleMerchantApp<Config> {
-  return config.distribution === AppDistribution.ShopifyAdmin;
+): _shopify is SingleMerchantApp<Config> {
+  return config.distribution === AppDistribution.SingleMerchant;
 }
 
 function deriveApi<Resources extends ShopifyRestResources>(
@@ -175,12 +181,12 @@ function deriveConfig<Storage extends SessionStorage>(
   }
 
   const authPathPrefix = appConfig.authPathPrefix || '/auth';
-  const distribution = appConfig.distribution ?? AppDistribution.AppStore;
+  appConfig.distribution = appConfig.distribution ?? AppDistribution.AppStore;
 
   return {
     ...appConfig,
     ...apiConfig,
-    canUseLoginForm: distribution !== AppDistribution.ShopifyAdmin,
+    canUseLoginForm: appConfig.distribution !== AppDistribution.ShopifyAdmin,
     useOnlineTokens: appConfig.useOnlineTokens ?? false,
     hooks: appConfig.hooks ?? {},
     sessionStorage: appConfig.sessionStorage as Storage,

--- a/packages/shopify-app-remix/src/types.ts
+++ b/packages/shopify-app-remix/src/types.ts
@@ -80,7 +80,7 @@ type SessionStorageType<Config extends AppConfigArg> =
     ? Config['sessionStorage']
     : SessionStorage;
 
-interface ShopifyAppBase<Config extends AppConfigArg> {
+export interface ShopifyAppBase<Config extends AppConfigArg> {
   /**
    * The SessionStorage instance your app is using.
    *
@@ -360,10 +360,10 @@ interface ShopifyAppLogin {
   login: Login;
 }
 
-type AdminApp<Config extends AppConfigArg> = ShopifyAppBase<Config>;
-type SingleMerchantApp<Config extends AppConfigArg> = ShopifyAppBase<Config> &
-  ShopifyAppLogin;
-type AppStoreApp<Config extends AppConfigArg> = ShopifyAppBase<Config> &
+export type AdminApp<Config extends AppConfigArg> = ShopifyAppBase<Config>;
+export type SingleMerchantApp<Config extends AppConfigArg> =
+  ShopifyAppBase<Config> & ShopifyAppLogin;
+export type AppStoreApp<Config extends AppConfigArg> = ShopifyAppBase<Config> &
   ShopifyAppLogin;
 
 /**

--- a/packages/shopify-app-remix/src/types.ts
+++ b/packages/shopify-app-remix/src/types.ts
@@ -12,6 +12,7 @@ import type {
   RegisterWebhooksOptions,
   WebhookContext,
 } from './auth/webhooks/types';
+import {ErrorBoundary, HeadersBoundary} from './boundary/types';
 
 export interface BasicParams {
   api: Shopify;
@@ -34,6 +35,11 @@ export enum AppDistribution {
   SingleMerchant = 'single_merchant',
   ShopifyAdmin = 'shopify_admin',
 }
+
+export type MandatoryTopics =
+  | 'CUSTOMERS_DATA_REQUEST'
+  | 'CUSTOMERS_REDACT'
+  | 'SHOP_REDACT';
 
 interface JSONObject {
   [x: string]: JSONValue;
@@ -301,6 +307,11 @@ export interface ShopifyAppBase<Config extends AppConfigArg> {
       keyof Config['webhooks'] | MandatoryTopics
     >;
   };
+
+  boundary: {
+    error: ErrorBoundary;
+    headers: HeadersBoundary;
+  };
 }
 
 interface ShopifyAppLogin {
@@ -379,8 +390,3 @@ export type ShopifyApp<Config extends AppConfigArg> =
     : Config['distribution'] extends AppDistribution.AppStore
     ? AppStoreApp<Config>
     : AppStoreApp<Config>;
-
-export type MandatoryTopics =
-  | 'CUSTOMERS_DATA_REQUEST'
-  | 'CUSTOMERS_REDACT'
-  | 'SHOP_REDACT';


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, Remix apps will need a little bit of boilerplate code to ensure that we're handling the headers for responses we throw in some locations. Since that code depends on code that's internal to the package, we shouldn't put the burden on the app to handle it properly.

### WHAT is this pull request doing?

Exposing a new `boundary` item in the `shopifyApp` object which abstracts that boilerplate into the package.

While adding the new fields in `shopifyApp`, I noticed we weren't getting a squiggly for the unknown field, so I tightened up the types a little bit more.