### PR TITLE
Fix type error in authenticate.appProxy was typed as if it c…

### DIFF
--- a/.changeset/stupid-cups-warn.md
+++ b/.changeset/stupid-cups-warn.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fix type error. Previosuly authenticate.appProxy() was typed as if it could return an object without session and admin properties. This was incorrect. Those properties will always exist, they may just be undefined.

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -4,7 +4,7 @@ import {adminClientFactory} from '../../../clients/admin';
 import {BasicParams} from '../../../types';
 
 import {
-  AppProxyContextWithoutSession,
+  AppProxyContext,
   AppProxyContextWithSession,
   AuthenticateAppProxy,
   LiquidResponseFunction,
@@ -17,9 +17,7 @@ export function authenticateAppProxyFactory<
 
   return async function authenticate(
     request,
-  ): Promise<
-    AppProxyContextWithoutSession | AppProxyContextWithSession<Resources>
-  > {
+  ): Promise<AppProxyContext | AppProxyContextWithSession<Resources>> {
     logger.info('Authenticating app proxy request');
 
     const {searchParams} = new URL(request.url);
@@ -48,7 +46,7 @@ export function authenticateAppProxyFactory<
     const session = await config.sessionStorage.loadSession(sessionId);
 
     if (!session) {
-      const context: AppProxyContextWithoutSession = {
+      const context: AppProxyContext = {
         liquid,
         session: undefined,
         admin: undefined,

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/types.ts
@@ -15,7 +15,7 @@ export type LiquidResponseFunction = (
   initAndOptions?: number | (ResponseInit & Options),
 ) => Response;
 
-interface AppProxyContext {
+interface Context {
   /**
    * A utility for creating a Liquid Response.
    *
@@ -36,7 +36,7 @@ interface AppProxyContext {
   liquid: LiquidResponseFunction;
 }
 
-export interface AppProxyContextWithoutSession extends AppProxyContext {
+export interface AppProxyContext extends Context {
   /**
    * No session is available for the shop that made this request.
    *
@@ -52,7 +52,7 @@ export interface AppProxyContextWithoutSession extends AppProxyContext {
 
 export interface AppProxyContextWithSession<
   Resources extends ShopifyRestResources = ShopifyRestResources,
-> extends AppProxyContext {
+> extends Context {
   /**
    * The session for the shop that made the request.
    *


### PR DESCRIPTION
### WHY are these changes introduced?

Previously authenticate.appProxy was typed as if it could return an object without session and admin properties. This was incorrect. Those properties will always exist, they may just be undefined

### WHAT is this pull request doing?

Update types

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~~[ ] I have added/updated tests for this change~~ Not required
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~ Not required
