### PR TITLE
Remix redirect helper

### DIFF
--- a/.changeset/odd-clouds-thank.md
+++ b/.changeset/odd-clouds-thank.md
@@ -2,7 +2,7 @@
 '@shopify/shopify-app-remix': minor
 ---
 
-Adding a new `redirect` helper to the AdminContext type, which will be able to redirect to the given URL regardless of where an embedded app request is being served.
+Adding a new `redirect` helper to the `EmbeddedAdminContext` type, which will be able to redirect to the given URL regardless of where an embedded app request is being served.
 
 You can also use it to redirect to an external page out of the Shopify Admin by using the `target` option.
 

--- a/.changeset/odd-clouds-thank.md
+++ b/.changeset/odd-clouds-thank.md
@@ -2,4 +2,14 @@
 '@shopify/shopify-app-remix': minor
 ---
 
-Adding a new `redirect` helper to the AdminContext type, which will be able to redirect to the given URL regardless of where an embedded app request is being served
+Adding a new `redirect` helper to the AdminContext type, which will be able to redirect to the given URL regardless of where an embedded app request is being served.
+
+You can also use it to redirect to an external page out of the Shopify Admin by using the `target` option.
+
+```ts
+export const loader = async ({request}) => {
+  const {redirect} = await authenticate.admin(request);
+
+  return redirect('https://www.example.com', {target: '_top'});
+};
+```

--- a/.changeset/odd-clouds-thank.md
+++ b/.changeset/odd-clouds-thank.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Adding a new `redirect` helper to the AdminContext type, which will be able to redirect to the given URL regardless of where an embedded app request is being served

--- a/package.json
+++ b/package.json
@@ -22,12 +22,12 @@
     "@shopify/prettier-config": "^1.1.2",
     "@shopify/typescript-configs": "^5.1.0",
     "eslint": "^8.40.0",
-    "rimraf": "^5.0.0",
-    "typescript": "^4.9.5",
     "jest": "^29.1.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-runner-eslint": "^2.0.0",
-    "ts-jest": "^29.1.0"
+    "rimraf": "^5.0.0",
+    "ts-jest": "^29.1.0",
+    "typescript": "^4.9.5"
   },
   "dependencies": {},
   "workspaces": [

--- a/packages/shopify-app-remix/loom.config.ts
+++ b/packages/shopify-app-remix/loom.config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 
 import {createPackage} from '@shopify/loom';
-import {buildLibrary} from '@shopify/loom-plugin-build-library';
+import {babel, buildLibrary} from '@shopify/loom-plugin-build-library';
 
 export default createPackage((pkg) => {
   pkg.entry({root: './src/server/index.ts'});
@@ -33,6 +33,25 @@ export default createPackage((pkg) => {
       rootEntrypoints: false,
       // Optional. Defaults to 'node'. Defines if the jest environment should be 'node' or 'jsdom'.
       jestTestEnvironment: 'node',
+    }),
+    babel({
+      config(babelConfig) {
+        const presets = babelConfig.presets!;
+        const babelPresetIndex = presets.findIndex((preset) =>
+          String(preset[0]).includes('@shopify/babel-preset'),
+        );
+        const existingConfig = presets[babelPresetIndex][1];
+        presets[babelPresetIndex][1] = {
+          ...existingConfig,
+          reactOptions: {
+            ...existingConfig.reactOptions,
+            // This is required to support React 17
+            runtime: 'automatic',
+          },
+        };
+
+        return babelConfig;
+      },
     }),
   );
 });

--- a/packages/shopify-app-remix/package.json
+++ b/packages/shopify-app-remix/package.json
@@ -49,10 +49,12 @@
     "@shopify/shopify-app-session-storage-memory": "^1.0.10",
     "@types/jest": "^29.5.1",
     "@types/jsonwebtoken": "^9.0.2",
+    "@types/react": "^18.2.18",
     "@types/semver": "^7.3.13",
     "jest": "^29.5.0",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.0",
+    "react": "^18.2.0",
     "ts-jest": "^29.1.0"
   },
   "dependencies": {
@@ -62,6 +64,10 @@
     "isbot": "^3.6.5",
     "semver": "^7.5.0",
     "tslib": "^2.5.0"
+  },
+  "peerDependencies": {
+    "@remix-run/react": "*",
+    "react": "*"
   },
   "files": [
     "build/*",

--- a/packages/shopify-app-remix/src/server/__tests__/setup-jest.ts
+++ b/packages/shopify-app-remix/src/server/__tests__/setup-jest.ts
@@ -1,8 +1,0 @@
-import fetchMock from 'jest-fetch-mock';
-
-// Globally disable fetch requests so we don't risk making real ones
-fetchMock.enableMocks();
-
-beforeEach(() => {
-  fetchMock.mockReset();
-});

--- a/packages/shopify-app-remix/src/server/auth/admin/__tests__/exit-i-frame-path.test.ts
+++ b/packages/shopify-app-remix/src/server/auth/admin/__tests__/exit-i-frame-path.test.ts
@@ -32,7 +32,7 @@ describe('authorize.admin exit iframe path', () => {
       `<script data-api-key="${config.apiKey}" src="${APP_BRIDGE_URL}"></script>`,
     );
     expect(responseText).toContain(
-      `<script>window.open("${decodeURIComponent(exitTo)}", "_top")</script>`,
+      `<script>window.open("${decodeURIComponent(exitTo)}/", "_top")</script>`,
     );
     expectDocumentRequestHeaders(response);
   });
@@ -61,7 +61,7 @@ describe('authorize.admin exit iframe path', () => {
       `<script data-api-key="${config.apiKey}" src="${APP_BRIDGE_URL}"></script>`,
     );
     expect(responseText).toContain(
-      `<script>window.open("${decodeURIComponent(exitTo)}", "_top")</script>`,
+      `<script>window.open("${decodeURIComponent(exitTo)}/", "_top")</script>`,
     );
     expectDocumentRequestHeaders(response);
   });

--- a/packages/shopify-app-remix/src/server/auth/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/auth/admin/authenticate.ts
@@ -93,13 +93,13 @@ export class AuthStrategy<
       billing: this.createBillingContext(request, sessionContext.session),
       session: sessionContext.session,
       cors,
