### PR TITLE
Fix non embedded check

### DIFF
--- a/.changeset/unlucky-jobs-hunt.md
+++ b/.changeset/unlucky-jobs-hunt.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fixing issue when authenticating requests without a `shop` search param to non-embedded apps.

--- a/packages/shopify-app-remix/src/auth/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/auth/admin/authenticate.ts
@@ -260,10 +260,7 @@ export class AuthStrategy<
 
     const offlineId = shop
       ? api.session.getOfflineId(shop)
-      : await api.session.getCurrentId({
-          isOnline: config.useOnlineTokens,
-          rawRequest: request,
-        });
+      : await api.session.getCurrentId({isOnline: false, rawRequest: request});
 
     if (!offlineId) {
       logger.info("Could not find a shop, can't authenticate request");
@@ -276,21 +273,13 @@ export class AuthStrategy<
     const offlineSession = await config.sessionStorage.loadSession(offlineId);
 
     if (!offlineSession) {
-      if (!shop) {
-        logger.info("Could not find a shop, can't authenticate request");
-        throw new Response(undefined, {
-          status: 400,
-          statusText: 'Bad Request',
-        });
-      }
-
       logger.info("Shop hasn't installed app yet, redirecting to OAuth", {
         shop,
       });
       if (isEmbedded) {
-        redirectWithExitIframe({api, config, logger}, request, shop);
+        redirectWithExitIframe({api, config, logger}, request, shop!);
       } else {
-        throw await beginAuth({api, config, logger}, request, false, shop);
+        throw await beginAuth({api, config, logger}, request, false, shop!);
       }
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

For non-embedded apps, we should never expect a `shop` search param, aside from the OAuth callback. We should always be able to fetch the shop from the cookies instead.

### WHAT is this pull request doing?

Ensuring those requests are properly handled.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
