### PR TITLE
Allow custom table names in Prisma schemas

### DIFF
--- a/.changeset/green-pugs-matter.md
+++ b/.changeset/green-pugs-matter.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-prisma': minor
+---
+
+Allow using custom tables for the Prisma session storage.

--- a/packages/shopify-app-session-storage-prisma/README.md
+++ b/packages/shopify-app-session-storage-prisma/README.md
@@ -35,6 +35,15 @@ const shopify = shopifyApp({
 
 > **Note**: If you use [SQLite](https://sqlite.com) with Prisma note that sqlite is a local, file-based SQL database. It persists all tables to a single file on your local disk. As such, it’s simple to set up and is a great choice for getting started with Shopify App development. However, it won’t work when your app getting scaled across multiple instances because they would each create their own database.
 
+You can also pass in some optional flags to tweak the behavior of the adapter.
+For example, you can pass in `tableName` if you want to use a different table name in your schema.
+
+```ts
+const storage = new PrismaSessionStorage(prisma, {
+  tableName: 'MyCustomSession',
+});
+```
+
 If you prefer to use your own implementation of a session storage mechanism that is compatible with the `@shopify/shopify-app-express` package, see the [implementing session storage guide](https://github.com/Shopify/shopify-app-js/blob/main/packages/shopify-app-session-storage/implementing-session-storage.md).
 
 ## Troubleshooting

--- a/packages/shopify-app-session-storage-prisma/prisma/migrations/20230906155758_mySession/migration.sql
+++ b/packages/shopify-app-session-storage-prisma/prisma/migrations/20230906155758_mySession/migration.sql
@@ -1,0 +1,11 @@
+-- CreateTable
+CREATE TABLE "MySession" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "shop" TEXT NOT NULL,
+    "state" TEXT NOT NULL,
+    "isOnline" BOOLEAN NOT NULL DEFAULT false,
+    "scope" TEXT,
+    "expires" DATETIME,
+    "accessToken" TEXT NOT NULL,
+    "userId" BIGINT
+);

--- a/packages/shopify-app-session-storage-prisma/prisma/schema.prisma
+++ b/packages/shopify-app-session-storage-prisma/prisma/schema.prisma
@@ -17,3 +17,14 @@ model Session {
   accessToken String
   userId      BigInt?
 }
+
+model MySession {
+  id          String    @id
+  shop        String
+  state       String
+  isOnline    Boolean   @default(false)
+  scope       String?
+  expires     DateTime?
+  accessToken String
+  userId      BigInt?
+}

--- a/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
+++ b/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
@@ -20,9 +20,17 @@ describe('PrismaSessionStorage', () => {
 
   afterAll(async () => {
     await prisma.session.deleteMany();
+    await prisma.mySession.deleteMany();
   });
 
+  // Using the default table name
   batteryOfTests(async () => new PrismaSessionStorage<PrismaClient>(prisma));
+
+  // Using a custom table name
+  batteryOfTests(
+    async () =>
+      new PrismaSessionStorage<PrismaClient>(prisma, {tableName: 'mySession'}),
+  );
 });
 
 describe('PrismaSessionStoragewhen with no database set up', () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #418, #419

As proposed by @therealflyingcoder (thanks!), we should support table names other than `Session` in our prisma schema to give more flexibility to how apps can set up their DBs.

### WHAT is this pull request doing?

Adding an optional `Options` param to `PrismaSessionStorage`, so that apps can tweak the behaviour of the class. I ended up going with an object to make it more future-proof and easier to read when looking at the caller.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
