### PR TITLE
Don't rely on request origin for redirects to bounce page

### DIFF
--- a/.changeset/metal-shirts-try.md
+++ b/.changeset/metal-shirts-try.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fixed an issue when running the app behind a reverse proxy that rewrites the `Host` header, where the bounce flow redirect (to ensure the id_token search param is present) relied on the incoming request URL and pointed to the internal host rather than the external one.

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
@@ -203,6 +203,31 @@ describe('authorize.admin doc request path', () => {
       );
     });
 
+    it('always bounces to the app URL, regardless of request URL', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      await setUpValidSession(shopify.sessionStorage);
+
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.admin,
+        new Request(
+          `https://some-other-host.not.real?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}`,
+        ),
+      );
+
+      // THEN
+      const {searchParams} = new URL(
+        response.headers.get('location')!,
+        APP_URL,
+      );
+
+      expect(response.status).toBe(302);
+      expect(searchParams.get('shopify-reload')).toBe(
+        `${APP_URL}/?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}`,
+      );
+    });
+
     it('throws a 401 if app is embedded and the id_token search param is invalid', async () => {
       // GIVEN
       const shopify = shopifyApp(testConfig());

--- a/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -497,20 +497,19 @@ export class AuthStrategy<
   }
 
   private redirectToBouncePage(url: URL): never {
-    const {api, config} = this;
+    const {config} = this;
 
-    // eslint-disable-next-line no-warning-comments
-    // TODO this is to work around a remix bug
-    // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28376650
-    url.protocol = `${api.config.hostScheme}:`;
-
-    const params = new URLSearchParams(url.search);
-    params.set('shopify-reload', url.href);
+    // Make sure we always point to the configured app URL so it also works behind reverse proxies (that alter the Host
+    // header).
+    url.searchParams.set(
+      'shopify-reload',
+      `${config.appUrl}${url.pathname}${url.search}`,
+    );
 
     // eslint-disable-next-line no-warning-comments
     // TODO Make sure this works on chrome without a tunnel (weird HTTPS redirect issue)
     // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28376650
-    throw redirect(`${config.auth.patchSessionTokenPath}?${params.toString()}`);
+    throw redirect(`${config.auth.patchSessionTokenPath}${url.search}`);
   }
 
   private createBillingContext(


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #378 

When running the app behind a reverse proxy that rewrites the `Host` header, the incoming request origin may not match the configured app URL, and it breaks the flow. 

### WHAT is this pull request doing?

Ensuring that we always use the configured URL as the origin for the redirect so that we don't accidentally point the redirect flow at the internal host address.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
