### PR TITLE
[Feature] App proxy liquid helper

### DIFF
--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -67,12 +67,18 @@ export function authenticateAppProxyFactory<
   };
 }
 
-// ignoring because I want to type the function using LiquidResponseFunction
-// eslint-disable-next-line func-style
-const liquid: LiquidResponseFunction = function liquid(body, init, options) {
-  const responseInit = typeof init === 'number' ? {status: init} : init || {};
-  const responseBody =
-    options?.layout === false ? `{% layout none %} ${body}` : body;
+const liquid: LiquidResponseFunction = (body, initAndOptions) => {
+  if (typeof initAndOptions !== 'object') {
+    return new Response(body, {
+      status: initAndOptions || 200,
+      headers: {
+        'Content-Type': 'application/liquid',
+      },
+    });
+  }
+
+  const {layout, ...responseInit} = initAndOptions || {};
+  const responseBody = layout === false ? `{% layout none %} ${body}` : body;
 
   const headers = new Headers(responseInit.headers);
   headers.set('Content-Type', 'application/liquid');

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -6,10 +6,13 @@ export type AuthenticateAppProxy = (
   request: Request,
 ) => Promise<AppProxyContext | AppProxyContextWithSession>;
 
+interface Options {
+  layout?: boolean;
+}
+
 export type LiquidResponseFunction = (
   body: string,
-  init?: number | ResponseInit,
-  options?: {layout: boolean},
+  initAndOptions?: number | (ResponseInit & Options),
 ) => Response;
 
 interface AppProxyContext {


### PR DESCRIPTION
### WHY are these changes introduced?

App proxy requests can return liquid, which Shopify then parses and renders inside the storefronts theme.  We want to make returning a liquid Response easy.

### WHAT is this pull request doing?

`authenticate.appProxy(request)` now returns a liquid helper.  This helper:

1. Returns a response with `'Content-Type', 'application/liquid'`
2. Copies the implementation of Remix's `json` method.  Accepting the Response Body as the first argument and an optional a status or Response Init as the second argument
3. Accepts a third argument to `{layout: false}`, which tells Shopify to render the liquid response without the Stores Theme layout.

Here is an example:

```
import {authenticate} from "~/shopify.server"

export async function loader({request}) {
  const {liquid} = authenticate.public.appProxy(request)

  return liquid("Hello from {{shop.name}}")
}
```

## Type of change

This will become a Minor change, but I'll handle that in the base branch.

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

I'll update the changelog in the base branch

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
