### PR TITLE
Include session in unauthenticated admin return

### DIFF
--- a/.changeset/chatty-clouds-sparkle.md
+++ b/.changeset/chatty-clouds-sparkle.md
@@ -26,7 +26,7 @@ import shopify from '../../shopify.server';
 
 export async function loader({request}) {
   const shop = await authenticateExternalRequest(request);
-  const {admin} = await shopify.unauthenticated.admin(shop);
+  const {admin, session} = await shopify.unauthenticated.admin(shop);
 
   return json(await admin.rest.resources.Product.count({session}));
 }

--- a/packages/shopify-app-remix/src/server/__tests__/request-mock.ts
+++ b/packages/shopify-app-remix/src/server/__tests__/request-mock.ts
@@ -92,6 +92,9 @@ export async function validateMocks() {
     if (request?.headers) {
       expected.headers = {};
       actual.headers = {};
+
+      // eslint-disable-next-line no-warning-comments
+      // TODO: we're currently not checking the headers properly. We should fix this.
       Object.entries(request.headers).forEach(([key, value]) => {
         expected.headers[key] = value;
         actual.headers[key] = (init?.headers as any)[key];

--- a/packages/shopify-app-remix/src/server/__tests__/shopify-app.test.ts
+++ b/packages/shopify-app-remix/src/server/__tests__/shopify-app.test.ts
@@ -12,10 +12,7 @@ import {
 } from '../index';
 import {AppConfigArg} from '../config-types';
 
-import {TEST_SHOP, setUpValidSession, testConfig} from './test-helper';
-import {mockExternalRequest} from './request-mock';
-
-const REQUEST_URL = `https://${TEST_SHOP}/admin/api/${shopifyApiPackage.LATEST_API_VERSION}/customers.json`;
+import {testConfig} from './test-helper';
 
 describe('shopifyApp', () => {
   /* eslint-disable no-process-env */
@@ -118,111 +115,5 @@ describe('shopifyApp', () => {
 
     // THEN
     expect(() => shopifyApp(config)).toThrowError(ShopifyError);
-  });
-
-  describe('unauthenticated admin context', () => {
-    it('REST client can perform GET requests', async () => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      await setUpValidSession(shopify.sessionStorage, false);
-      const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
-
-      await mockExternalRequest({
-        request: new Request(REQUEST_URL),
-        response: new Response(JSON.stringify({customers: []})),
-      });
-
-      // WHEN
-      const response = await admin.rest.get({path: 'customers'});
-
-      // THEN
-      expect(response.status).toEqual(200);
-      expect(await response.json()).toEqual({customers: []});
-    });
-
-    it('REST client can perform POST requests', async () => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      await setUpValidSession(shopify.sessionStorage, false);
-      const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
-
-      await mockExternalRequest({
-        request: new Request(REQUEST_URL, {method: 'POST'}),
-        response: new Response(JSON.stringify({customers: []})),
-      });
-
-      // WHEN
-      const response = await admin.rest.post({
-        path: '/customers.json',
-        data: '',
-      });
-
-      // THEN
-      expect(response.status).toEqual(200);
-      expect(await response.json()).toEqual({customers: []});
-    });
-
-    it('REST client can perform PUT requests', async () => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      await setUpValidSession(shopify.sessionStorage, false);
-      const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
-
-      await mockExternalRequest({
-        request: new Request(REQUEST_URL, {method: 'PUT'}),
-        response: new Response(JSON.stringify({customers: []})),
-      });
-
-      // WHEN
-      const response = await admin.rest.put({
-        path: '/customers.json',
-        data: '',
-      });
-
-      // THEN
-      expect(response.status).toEqual(200);
-      expect(await response.json()).toEqual({customers: []});
-    });
-
-    it('REST client can perform DELETE requests', async () => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      await setUpValidSession(shopify.sessionStorage, false);
-      const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
-
-      await mockExternalRequest({
-        request: new Request(REQUEST_URL, {method: 'DELETE'}),
-        response: new Response(JSON.stringify({customers: []})),
-      });
-
-      // WHEN
-      const response = await admin.rest.delete({path: '/customers.json'});
-
-      // THEN
-      expect(response.status).toEqual(200);
-      expect(await response.json()).toEqual({customers: []});
-    });
-
-    it('GraphQL client can perform requests', async () => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      await setUpValidSession(shopify.sessionStorage, false);
-      const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
-
-      await mockExternalRequest({
-        request: new Request(
-          `https://${TEST_SHOP}/admin/api/${shopifyApiPackage.LATEST_API_VERSION}/graphql.json`,
-          {method: 'POST'},
-        ),
-        response: new Response(JSON.stringify({shop: {name: 'Test shop'}})),
-      });
-
-      // WHEN
-      const response = await admin.graphql('{ shop { name } }');
-
-      // THEN
-      expect(response.status).toEqual(200);
-      expect(await response.json()).toEqual({shop: {name: 'Test shop'}});
-    });
   });
 });

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -5,7 +5,7 @@ import {
 } from '@shopify/shopify-api';
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
 
