### PR TITLE
Re-export the ApiVersion type from the API library

### DIFF
--- a/.changeset/mighty-spoons-buy.md
+++ b/.changeset/mighty-spoons-buy.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Re-export ApiVersion object from shopify-api

--- a/packages/shopify-app-remix/src/__tests__/index.test.ts
+++ b/packages/shopify-app-remix/src/__tests__/index.test.ts
@@ -8,6 +8,7 @@ import {
   DeliveryMethod,
   BillingInterval,
   AppDistribution,
+  ApiVersion,
 } from '../index';
 import {AppConfigArg} from '../config-types';
 
@@ -96,7 +97,13 @@ describe('shopifyApp', () => {
 
   it('properly re-exports required @shopify/shopify-api imports', () => {
     // This test doesn't actually test anything, but it's here to make sure that we're actually importing the values
-    [APP_LATEST_API_VERSION, LogSeverity, DeliveryMethod, BillingInterval];
+    [
+      APP_LATEST_API_VERSION,
+      LogSeverity,
+      DeliveryMethod,
+      BillingInterval,
+      ApiVersion,
+    ];
   });
 
   it('fails if no session storage is given', () => {

--- a/packages/shopify-app-remix/src/index.ts
+++ b/packages/shopify-app-remix/src/index.ts
@@ -41,6 +41,7 @@ export {
   LogSeverity,
   DeliveryMethod,
   BillingInterval,
+  ApiVersion,
 } from '@shopify/shopify-api';
 
 setAbstractRuntimeString(() => {


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, we don't export the `ApiVersion` type from the library out of the remix package, which makes it harder for apps to use versions other than the latest, since they'd need to know the field is defined in the `@shopify/shopify-api` package.

### WHAT is this pull request doing?

Re-exporting the type to make it easier for apps to use different versions.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
