### PR TITLE
Allow all billing config overrides at request

### DIFF
--- a/.changeset/blue-icons-invite.md
+++ b/.changeset/blue-icons-invite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Allow all billing config overrides at request time.

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
@@ -20,6 +20,7 @@ export function requestBillingFactory<Config extends AppConfigArg>(
     plan,
     isTest,
     returnUrl,
+    ...overrides
   }: RequestBillingOptions<Config>): Promise<never> {
     const {api, logger} = params;
 
@@ -38,6 +39,7 @@ export function requestBillingFactory<Config extends AppConfigArg>(
         isTest,
         returnUrl,
         returnObject: true,
+        ...overrides,
       });
     } catch (error) {
       if (error instanceof HttpResponseError && error.response.code === 401) {


### PR DESCRIPTION
### WHY are these changes introduced?

With https://github.com/Shopify/shopify-api-js/pull/985, the library will allow overriding all fields when requesting payment, not just `trialDays`.

### WHAT is this pull request doing?

Passing through all params to `billing.request`, rather than just `trialDays`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