-      redirect: redirectFactory({api, config, logger}, request),
     };
 
     if (config.isEmbeddedApp) {
       return {
         ...context,
         sessionToken: sessionContext!.token!,
+        redirect: redirectFactory({api, config, logger}, request),
       } as AdminContext<Config, Resources>;
     } else {
       return context as AdminContext<Config, Resources>;
@@ -167,12 +167,7 @@ export class AuthStrategy<
       request.headers.get('Sec-Fetch-Dest') === 'iframe'
     ) {
       logger.debug('Auth request in iframe detected, exiting iframe', {shop});
-      throw redirectWithExitIframe(
-        {api, config, logger},
-        request,
-        config.auth.path,
-        shop,
-      );
+      throw redirectWithExitIframe({api, config, logger}, request, shop);
     } else {
       throw await beginAuth({api, config, logger}, request, false, shop);
     }
@@ -284,12 +279,7 @@ export class AuthStrategy<
         shop,
       });
       if (isEmbedded) {
-        redirectWithExitIframe(
-          {api, config, logger},
-          request,
-          config.auth.path,
-          shop!,
-        );
+        redirectWithExitIframe({api, config, logger}, request, shop!);
       } else {
         throw await beginAuth({api, config, logger}, request, false, shop!);
       }

--- a/packages/shopify-app-remix/src/server/auth/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/auth/admin/authenticate.ts
@@ -24,8 +24,6 @@ import {
   requireBillingFactory,
 } from '../../billing';
 import {
-  appBridgeUrl,
-  addDocumentResponseHeaders,
   beginAuth,
   getSessionTokenHeader,
   redirectWithExitIframe,
@@ -34,6 +32,8 @@ import {
   rejectBotRequest,
   respondToOptionsRequest,
   ensureCORSHeadersFactory,
+  renderAppBridge,
+  redirectFactory,
 } from '../helpers';
 
 import type {
@@ -93,6 +93,7 @@ export class AuthStrategy<
       billing: this.createBillingContext(request, sessionContext.session),
       session: sessionContext.session,
       cors,
+      redirect: redirectFactory({api, config, logger}, request),
     };
 
     if (config.isEmbeddedApp) {
@@ -109,6 +110,7 @@ export class AuthStrategy<
     request: Request,
   ): Promise<SessionContext> {
     const {api, logger, config} = this;
+    const params: BasicParams = {api, logger, config};
 
     const url = new URL(request.url);
 
@@ -123,12 +125,12 @@ export class AuthStrategy<
 
     if (isPatchSessionToken) {
       logger.debug('Rendering bounce page');
-      throw this.renderAppBridge(request);
+      throw renderAppBridge(params, request);
     } else if (isExitIframe) {
       const destination = url.searchParams.get('exitIframe')!;
 
       logger.debug('Rendering exit iframe page', {destination});
-      throw this.renderAppBridge(request, destination);
+      throw renderAppBridge(params, request, {url: destination});
     } else if (isAuthCallbackRequest) {
       throw await this.handleAuthCallbackRequest(request);
     } else if (isAuthRequest) {
@@ -165,7 +167,12 @@ export class AuthStrategy<
       request.headers.get('Sec-Fetch-Dest') === 'iframe'
     ) {
       logger.debug('Auth request in iframe detected, exiting iframe', {shop});
-      throw redirectWithExitIframe({api, config, logger}, request, shop);
+      throw redirectWithExitIframe(
+        {api, config, logger},
+        request,
+        config.auth.path,
+        shop,
+      );
     } else {
       throw await beginAuth({api, config, logger}, request, false, shop);
     }
@@ -277,7 +284,12 @@ export class AuthStrategy<
         shop,
       });
       if (isEmbedded) {
-        redirectWithExitIframe({api, config, logger}, request, shop!);
+        redirectWithExitIframe(
+          {api, config, logger},
+          request,
+          config.auth.path,
+          shop!,
+        );
       } else {
         throw await beginAuth({api, config, logger}, request, false, shop!);
       }
@@ -507,40 +519,6 @@ export class AuthStrategy<
     // TODO Make sure this works on chrome without a tunnel (weird HTTPS redirect issue)
     // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28376650
     throw redirect(`${config.auth.patchSessionTokenPath}?${params.toString()}`);
-  }
-
-  private renderAppBridge(request: Request, redirectTo?: string): never {
-    const {config} = this;
-
-    let redirectToScript = '';
-    if (redirectTo) {
-      const redirectUrl = decodeURIComponent(
-        redirectTo.startsWith('/')
-          ? `${config.appUrl}${redirectTo}`
-          : redirectTo,
-      );
-
-      redirectToScript = `<script>window.open("${redirectUrl}", "_top")</script>`;
-    }
-
-    const responseHeaders = new Headers({
-      'content-type': 'text/html;charset=utf-8',
-    });
-    addDocumentResponseHeaders(
-      responseHeaders,
-      config.isEmbeddedApp,
-      new URL(request.url).searchParams.get('shop'),
-    );
-
-    throw new Response(
-      `
-        <script data-api-key="${
-          config.apiKey
-        }" src="${appBridgeUrl()}"></script>
-        ${redirectToScript}
-      `,
-      {headers: responseHeaders},
-    );
   }
 
   private overriddenRestClient(request: Request, session: Session) {

--- a/packages/shopify-app-remix/src/server/auth/admin/types.ts
+++ b/packages/shopify-app-remix/src/server/auth/admin/types.ts
@@ -86,26 +86,6 @@ interface AdminContextInternal<
    * ```
    */
   cors: EnsureCORSFunction;
-
-  /**
-   * A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded
-   * apps
-   *
-   * @example
-   * Redirecting the user to the app's home page
-   * ```ts
-   * // app/routes/admin/widgets.ts
-   * import { LoaderArgs, json } from "@remix-run/node";
-   * import { authenticate } from "../shopify.server";
-   * import { getWidgets } from "~/db/widgets.server";
-   *
-   * export const loader = async ({ request }: LoaderArgs) => {
-   *   const { session, redirect } = await authenticate.admin(request);
-   *   return redirect("/");
-   * };
-   * ```
-   */
-  redirect: RedirectFunction;
 }
 
 export interface EmbeddedAdminContext<
@@ -144,6 +124,26 @@ export interface EmbeddedAdminContext<
    * ```
    */
   sessionToken: JwtPayload;
+
+  /**
+   * A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded
+   * apps
+   *
+   * @example
+   * Redirecting the user to the app's home page
+   * ```ts
+   * // app/routes/admin/widgets.ts
+   * import { LoaderArgs, json } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   * import { getWidgets } from "~/db/widgets.server";
+   *
+   * export const loader = async ({ request }: LoaderArgs) => {
+   *   const { session, redirect } = await authenticate.admin(request);
+   *   return redirect("/");
+   * };
+   * ```
+   */
+  redirect: RedirectFunction;
 }
 export interface NonEmbeddedAdminContext<
   Config extends AppConfigArg,

