### PR TITLE
Authenticate App Proxy now returns an admin API context if there is a…

### DIFF
--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -1,3 +1,5 @@
+import {ShopifyRestResources} from '@shopify/shopify-api';
+
 import {adminClientFactory} from '../../../clients/admin';
 import {BasicParams} from '../../../types';
 
@@ -6,7 +8,6 @@ import {
   AppProxyContextWithSession,
   AuthenticateAppProxy,
 } from './types';
-import {ShopifyRestResources} from '@shopify/shopify-api';
 
 export function authenticateAppProxyFactory<
   Resources extends ShopifyRestResources,

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -1,12 +1,21 @@
+import {adminClientFactory} from '../../../clients/admin';
 import {BasicParams} from '../../../types';
 
-import {AuthenticateAppProxy} from './types';
+import {
+  AppProxyContext,
+  AppProxyContextWithSession,
+  AuthenticateAppProxy,
+} from './types';
+import {ShopifyRestResources} from '@shopify/shopify-api';
 
-export function authenticateAppProxyFactory({
-  logger,
-  api,
-}: BasicParams): AuthenticateAppProxy {
-  return async function authenticateAppProxy(request): Promise<undefined> {
+export function authenticateAppProxyFactory<
+  Resources extends ShopifyRestResources,
+>(params: BasicParams): AuthenticateAppProxy {
+  const {api, config, logger} = params;
+
+  return async function authenticate(
+    request,
+  ): Promise<AppProxyContext | AppProxyContextWithSession<Resources>> {
     logger.info('Authenticating app proxy request');
 
     const {searchParams} = new URL(request.url);
@@ -30,6 +39,24 @@ export function authenticateAppProxyFactory({
       });
     }
 
-    return undefined;
+    const shop = searchParams.get('shop')!;
+    const sessionId = api.session.getOfflineId(shop);
+    const session = await config.sessionStorage.loadSession(sessionId);
+
+    if (!session) {
+      const context: AppProxyContext = {
+        session: undefined,
+        admin: undefined,
+      };
+
+      return context;
+    }
+
+    const context: AppProxyContextWithSession<Resources> = {
+      session,
+      admin: adminClientFactory({params, session}),
+    };
+
+    return context;
   };
 }

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -31,7 +31,7 @@ export interface AppProxyContextWithSession<
    * Use this to get shop or user specific data.
    *
    * @example
-   * Getting your app's shop specific widget data using an offline session
+   * <caption>Getting your app's shop specific widget data using an offline session</caption>
    * ```ts
    * // app/routes/**\/.ts
    * import { json } from "@remix-run/node";

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -6,13 +6,46 @@ export type AuthenticateAppProxy = (
 ) => Promise<AppProxyContext | AppProxyContextWithSession>;
 
 export interface AppProxyContext {
+  /**
+   * No session is available for the shop who made this request.
+   *
+   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.
+   */
   session: undefined;
+  /**
+   * No session is available for the shop who made this request.
+   * Therefore no methods for interacting with the Shopify GraphQL / REST Admin APIs are available.
+   */
   admin: undefined;
 }
 
 export interface AppProxyContextWithSession<
   Resources extends ShopifyRestResources = ShopifyRestResources,
 > {
+  /**
+   * The session for the shop who made the request.
+   *
+   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.
+   *
+   * Use this to get shop or user specific data.
+   *
+   * @example
+   * Getting your app's shop specific widget data using an offline session
+   * ```ts
+   * // app/routes/**\/.ts
+   * import { json } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   * import { getWidgets } from "~/db/widgets.server";
+   *
+   * export const loader = async ({ request }) => {
+   *   const { session } = await authenticate.public.appProxy(request);
+   *   return json(await getWidgets({shop: session.shop));
+   * };
+   * ```
+   */
   session: Session;
+  /**
+   * Methods for interacting with the Shopify GraphQL / REST Admin APIs for the store that made the request
+   */
   admin: AdminApiContext<Resources>;
 }

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -1,1 +1,18 @@
-export type AuthenticateAppProxy = (request: Request) => Promise<undefined>;
+import {Session, ShopifyRestResources} from '@shopify/shopify-api';
+import {AdminApiContext} from '../../../config-types';
+
+export type AuthenticateAppProxy = (
+  request: Request,
+) => Promise<AppProxyContext | AppProxyContextWithSession>;
+
+export interface AppProxyContext {
+  session: undefined;
+  admin: undefined;
+}
+
+export interface AppProxyContextWithSession<
+  Resources extends ShopifyRestResources = ShopifyRestResources,
+> {
+  session: Session;
+  admin: AdminApiContext<Resources>;
+}

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -1,4 +1,5 @@
 import {Session, ShopifyRestResources} from '@shopify/shopify-api';
+
 import {AdminApiContext} from '../../../config-types';
 
 export type AuthenticateAppProxy = (

--- a/packages/shopify-app-remix/src/server/authenticate/public/factory.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/factory.ts
@@ -4,10 +4,11 @@ import {authenticateCheckoutFactory} from './checkout/authenticate';
 import {AuthenticateCheckoutOptions} from './checkout/types';
 import {authenticateAppProxyFactory} from './appProxy/authenticate';
 import {AuthenticatePublic} from './types';
+import {ShopifyRestResources} from '@shopify/shopify-api';
 
-export function authenticatePublicFactory(
-  params: BasicParams,
-): AuthenticatePublic {
+export function authenticatePublicFactory<
+  Resources extends ShopifyRestResources,
+>(params: BasicParams): AuthenticatePublic {
   const {logger} = params;
 
   const authenticateCheckout = authenticateCheckoutFactory(params);
@@ -24,7 +25,7 @@ export function authenticatePublicFactory(
   };
 
   authenticatePublic.checkout = authenticateCheckout;
-  authenticatePublic.appProxy = authenticateAppProxyFactory(params);
+  authenticatePublic.appProxy = authenticateAppProxyFactory<Resources>(params);
 
   return authenticatePublic;
 }

--- a/packages/shopify-app-remix/src/server/authenticate/public/factory.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/factory.ts
@@ -1,10 +1,11 @@
+import {ShopifyRestResources} from '@shopify/shopify-api';
+
 import {BasicParams} from '../../types';
 
 import {authenticateCheckoutFactory} from './checkout/authenticate';
 import {AuthenticateCheckoutOptions} from './checkout/types';
 import {authenticateAppProxyFactory} from './appProxy/authenticate';
 import {AuthenticatePublic} from './types';
-import {ShopifyRestResources} from '@shopify/shopify-api';
 
 export function authenticatePublicFactory<
   Resources extends ShopifyRestResources,

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -76,7 +76,7 @@ export function shopifyApp<
     registerWebhooks: registerWebhooksFactory(params),
     authenticate: {
       admin: oauth.authenticateAdmin.bind(oauth),
-      public: authenticatePublicFactory(params),
+      public: authenticatePublicFactory<Resources>(params),
       webhook: authenticateWebhookFactory<
         Resources,
         keyof Config['webhooks'] | MandatoryTopics


### PR DESCRIPTION
### WHY are these changes introduced?

Chatting with @nicday and @mgmanzella about app proxies we agreed that the authenticate function should not require a Session, but if we can get a session for that shop we should return an admin API context.

This means we save partners some lines of code, but we don't mandate that there must be a session.  It's important not to mandate a session because an app might not need one.  Instead, they might only be accessing data in their own database. or a 3P service... in which case they don't need a session.

### WHAT is this pull request doing?
App Proxy tries to create a session using the `shop` URL param.  If it can, it returns:

```
export interface AppProxyContextWithSession<
  Resources extends ShopifyRestResources = ShopifyRestResources,
> {
  session: Session;
  admin: AdminApiContext<Resources>;
}
```

If not, it returns:

```
export interface AppProxyContext {
  session: undefined;
  admin: undefined;
}
```

Then we update the tests to check the API client that is returned is valid.

## Type of change

This will be take care of by the base branch

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
