### PR TITLE
Remove trailing slashes from login shop domains

### DIFF
--- a/.changeset/eleven-actors-explode.md
+++ b/.changeset/eleven-actors-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Remove trailing slashes from shop domains when handling login form requests.

--- a/packages/shopify-app-remix/src/server/authenticate/login/__tests__/login.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/login/__tests__/login.test.ts
@@ -113,4 +113,26 @@ describe('login helper', () => {
       );
     },
   );
+
+  it('sanitizes the shop parameter', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const requestMock = {
+      url: `${APP_URL}/auth/login`,
+      formData: async () => ({get: () => `https://${TEST_SHOP}/`}),
+      method: 'POST',
+    };
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.login,
+      requestMock as any as Request,
+    );
+
+    // THEN
+    expect(response.status).toEqual(302);
+    expect(response.headers.get('location')).toEqual(
+      `${APP_URL}/auth?shop=${TEST_SHOP}`,
+    );
+  });
 });

--- a/packages/shopify-app-remix/src/server/authenticate/login/login.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/login/login.ts
@@ -21,7 +21,9 @@ export function loginFactory(params: BasicParams) {
       return {shop: LoginErrorType.MissingShop};
     }
 
-    const shopWithoutProtocol = shop.replace(/^https?:\/\//, '');
+    const shopWithoutProtocol = shop
+      .replace(/^https?:\/\//, '')
+      .replace(/\/$/, '');
     const shopWithDomain =
       shop?.indexOf('.') === -1
         ? `${shopWithoutProtocol}.myshopify.com`


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, when sanitizing the shop we receive from the login form, we're not properly handling trailing slashes.

### WHAT is this pull request doing?

Removing trailing slashes from the shop domain automatically so developers don't have to remember to do it.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
