### PR TITLE
Fixing small issue in the README on npmjs.org

### DIFF
--- a/.changeset/lazy-chefs-hope.md
+++ b/.changeset/lazy-chefs-hope.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fixing small issue in the README

--- a/packages/shopify-app-remix/README.md
+++ b/packages/shopify-app-remix/README.md
@@ -206,11 +206,11 @@ If there is no session for the user, the loader will throw the appropriate redir
 
 If your Remix server is authenticating an admin extension, a request from the extension to Remix will be cross-origin. Here `shopify.authenticate.admin` provides a cors function to add the required cross-origin headers:
 
-````ts
+```ts
 export const loader = async ({request}: LoaderArgs) => {
   const {cors} = await shopify.authenticate.admin(request);
 
-  return cors(json({"my": "data"}));
+  return cors(json({my: 'data'}));
 };
 ```
 
@@ -418,4 +418,3 @@ In Remix apps, you can navigate to a different page either by adding an `<a>` ta
 In Shopify Remix apps you should avoid using `<a>`.
 Use `<Link> `from `@remix-run/react` instead.
 This ensures that your user remains authenticated.
-````


### PR DESCRIPTION
The published version on NPM had a typo in the README that broke formatting, this PR sets up a release to fix it.