--- a/packages/shopify-app-remix/src/server/auth/admin/types.ts
+++ b/packages/shopify-app-remix/src/server/auth/admin/types.ts
@@ -3,6 +3,7 @@ import {JwtPayload, Session, ShopifyRestResources} from '@shopify/shopify-api';
 import type {AdminApiContext, AppConfigArg} from '../../config-types';
 import type {BillingContext} from '../../billing/types';
 import {EnsureCORSFunction} from '../helpers/ensure-cors-headers';
+import {RedirectFunction} from '../helpers/redirect';
 
 interface AdminContextInternal<
   Config extends AppConfigArg,
@@ -85,6 +86,26 @@ interface AdminContextInternal<
    * ```
    */
   cors: EnsureCORSFunction;
+
+  /**
+   * A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded
+   * apps
+   *
+   * @example
+   * Redirecting the user to the app's home page
+   * ```ts
+   * // app/routes/admin/widgets.ts
+   * import { LoaderArgs, json } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   * import { getWidgets } from "~/db/widgets.server";
+   *
+   * export const loader = async ({ request }: LoaderArgs) => {
+   *   const { session, redirect } = await authenticate.admin(request);
+   *   return redirect("/");
+   * };
+   * ```
+   */
+  redirect: RedirectFunction;
 }
 
 export interface EmbeddedAdminContext<

--- a/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
@@ -1,0 +1,338 @@
+import {SESSION_COOKIE_NAME} from '@shopify/shopify-api';
+
+import {shopifyApp} from '../../..';
+import {
+  API_KEY,
+  APP_URL,
+  BASE64_HOST,
+  TEST_SHOP,
+  getJwt,
+  getThrownResponse,
+  setUpValidSession,
+  signRequestCookie,
+  testConfig,
+} from '../../../__tests__/test-helper';
+import {APP_BRIDGE_URL, REAUTH_URL_HEADER} from '../../const';
+
+describe('Redirect helper', () => {
+  describe('when embedded', () => {
+    describe("passes request search params to redirect, but doesn't override them", () => {
+      it('when URL is a relative path', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = documentLoadRequest(true);
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = redirect('/?shop=override');
+
+        // THEN
+        searchParams.set('shop', 'override');
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(
+          `${APP_URL}/?${searchParams}`,
+        );
+      });
+
+      it('when URL is absolute', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = documentLoadRequest(true);
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = redirect(`${APP_URL}/test?shop=override`, {
+          status: 304,
+        });
+
+        // THEN
+        searchParams.set('shop', 'override');
+        expect(response.status).toBe(304);
+        expect(response.headers.get('location')).toBe(
+          `${APP_URL}/test?${searchParams}`,
+        );
+      });
+    });
+
+    it('does not alter external URLs', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request} = documentLoadRequest(true);
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = redirect('https://www.example.local?test');
+
+      // THEN
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(
+        'https://www.example.local/?test',
+      );
+    });
+
+    describe('and the target is _self', () => {
+      it('returns a 302 on embedded document loads', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = documentLoadRequest(true);
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = redirect('/');
+
+        // THEN
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(
+          `${APP_URL}/?${searchParams}`,
+        );
+      });
+
+      it('returns an app bridge script on bounce requests', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = bounceRequest();
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = await getThrownResponse(
+          async () => redirect('/'),
+          request,
+        );
+
+        // THEN
+        await assertAppBridgeScript(
+          response,
+          `${APP_URL}/?${searchParams}`,
+          '_self',
+        );
+      });
+
+      it("uses Remix's default behaviour for GET data requests", async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request} = remixDataLoadRequest('GET');
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = redirect('/');
+
+        // THEN
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(`${APP_URL}/`);
+      });
+
+      it("uses Remix's default behaviour for POST data requests", async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request} = remixDataLoadRequest('POST');
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = redirect('/');
+
+        // THEN
+        expect(response.status).toBe(302);
+        expect(response.headers.get('location')).toBe(`${APP_URL}/`);
+      });
+    });
+
+    describe('and the target is _parent', () => {
+      it('returns an app bridge redirect on embedded document loads', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = documentLoadRequest(true);
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = await getThrownResponse(
+          async () => redirect('/', {target: '_parent'}),
+          request,
+        );
+
+        // THEN
+        await assertAppBridgeScript(
+          response,
+          `${APP_URL}/?${searchParams}`,
+          '_parent',
+        );
+      });
+
+      it('returns an app bridge script on bounce requests', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request, searchParams} = bounceRequest();
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = await getThrownResponse(
+          async () => redirect('/', {target: '_parent'}),
+          request,
+        );
+
+        // THEN
+        await assertAppBridgeScript(
+          response,
+          `${APP_URL}/?${searchParams}`,
+          '_parent',
+        );
+      });
+
+      it('returns AB redirection headers for GET data requests', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request} = remixDataLoadRequest('GET');
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = await getThrownResponse(
+          async () => redirect('/', {target: '_parent'}),
+          request,
+        );
+
+        // THEN
+        await assertAppBridgeHeaders(response, `${APP_URL}/`);
+      });
+
+      it('returns AB redirection headers for POST data requests', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig());
+        await setUpValidSession(shopify.sessionStorage);
+
+        const {request} = remixDataLoadRequest('POST');
+        const {redirect} = await shopify.authenticate.admin(request);
+
+        // WHEN
+        const response = await getThrownResponse(
+          async () => redirect('/', {target: '_parent'}),
+          request,
+        );
+
+        // THEN
+        await assertAppBridgeHeaders(response, `${APP_URL}/`);
+      });
+    });
+
+    function documentLoadRequest(embedded: boolean) {
+      const {token} = getJwt();
+      const searchParams = new URLSearchParams({
+        shop: TEST_SHOP,
+        embedded: embedded ? '1' : '0',
+        host: BASE64_HOST,
+        id_token: token,
+      });
+
+      return {request: new Request(`${APP_URL}?${searchParams}`), searchParams};
+    }
+
+    function bounceRequest() {
+      const {token} = getJwt();
+      const searchParams = new URLSearchParams({
+        shop: TEST_SHOP,
+        embedded: '1',
+        host: BASE64_HOST,
+      });
+
+      return {
+        request: new Request(`${APP_URL}?${searchParams}`, {
+          headers: {Authorization: `Bearer ${token}`},
+        }),
+        searchParams,
+      };
+    }
+
+    function remixDataLoadRequest(method: string) {
+      const {token} = getJwt();
+
+      return {
+        request: new Request(APP_URL, {
+          headers: {Authorization: `Bearer ${token}`},
+          method,
+        }),
+      };
+    }
+
+    async function assertAppBridgeScript(
+      response: Response,
+      url: string,
+      target: string,
+    ) {
+      const body = await response.text();
+      expect(response.status).toBe(200);
+      expect(body).toContain(
+        `<script data-api-key="${API_KEY}" src="${APP_BRIDGE_URL}"></script>`,
+      );
+      expect(body).toContain(
+        `<script>window.open("${url}", "${target}")</script>`,
+      );
+    }
+
+    async function assertAppBridgeHeaders(response: Response, url: string) {
+      expect(response.status).toBe(401);
+      expect(response.headers.get(REAUTH_URL_HEADER)).toBe(url);
+    }
+  });
+
+  describe('does not alter the URL when not embedded', () => {
+    it('with a status code init param', async () => {
+      // GIVEN
+      const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+      const testSession = await setUpValidSession(shopify.sessionStorage);
+
+      const request = new Request(APP_URL);
+      signRequestCookie({
+        request,
+        cookieName: SESSION_COOKIE_NAME,
+        cookieValue: testSession.id,
+      });
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = redirect('/');
+
+      // THEN
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe('/');
+    });
+
+    it('with an object init param', async () => {
+      // GIVEN
+      const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+      const testSession = await setUpValidSession(shopify.sessionStorage);
+
+      const request = new Request(APP_URL);
+      signRequestCookie({
+        request,
+        cookieName: SESSION_COOKIE_NAME,
+        cookieValue: testSession.id,
+      });
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = redirect('/', {status: 304});
+
+      // THEN
+      expect(response.status).toBe(304);
+      expect(response.headers.get('location')).toBe('/');
+    });
+  });
+});

--- a/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
@@ -253,7 +253,7 @@ describe('Redirect helper', () => {
 
     return {
       request: new Request(`${APP_URL}?${searchParams}`, {
-        headers: {Authorization: `Bearer ${token}`},
+        headers: {Authorization: `Bearer ${token}`, 'X-Shopify-Bounce': '1'},
       }),
       searchParams,
     };

--- a/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/__tests__/redirect.test.ts
@@ -15,295 +15,73 @@ import {
 import {APP_BRIDGE_URL, REAUTH_URL_HEADER} from '../../const';
 
 describe('Redirect helper', () => {
-  describe('when embedded', () => {
-    describe("passes request search params to redirect, but doesn't override them", () => {
-      it('when URL is a relative path', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request, searchParams} = documentLoadRequest(true);
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = redirect('/?shop=override');
-
-        // THEN
-        searchParams.set('shop', 'override');
-        expect(response.status).toBe(302);
-        expect(response.headers.get('location')).toBe(
-          `${APP_URL}/?${searchParams}`,
-        );
-      });
-
-      it('when URL is absolute', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request, searchParams} = documentLoadRequest(true);
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = redirect(`${APP_URL}/test?shop=override`, {
-          status: 304,
-        });
-
-        // THEN
-        searchParams.set('shop', 'override');
-        expect(response.status).toBe(304);
-        expect(response.headers.get('location')).toBe(
-          `${APP_URL}/test?${searchParams}`,
-        );
-      });
-    });
-
-    it('does not alter external URLs', async () => {
+  describe("passes request search params to redirect, but doesn't override them", () => {
+    it('when URL is a relative path', async () => {
       // GIVEN
       const shopify = shopifyApp(testConfig());
       await setUpValidSession(shopify.sessionStorage);
 
-      const {request} = documentLoadRequest(true);
+      const {request, searchParams} = documentLoadRequest(true);
       const {redirect} = await shopify.authenticate.admin(request);
 
       // WHEN
-      const response = redirect('https://www.example.local?test');
+      const response = redirect('/?shop=override');
 
       // THEN
+      searchParams.set('shop', 'override');
       expect(response.status).toBe(302);
       expect(response.headers.get('location')).toBe(
-        'https://www.example.local/?test',
+        `${APP_URL}/?${searchParams}`,
       );
     });
 
-    describe('and the target is _self', () => {
-      it('returns a 302 on embedded document loads', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
+    it('when URL is absolute', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
 
-        const {request, searchParams} = documentLoadRequest(true);
-        const {redirect} = await shopify.authenticate.admin(request);
+      const {request, searchParams} = documentLoadRequest(true);
+      const {redirect} = await shopify.authenticate.admin(request);
 
-        // WHEN
-        const response = redirect('/');
-
-        // THEN
-        expect(response.status).toBe(302);
-        expect(response.headers.get('location')).toBe(
-          `${APP_URL}/?${searchParams}`,
-        );
+      // WHEN
+      const response = redirect(`${APP_URL}/test?shop=override`, {
+        status: 304,
       });
 
-      it('returns an app bridge script on bounce requests', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request, searchParams} = bounceRequest();
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = await getThrownResponse(
-          async () => redirect('/'),
-          request,
-        );
-
-        // THEN
-        await assertAppBridgeScript(
-          response,
-          `${APP_URL}/?${searchParams}`,
-          '_self',
-        );
-      });
-
-      it("uses Remix's default behaviour for GET data requests", async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request} = remixDataLoadRequest('GET');
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = redirect('/');
-
-        // THEN
-        expect(response.status).toBe(302);
-        expect(response.headers.get('location')).toBe(`${APP_URL}/`);
-      });
-
-      it("uses Remix's default behaviour for POST data requests", async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request} = remixDataLoadRequest('POST');
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = redirect('/');
-
-        // THEN
-        expect(response.status).toBe(302);
-        expect(response.headers.get('location')).toBe(`${APP_URL}/`);
-      });
-    });
-
-    describe('and the target is _parent', () => {
-      it('returns an app bridge redirect on embedded document loads', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request, searchParams} = documentLoadRequest(true);
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = await getThrownResponse(
-          async () => redirect('/', {target: '_parent'}),
-          request,
-        );
-
-        // THEN
-        await assertAppBridgeScript(
-          response,
-          `${APP_URL}/?${searchParams}`,
-          '_parent',
-        );
-      });
-
-      it('returns an app bridge script on bounce requests', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request, searchParams} = bounceRequest();
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = await getThrownResponse(
-          async () => redirect('/', {target: '_parent'}),
-          request,
-        );
-
-        // THEN
-        await assertAppBridgeScript(
-          response,
-          `${APP_URL}/?${searchParams}`,
-          '_parent',
-        );
-      });
-
-      it('returns AB redirection headers for GET data requests', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request} = remixDataLoadRequest('GET');
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = await getThrownResponse(
-          async () => redirect('/', {target: '_parent'}),
-          request,
-        );
-
-        // THEN
-        await assertAppBridgeHeaders(response, `${APP_URL}/`);
-      });
-
-      it('returns AB redirection headers for POST data requests', async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig());
-        await setUpValidSession(shopify.sessionStorage);
-
-        const {request} = remixDataLoadRequest('POST');
-        const {redirect} = await shopify.authenticate.admin(request);
-
-        // WHEN
-        const response = await getThrownResponse(
-          async () => redirect('/', {target: '_parent'}),
-          request,
-        );
-
-        // THEN
-        await assertAppBridgeHeaders(response, `${APP_URL}/`);
-      });
-    });
-
-    function documentLoadRequest(embedded: boolean) {
-      const {token} = getJwt();
-      const searchParams = new URLSearchParams({
-        shop: TEST_SHOP,
-        embedded: embedded ? '1' : '0',
-        host: BASE64_HOST,
-        id_token: token,
-      });
-
-      return {request: new Request(`${APP_URL}?${searchParams}`), searchParams};
-    }
-
-    function bounceRequest() {
-      const {token} = getJwt();
-      const searchParams = new URLSearchParams({
-        shop: TEST_SHOP,
-        embedded: '1',
-        host: BASE64_HOST,
-      });
-
-      return {
-        request: new Request(`${APP_URL}?${searchParams}`, {
-          headers: {Authorization: `Bearer ${token}`},
-        }),
-        searchParams,
-      };
-    }
-
-    function remixDataLoadRequest(method: string) {
-      const {token} = getJwt();
-
-      return {
-        request: new Request(APP_URL, {
-          headers: {Authorization: `Bearer ${token}`},
-          method,
-        }),
-      };
-    }
-
-    async function assertAppBridgeScript(
-      response: Response,
-      url: string,
-      target: string,
-    ) {
-      const body = await response.text();
-      expect(response.status).toBe(200);
-      expect(body).toContain(
-        `<script data-api-key="${API_KEY}" src="${APP_BRIDGE_URL}"></script>`,
+      // THEN
+      searchParams.set('shop', 'override');
+      expect(response.status).toBe(304);
+      expect(response.headers.get('location')).toBe(
+        `${APP_URL}/test?${searchParams}`,
       );
-      expect(body).toContain(
-        `<script>window.open("${url}", "${target}")</script>`,
-      );
-    }
-
-    async function assertAppBridgeHeaders(response: Response, url: string) {
-      expect(response.status).toBe(401);
-      expect(response.headers.get(REAUTH_URL_HEADER)).toBe(url);
-    }
+    });
   });
 
-  describe('does not alter the URL when not embedded', () => {
-    it('with a status code init param', async () => {
-      // GIVEN
-      const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
-      const testSession = await setUpValidSession(shopify.sessionStorage);
+  it('does not alter external URLs', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    await setUpValidSession(shopify.sessionStorage);
 
-      const request = new Request(APP_URL);
-      signRequestCookie({
-        request,
-        cookieName: SESSION_COOKIE_NAME,
-        cookieValue: testSession.id,
-      });
+    const {request} = documentLoadRequest(true);
+    const {redirect} = await shopify.authenticate.admin(request);
+
+    // WHEN
+    const response = redirect('https://www.example.local?test');
+
+    // THEN
+    expect(response.status).toBe(302);
+    expect(response.headers.get('location')).toBe(
+      'https://www.example.local/?test',
+    );
+  });
+
+  describe('and the target is _self', () => {
+    it('returns a 302 on embedded document loads', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request, searchParams} = documentLoadRequest(true);
       const {redirect} = await shopify.authenticate.admin(request);
 
       // WHEN
@@ -311,10 +89,209 @@ describe('Redirect helper', () => {
 
       // THEN
       expect(response.status).toBe(302);
-      expect(response.headers.get('location')).toBe('/');
+      expect(response.headers.get('location')).toBe(
+        `${APP_URL}/?${searchParams}`,
+      );
     });
 
-    it('with an object init param', async () => {
+    it('returns an app bridge script on bounce requests', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request, searchParams} = bounceRequest();
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = await getThrownResponse(
+        async () => redirect('/'),
+        request,
+      );
+
+      // THEN
+      await assertAppBridgeScript(
+        response,
+        `${APP_URL}/?${searchParams}`,
+        '_self',
+      );
+    });
+
+    it("uses Remix's default behaviour for GET data requests", async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request} = remixDataLoadRequest('GET');
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = redirect('/');
+
+      // THEN
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(`${APP_URL}/`);
+    });
+
+    it("uses Remix's default behaviour for POST data requests", async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request} = remixDataLoadRequest('POST');
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = redirect('/');
+
+      // THEN
+      expect(response.status).toBe(302);
+      expect(response.headers.get('location')).toBe(`${APP_URL}/`);
+    });
+  });
+
+  describe('and the target is _parent', () => {
+    it('returns an app bridge redirect on embedded document loads', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request, searchParams} = documentLoadRequest(true);
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = await getThrownResponse(
+        async () => redirect('/', {target: '_parent'}),
+        request,
+      );
+
+      // THEN
+      await assertAppBridgeScript(
+        response,
+        `${APP_URL}/?${searchParams}`,
+        '_parent',
+      );
+    });
+
+    it('returns an app bridge script on bounce requests', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request, searchParams} = bounceRequest();
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = await getThrownResponse(
+        async () => redirect('/', {target: '_parent'}),
+        request,
+      );
+
+      // THEN
+      await assertAppBridgeScript(
+        response,
+        `${APP_URL}/?${searchParams}`,
+        '_parent',
+      );
+    });
+
+    it('returns AB redirection headers for GET data requests', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request} = remixDataLoadRequest('GET');
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = await getThrownResponse(
+        async () => redirect('/', {target: '_parent'}),
+        request,
+      );
+
+      // THEN
+      await assertAppBridgeHeaders(response, `${APP_URL}/`);
+    });
+
+    it('returns AB redirection headers for POST data requests', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      const {request} = remixDataLoadRequest('POST');
+      const {redirect} = await shopify.authenticate.admin(request);
+
+      // WHEN
+      const response = await getThrownResponse(
+        async () => redirect('/', {target: '_parent'}),
+        request,
+      );
+
+      // THEN
+      await assertAppBridgeHeaders(response, `${APP_URL}/`);
+    });
+  });
+
+  function documentLoadRequest(embedded: boolean) {
+    const {token} = getJwt();
+    const searchParams = new URLSearchParams({
+      shop: TEST_SHOP,
+      embedded: embedded ? '1' : '0',
+      host: BASE64_HOST,
+      id_token: token,
+    });
+
+    return {request: new Request(`${APP_URL}?${searchParams}`), searchParams};
+  }
+
+  function bounceRequest() {
+    const {token} = getJwt();
+    const searchParams = new URLSearchParams({
+      shop: TEST_SHOP,
+      embedded: '1',
+      host: BASE64_HOST,
+    });
+
+    return {
+      request: new Request(`${APP_URL}?${searchParams}`, {
+        headers: {Authorization: `Bearer ${token}`},
+      }),
+      searchParams,
+    };
+  }
+
+  function remixDataLoadRequest(method: string) {
+    const {token} = getJwt();
+
+    return {
+      request: new Request(APP_URL, {
+        headers: {Authorization: `Bearer ${token}`},
+        method,
+      }),
+    };
+  }
+
+  async function assertAppBridgeScript(
+    response: Response,
+    url: string,
+    target: string,
+  ) {
+    const body = await response.text();
+    expect(response.status).toBe(200);
+    expect(body).toContain(
+      `<script data-api-key="${API_KEY}" src="${APP_BRIDGE_URL}"></script>`,
+    );
+    expect(body).toContain(
+      `<script>window.open("${url}", "${target}")</script>`,
+    );
+  }
+
+  async function assertAppBridgeHeaders(response: Response, url: string) {
+    expect(response.status).toBe(401);
+    expect(response.headers.get(REAUTH_URL_HEADER)).toBe(url);
+  }
+
+  describe('when not embedded', () => {
+    it('is not returned as part of the context', async () => {
       // GIVEN
       const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
       const testSession = await setUpValidSession(shopify.sessionStorage);
@@ -325,14 +302,12 @@ describe('Redirect helper', () => {
         cookieName: SESSION_COOKIE_NAME,
         cookieValue: testSession.id,
       });
-      const {redirect} = await shopify.authenticate.admin(request);
 
       // WHEN
-      const response = redirect('/', {status: 304});
+      const context = await shopify.authenticate.admin(request);
 
       // THEN
-      expect(response.status).toBe(304);
-      expect(response.headers.get('location')).toBe('/');
+      expect(context).not.toHaveProperty('redirect');
     });
   });
 });

--- a/packages/shopify-app-remix/src/server/auth/helpers/index.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/index.ts
@@ -9,3 +9,5 @@ export * from './get-session-token-header';
 export * from './reject-bot-request';
 export * from './respond-to-options-request';
 export * from './handle-client-error';
+export * from './redirect';
+export * from './render-app-bridge';

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect-to-auth-page.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect-to-auth-page.ts
@@ -10,14 +10,18 @@ export async function redirectToAuthPage(
   shop: string,
   isOnline = false,
 ): Promise<never> {
+  const {config} = params;
+
   const url = new URL(request.url);
   const isEmbeddedRequest = url.searchParams.get('embedded') === '1';
   const isXhrRequest = request.headers.get('authorization');
 
   if (isXhrRequest) {
-    redirectWithAppBridgeHeaders(params, shop);
+    const redirectUri = new URL(config.auth.path, config.appUrl);
+    redirectUri.searchParams.set('shop', shop);
+    redirectWithAppBridgeHeaders(redirectUri.toString());
   } else if (isEmbeddedRequest) {
-    redirectWithExitIframe(params, request, shop);
+    redirectWithExitIframe(params, request, config.auth.path, shop);
   } else {
     throw await beginAuth(params, request, isOnline, shop);
   }

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect-to-auth-page.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect-to-auth-page.ts
@@ -21,7 +21,7 @@ export async function redirectToAuthPage(
     redirectUri.searchParams.set('shop', shop);
     redirectWithAppBridgeHeaders(redirectUri.toString());
   } else if (isEmbeddedRequest) {
-    redirectWithExitIframe(params, request, config.auth.path, shop);
+    redirectWithExitIframe(params, request, shop);
   } else {
     throw await beginAuth(params, request, isOnline, shop);
   }

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-app-bridge-headers.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-app-bridge-headers.ts
@@ -1,13 +1,6 @@
-import type {BasicParams} from '../../types';
 import {REAUTH_URL_HEADER} from '../const';
 
-export function redirectWithAppBridgeHeaders(
-  params: BasicParams,
-  shop: string,
-): never {
-  const {config} = params;
-  const redirectUri = `${config.appUrl}${config.auth.path}?shop=${shop}`;
-
+export function redirectWithAppBridgeHeaders(redirectUri: string): never {
   throw new Response(undefined, {
     status: 401,
     statusText: 'Unauthorized',

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-exitiframe.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-exitiframe.ts
@@ -5,6 +5,7 @@ import type {BasicParams} from '../../types';
 export function redirectWithExitIframe(
   params: BasicParams,
   request: Request,
+  redirectPath: string,
   shop: string,
 ): never {
   const {api, config} = params;
@@ -14,7 +15,7 @@ export function redirectWithExitIframe(
   const host = api.utils.sanitizeHost(queryParams.get('host')!);
 
   queryParams.set('shop', shop);
-  queryParams.set('exitIframe', `${config.auth.path}?shop=${shop}`);
+  queryParams.set('exitIframe', `${redirectPath}?shop=${shop}`);
 
   if (host) {
     queryParams.set('host', host);

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-exitiframe.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect-with-exitiframe.ts
@@ -5,7 +5,6 @@ import type {BasicParams} from '../../types';
 export function redirectWithExitIframe(
   params: BasicParams,
   request: Request,
-  redirectPath: string,
   shop: string,
 ): never {
   const {api, config} = params;
@@ -15,7 +14,7 @@ export function redirectWithExitIframe(
   const host = api.utils.sanitizeHost(queryParams.get('host')!);
 
   queryParams.set('shop', shop);
-  queryParams.set('exitIframe', `${redirectPath}?shop=${shop}`);
+  queryParams.set('exitIframe', `${config.auth.path}?shop=${shop}`);
 
   if (host) {
     queryParams.set('host', host);

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect.ts
@@ -59,31 +59,23 @@ export function redirectFactory(
 }
 
 function isBounceRequest(request: Request) {
-  const {searchParams} = new URL(request.url);
-
-  const isGet = request.method === 'GET';
-  const sessionTokenHeader = Boolean(getSessionTokenHeader(request));
-  const sessionTokenSearchParam = searchParams.has('id_token');
-
   return (
-    sessionTokenHeader &&
-    !sessionTokenSearchParam &&
-    isEmbeddedRequest(request) &&
-    isGet
+    Boolean(getSessionTokenHeader(request)) &&
+    request.headers.has('X-Shopify-Bounce')
   );
 }
 
 function isDataRequest(request: Request) {
   const {searchParams} = new URL(request.url);
 
-  const isGet = request.method === 'GET';
   const sessionTokenHeader = Boolean(getSessionTokenHeader(request));
   const sessionTokenSearchParam = searchParams.has('id_token');
 
   return (
     sessionTokenHeader &&
     !sessionTokenSearchParam &&
-    (!isEmbeddedRequest(request) || !isGet)
+    !isBounceRequest(request) &&
+    !isEmbeddedRequest(request)
   );
 }
 

--- a/packages/shopify-app-remix/src/server/auth/helpers/redirect.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/redirect.ts
@@ -1,0 +1,77 @@
+import {
+  TypedResponse,
+  redirect as remixRedirect,
+} from '@remix-run/server-runtime';
+
+import {BasicParams} from '../../types';
+
+import {renderAppBridge} from './render-app-bridge';
+import {getSessionTokenHeader} from './get-session-token-header';
+import {redirectWithAppBridgeHeaders} from './redirect-with-app-bridge-headers';
+
+export type RedirectTarget = '_self' | '_parent' | '_top';
+export type RedirectInit = number | (ResponseInit & {target?: RedirectTarget});
+export type RedirectFunction = (
+  url: string,
+  init?: RedirectInit,
+) => TypedResponse<never>;
+
+export function redirectFactory(
+  params: BasicParams,
+  request: Request,
+): RedirectFunction {
+  const {config} = params;
+
+  return function redirect(url, init: RedirectInit) {
+    if (config.isEmbeddedApp) {
+      const {searchParams} = new URL(request.url);
+      const parsedUrl = new URL(url, config.appUrl);
+      const target = (typeof init !== 'number' && init?.target) || '_self';
+
+      const isGet = request.method === 'GET';
+      const isSameOrigin = parsedUrl.origin === config.appUrl;
+      const sessionTokenHeader = Boolean(getSessionTokenHeader(request));
+      const sessionTokenSearchParam = searchParams.has('id_token');
+      const embeddedSearchParam = searchParams.get('embedded') === '1';
+
+      const isBounceRequest =
+        sessionTokenHeader &&
+        !sessionTokenSearchParam &&
+        embeddedSearchParam &&
+        isGet;
+
+      const isDataRequest =
+        sessionTokenHeader &&
+        !sessionTokenSearchParam &&
+        (!embeddedSearchParam || !isGet);
+
+      if (isSameOrigin || url.startsWith('/')) {
+        searchParams.forEach((value, key) => {
+          if (!parsedUrl.searchParams.has(key)) {
+            parsedUrl.searchParams.set(key, value);
+          }
+        });
+      }
+
+      if (target === '_self') {
+        if (isBounceRequest) {
+          throw renderAppBridge(params, request, {
+            url: parsedUrl.toString(),
+            target,
+          });
+        } else {
+          return remixRedirect(parsedUrl.toString(), init);
+        }
+      } else if (isDataRequest) {
+        throw redirectWithAppBridgeHeaders(parsedUrl.toString());
+      } else if (embeddedSearchParam) {
+        throw renderAppBridge(params, request, {
+          url: parsedUrl.toString(),
+          target,
+        });
+      }
+    }
+
+    return remixRedirect(url, init);
+  };
+}

--- a/packages/shopify-app-remix/src/server/auth/helpers/render-app-bridge.ts
+++ b/packages/shopify-app-remix/src/server/auth/helpers/render-app-bridge.ts
@@ -1,0 +1,43 @@
+import {BasicParams} from '../../types';
+
+import type {RedirectTarget} from './redirect';
+import {appBridgeUrl} from './app-bridge-url';
+import {addDocumentResponseHeaders} from './add-response-headers';
+
+export interface RedirectToOptions {
+  url: string | URL;
+  target?: RedirectTarget;
+}
+
+export function renderAppBridge(
+  {config}: BasicParams,
+  request: Request,
+  redirectTo?: RedirectToOptions,
+): never {
+  let redirectToScript = '';
+  if (redirectTo) {
+    const destination = new URL(redirectTo.url, config.appUrl);
+    const target = redirectTo.target ?? '_top';
+
+    redirectToScript = `<script>window.open(${JSON.stringify(
+      destination.toString(),
+    )}, ${JSON.stringify(target)})</script>`;
+  }
+
+  const responseHeaders = new Headers({
+    'content-type': 'text/html;charset=utf-8',
+  });
+  addDocumentResponseHeaders(
+    responseHeaders,
+    config.isEmbeddedApp,
+    new URL(request.url).searchParams.get('shop'),
+  );
+
+  throw new Response(
+    `
+      <script data-api-key="${config.apiKey}" src="${appBridgeUrl()}"></script>
+      ${redirectToScript}
+    `,
+    {headers: responseHeaders},
+  );
+}

--- a/packages/shopify-app-remix/src/server/boundary/__tests__/error.test.tsx
+++ b/packages/shopify-app-remix/src/server/boundary/__tests__/error.test.tsx
@@ -1,22 +1,19 @@
-import {boundary, shopifyApp} from '../../index';
-import {testConfig} from '../../__tests__/test-helper';
+import React from 'react';
+
+import {boundary} from '../../index';
 
 describe('Error boundary', () => {
   it('returns a string when handling an ErrorResponse', () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
-
     // WHEN
     const result = boundary.error(new ErrorResponse());
 
     // THEN
-    expect(result).toEqual('Handling response');
+    expect(result).toEqual(
+      <div dangerouslySetInnerHTML={{__html: 'Handling response'}} />,
+    );
   });
 
   it('throws an error when handling an unknown error', () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
-
     // WHEN
     const result = () => boundary.error(new Error());
 

--- a/packages/shopify-app-remix/src/server/boundary/error.ts
+++ b/packages/shopify-app-remix/src/server/boundary/error.ts
@@ -1,7 +1,0 @@
-export function errorBoundary(error: any): string | never {
-  if (error.constructor.name === 'ErrorResponse') {
-    return 'Handling response';
-  }
-
-  throw error;
-}

--- a/packages/shopify-app-remix/src/server/boundary/error.tsx
+++ b/packages/shopify-app-remix/src/server/boundary/error.tsx
@@ -1,0 +1,11 @@
+export function errorBoundary(error: any) {
+  if (error.constructor.name === 'ErrorResponse') {
+    return (
+      <div
+        dangerouslySetInnerHTML={{__html: error.data || 'Handling response'}}
+      />
+    );
+  }
+
+  throw error;
+}

--- a/packages/shopify-app-remix/tsconfig.json
+++ b/packages/shopify-app-remix/tsconfig.json
@@ -3,8 +3,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "outDir": "./build/ts",
-    "rootDir": "src"
+    "rootDir": "src",
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/test/*", "**/__tests__/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3362,6 +3362,11 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.2.tgz#6c2324641cc4ba050a8c710b2b251b377581fbf0"
   integrity sha512-KufADq8uQqo1pYKVIYzfKbJfBAc0sOeXqGbFaSpv8MRmC/zXgowNZmFcbngndGk922QDmOASEXUZCaY48gs4cg==
 
+"@types/prop-types@*":
+  version "15.7.5"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
+  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
+
 "@types/qs@*":
   version "6.9.7"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
@@ -3372,12 +3377,26 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/react@^18.2.18":
+  version "18.2.18"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.18.tgz#c8b233919eef1bdc294f6f34b37f9727ad677516"
+  integrity sha512-da4NTSeBv/P34xoZPhtcLkmZuJ+oYaCxHmyHzwaDQo9RQPBeXV+06gEk2FpqEcsX9XrnNLvRpVh6bdavDSjtiQ==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
 "@types/resolve@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.17.1.tgz#3afd6ad8967c77e4376c598a82ddd58f46ec45d6"
   integrity sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
   dependencies:
     "@types/node" "*"
+
+"@types/scheduler@*":
+  version "0.16.3"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.3.tgz#cef09e3ec9af1d63d2a6cc5b383a737e24e6dcf5"
+  integrity sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==
 
 "@types/semver@^6.0.0":
   version "6.2.3"
@@ -4516,6 +4535,11 @@ cssstyle@^2.3.0:
   integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^3.0.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.2.tgz#1d4bf9d572f11c14031f0436e1c10bc1f571f50b"
+  integrity sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==
 
 csv-generate@^3.4.3:
   version "3.4.3"
@@ -7480,7 +7504,7 @@ long@^5.2.1:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
-loose-envify@^1.4.0:
+loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -8649,6 +8673,13 @@ react-is@^18.0.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
+
+react@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
+  integrity sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==
+  dependencies:
+    loose-envify "^1.1.0"
 
 read-pkg-up@^7.0.1:
   version "7.0.1"


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, when redirecting an authenticated request, the app will need to be aware of all of the possible scenarios for embedded apps:
- Document load / SSR request (document)
- Bounce page request (document-loading XHR)
- Remix link navigation request (JSON XHR)

We need to make it easier for apps to navigate to other pages without needing to keep track of this context.

### WHAT is this pull request doing?

Adding a new `redirect` helper that will look something like this:

```ts
export const loader = async ({ request }) => {
  const { session, redirect } = await authenticate.admin(request);

  const url = new URL(request.url);
  if (url.searchParams.get("redirectMe")) {
    return redirect("/app/additional");
  }

  return json({ shop: session.shop.replace(".myshopify.com", "") });
};
```

and be able to tell which scenario it is in to trigger the appropriate redirect response.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