-import type {AdminApiContext, AppConfig, AppConfigArg} from './config-types';
+import type {AppConfig, AppConfigArg} from './config-types';
 import type {AdminContext} from './authenticate/admin/types';
 import type {
   AuthenticatePublicOptions,
@@ -16,6 +16,7 @@ import type {
   WebhookContext,
   WebhookContextWithSession,
 } from './authenticate/webhooks/types';
+import type {UnauthenticatedAdminContext} from './unauthenticated/admin/types';
 
 export interface BasicParams {
   api: Shopify;
@@ -86,9 +87,9 @@ type AuthenticateWebhook<
   WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>
 >;
 
-interface UnauthenticatedAdmin<Resources extends ShopifyRestResources> {
-  admin: AdminApiContext<Resources>;
-}
+type UnauthenticatedAdmin<Resources extends ShopifyRestResources> = (
+  shop: string,
+) => Promise<UnauthenticatedAdminContext<Resources>>;
 
 type RestResourcesType<Config extends AppConfigArg> =
   Config['restResources'] extends ShopifyRestResources
@@ -353,9 +354,7 @@ export interface ShopifyAppBase<Config extends AppConfigArg> {
      * }
      * ```
      */
-    admin: (
-      shop: string,
-    ) => Promise<UnauthenticatedAdmin<RestResourcesType<Config>>>;
+    admin: UnauthenticatedAdmin<RestResourcesType<Config>>;
   };
 }
 

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
@@ -1,0 +1,134 @@
+import {LATEST_API_VERSION} from '@shopify/shopify-api';
+
+import {shopifyApp} from '../../../index';
+import {mockExternalRequest} from '../../../__tests__/request-mock';
+import {
+  TEST_SHOP,
+  setUpValidSession,
+  testConfig,
+} from '../../../__tests__/test-helper';
+
+const REQUEST_URL = `https://${TEST_SHOP}/admin/api/${LATEST_API_VERSION}/customers.json`;
+
+describe('unauthenticated admin context', () => {
+  it('REST client can perform GET requests', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    await setUpValidSession(shopify.sessionStorage, false);
+    const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
+
+    await mockExternalRequest({
+      request: new Request(REQUEST_URL),
+      response: new Response(JSON.stringify({customers: []})),
+    });
+
+    // WHEN
+    const response = await admin.rest.get({path: 'customers'});
+
+    // THEN
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({customers: []});
+  });
+
+  it('REST client can perform POST requests', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    await setUpValidSession(shopify.sessionStorage, false);
+    const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
+
+    await mockExternalRequest({
+      request: new Request(REQUEST_URL, {method: 'POST'}),
+      response: new Response(JSON.stringify({customers: []})),
+    });
+
+    // WHEN
+    const response = await admin.rest.post({
+      path: '/customers.json',
+      data: '',
+    });
+
+    // THEN
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({customers: []});
+  });
+
+  it('REST client can perform PUT requests', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    await setUpValidSession(shopify.sessionStorage, false);
+    const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
+
+    await mockExternalRequest({
+      request: new Request(REQUEST_URL, {method: 'PUT'}),
+      response: new Response(JSON.stringify({customers: []})),
+    });
+
+    // WHEN
+    const response = await admin.rest.put({
+      path: '/customers.json',
+      data: '',
+    });
+
+    // THEN
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({customers: []});
+  });
+
+  it('REST client can perform DELETE requests', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    await setUpValidSession(shopify.sessionStorage, false);
+    const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
+
+    await mockExternalRequest({
+      request: new Request(REQUEST_URL, {method: 'DELETE'}),
+      response: new Response(JSON.stringify({customers: []})),
+    });
+
+    // WHEN
+    const response = await admin.rest.delete({path: '/customers.json'});
+
+    // THEN
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({customers: []});
+  });
+
+  it('GraphQL client can perform requests', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const session = await setUpValidSession(shopify.sessionStorage, false);
+    const {admin} = await shopify.unauthenticated.admin(TEST_SHOP);
+
+    await mockExternalRequest({
+      request: new Request(
+        `https://${TEST_SHOP}/admin/api/${LATEST_API_VERSION}/graphql.json`,
+        {
+          method: 'POST',
+          headers: {'X-Shopify-Access-Token': session.accessToken!},
+        },
+      ),
+      response: new Response(JSON.stringify({shop: {name: 'Test shop'}})),
+    });
+
+    // WHEN
+    const response = await admin.graphql('{ shop { name } }');
+
+    // THEN
+    expect(response.status).toEqual(200);
+    expect(await response.json()).toEqual({shop: {name: 'Test shop'}});
+  });
+
+  it('returns a session object as part of the context', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const session = await setUpValidSession(shopify.sessionStorage, false);
+
+    // WHEN
+    const {session: actualSession} = await shopify.unauthenticated.admin(
+      TEST_SHOP,
+    );
+
+    // THEN
+    expect(actualSession).toEqual(session);
+  });
+});

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
@@ -3,10 +3,14 @@ import {ShopifyError, ShopifyRestResources} from '@shopify/shopify-api';
 import {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients/admin';
 
+import {UnauthenticatedAdminContext} from './types';
+
 export function unauthenticatedAdminContextFactory<
   Resources extends ShopifyRestResources,
 >(params: BasicParams) {
-  return async (shop: string) => {
+  return async (
+    shop: string,
+  ): Promise<UnauthenticatedAdminContext<Resources>> => {
     const offlineSessionId = params.api.session.getOfflineId(shop);
     const session = await params.config.sessionStorage.loadSession(
       offlineSessionId,
@@ -19,6 +23,7 @@ export function unauthenticatedAdminContextFactory<
     }
 
     return {
+      session,
       admin: adminClientFactory<Resources>({params, session}),
     };
   };

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/types.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/types.ts
@@ -1,0 +1,36 @@
+import {Session, ShopifyRestResources} from '@shopify/shopify-api';
+
+import type {AdminApiContext} from '../../config-types';
+
+export interface UnauthenticatedAdminContext<
+  Resources extends ShopifyRestResources,
+> {
+  /**
+   * The session for the given shop.
+   *
+   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.
+   *
+   * This will always be an offline session. You can use to get shop specific data.
+   *
+   * @example
+   * Getting your app's shop specific widget data using a session
+   * ```ts
+   * // app/routes/**\/.ts
+   * import { LoaderArgs, json } from "@remix-run/node";
+   * import { unauthenticated } from "../shopify.server";
+   * import { getWidgets } from "~/db/widgets.server";
+   *
+   * export const loader = async ({ request }: LoaderArgs) => {
+   *   const shop = getShopFromExternalRequest(request);
+   *   const { session } = await unauthenticated.admin(shop);
+   *   return json(await getWidgets({shop: session.shop));
+   * };
+   * ```
+   */
+  session: Session;
+
+  /**
+   * Methods for interacting with the Shopify GraphQL / REST Admin APIs for the given store.
+   */
+  admin: AdminApiContext<Resources>;
+}


### PR DESCRIPTION
The `unauthenticated.admin` function was set up to return the `admin` context, but not the `session` we'd need for e.g. REST resource requests. This PR includes that object in the return type.