### PR TITLE
Authenticate flow

### DIFF
--- a/.changeset/ninety-mugs-agree.md
+++ b/.changeset/ninety-mugs-agree.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": minor
+---
+
+Added a new method `shopify.authenticate.flow(request)`, which will validate a Flow extension request, and return the payload / API clients to the app.

--- a/packages/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -270,101 +270,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -376,60 +376,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -441,35 +441,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -477,7 +477,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -485,7 +485,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -493,11 +493,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "AdminApiContext": {
             "filePath": "src/server/clients/admin/types.ts",
@@ -641,14 +641,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -656,7 +656,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -664,7 +664,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -672,7 +672,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -680,11 +680,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -714,7 +714,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -946,7 +946,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "RequireBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -972,7 +972,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -988,24 +988,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "hasActivePayment",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the user has an active payment method."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchases",
                 "value": "OneTimePurchase[]",
-                "description": ""
+                "description": "The one-time purchases the shop has."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscriptions",
                 "value": "AppSubscription[]",
-                "description": ""
+                "description": "The active subscriptions the shop has."
               }
             ],
-            "value": "export interface BillingCheckResponseObject {\n    hasActivePayment: boolean;\n    oneTimePurchases: OneTimePurchase[];\n    appSubscriptions: AppSubscription[];\n}"
+            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
           },
           "OneTimePurchase": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -1017,31 +1017,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the one-time purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "status",
                 "value": "string",
-                "description": ""
+                "description": "The status of the one-time purchase."
               }
             ],
-            "value": "export interface OneTimePurchase {\n    id: string;\n    name: string;\n    test: boolean;\n    status: string;\n}"
+            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "AppSubscription": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -1053,24 +1053,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the app subscription."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test subscription."
               }
             ],
-            "value": "export interface AppSubscription {\n    id: string;\n    name: string;\n    test: boolean;\n}"
+            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n}"
           },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -1089,7 +1089,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -1304,66 +1304,66 @@
                 "syntaxKind": "PropertySignature",
                 "name": "iss",
                 "value": "string",
-                "description": ""
+                "description": "The shop's admin domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "dest",
                 "value": "string",
-                "description": ""
+                "description": "The shop's domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "aud",
                 "value": "string",
-                "description": ""
+                "description": "The client ID of the receiving app."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sub",
                 "value": "string",
-                "description": ""
+                "description": "The User that the session token is intended for."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "exp",
                 "value": "number",
-                "description": ""
+                "description": "When the session token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "nbf",
                 "value": "number",
-                "description": ""
+                "description": "When the session token activates."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "iat",
                 "value": "number",
-                "description": ""
+                "description": "When the session token was issued."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "jti",
                 "value": "string",
-                "description": ""
+                "description": "A secure random UUID."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sid",
                 "value": "string",
-                "description": ""
+                "description": "A unique session ID per user and app."
               }
             ],
-            "value": "export interface JwtPayload {\n    iss: string;\n    dest: string;\n    aud: string;\n    sub: string;\n    exp: number;\n    nbf: number;\n    iat: number;\n    jti: string;\n    sid: string;\n}"
+            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           },
           "RedirectFunction": {
             "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
@@ -1861,7 +1861,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "RequireBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -1887,7 +1887,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -1903,24 +1903,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "hasActivePayment",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the user has an active payment method."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchases",
                 "value": "OneTimePurchase[]",
-                "description": ""
+                "description": "The one-time purchases the shop has."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscriptions",
                 "value": "AppSubscription[]",
-                "description": ""
+                "description": "The active subscriptions the shop has."
               }
             ],
-            "value": "export interface BillingCheckResponseObject {\n    hasActivePayment: boolean;\n    oneTimePurchases: OneTimePurchase[];\n    appSubscriptions: AppSubscription[];\n}"
+            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
           },
           "OneTimePurchase": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -1932,31 +1932,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the one-time purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "status",
                 "value": "string",
-                "description": ""
+                "description": "The status of the one-time purchase."
               }
             ],
-            "value": "export interface OneTimePurchase {\n    id: string;\n    name: string;\n    test: boolean;\n    status: string;\n}"
+            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "AppSubscription": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -1968,24 +1968,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the app subscription."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test subscription."
               }
             ],
-            "value": "export interface AppSubscription {\n    id: string;\n    name: string;\n    test: boolean;\n}"
+            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n}"
           },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -2004,7 +2004,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -2191,6 +2191,756 @@
                   {
                     "title": "shopify.server.ts",
                     "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  },
+  {
+    "name": "Flow",
+    "description": "Contains functions for verifying Shopify Flow extensions.\n\nSee the [Flow documentation](https://shopify.dev/docs/apps/flow/actions/endpoints) for more information.",
+    "category": "Authenticate",
+    "type": "object",
+    "isVisualComponent": false,
+    "definitions": [
+      {
+        "title": "authenticate.flow",
+        "description": "Verifies requests coming from Shopify Flow extensions.",
+        "type": "AuthenticateFlow",
+        "typeDefinitions": {
+          "AuthenticateFlow": {
+            "filePath": "src/server/authenticate/flow/types.ts",
+            "name": "AuthenticateFlow",
+            "description": "",
+            "params": [
+              {
+                "name": "request",
+                "description": "",
+                "value": "Request",
+                "filePath": "src/server/authenticate/flow/types.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/server/authenticate/flow/types.ts",
+              "description": "",
+              "name": "Promise<FlowContext<Resources>>",
+              "value": "Promise<FlowContext<Resources>>"
+            },
+            "value": "export type AuthenticateFlow<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> = (request: Request) => Promise<FlowContext<Resources>>;"
+          },
+          "FlowContext": {
+            "filePath": "src/server/authenticate/flow/types.ts",
+            "name": "FlowContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "A session with an offline token for the shop.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "Shopify session for the Flow request",
+                    "description": "Use the session associated with this request to use REST resources.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { session, admin } = await authenticate.flow(request);\n\n  const products = await admin?.rest.resources.Product.all({ session });\n  // Use products\n\n  return new Response();\n};",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "payload",
+                "value": "any",
+                "description": "The payload from the Flow request.",
+                "examples": [
+                  {
+                    "title": "Flow payload",
+                    "description": "Get the request's POST payload.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { payload } = await authenticate.flow(request);\n  return new Response();\n};",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "admin",
+                "value": "AdminApiContext<Resources>",
+                "description": "An admin context for the Flow request.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "Flow admin context",
+                    "description": "Use the `admin` object in the context to interact with the Admin API.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.flow(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface FlowContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Shopify session for the Flow request.</caption>\n   * <description>Use the session associated with this request to use REST resources.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunction } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action: ActionFunction = async ({ request }) => {\n   *   const { session, admin } = await authenticate.flow(request);\n   *\n   *   const products = await admin?.rest.resources.Product.all({ session });\n   *   // Use products\n   *\n   *   return new Response();\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * The payload from the Flow request.\n   *\n   * @example\n   * <caption>Flow payload.</caption>\n   * <description>Get the request's POST payload.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunction } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action: ActionFunction = async ({ request }) => {\n   *   const { payload } = await authenticate.flow(request);\n   *   return new Response();\n   * };\n   * ```\n   */\n  payload: any;\n\n  /**\n   * An admin context for the Flow request.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Flow admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.flow(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
+          },
+          "Session": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+            "name": "Session",
+            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "scope",
+                "value": "string",
+                "description": "The desired scopes for the access token, at the time the session was created."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isActive",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeChanged",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token has the given scopes."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isExpired",
+                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
+                "description": "Whether the access token is expired."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toObject",
+                "value": "() => SessionParams",
+                "description": "Converts an object with data into a Session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(other: Session) => boolean",
+                "description": "Checks whether the given session is equal to this session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toPropertyArray",
+                "value": "() => [string, string | number | boolean][]",
+                "description": "Converts the session into an array of key-value pairs."
+              }
+            ],
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+          },
+          "OnlineAccessInfo": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
+            "name": "OnlineAccessInfo",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires_in",
+                "value": "number",
+                "description": "How long the access token is valid for, in seconds."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user_scope",
+                "value": "string",
+                "description": "The effective set of scopes for the session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user",
+                "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
+                "description": "The user associated with the access token."
+              }
+            ],
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
+          },
+          "AuthScopes": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
+            "name": "AuthScopes",
+            "description": "A class that represents a set of access token scopes.",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "has",
+                "value": "(scope: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes includes the given one."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes equals the given one."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toString",
+                "value": "() => string",
+                "description": "Returns a comma-separated string with the current set of scopes."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toArray",
+                "value": "() => string[]",
+                "description": "Returns an array with the current set of scopes."
+              }
+            ],
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+          },
+          "SessionParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+            "name": "SessionParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scope",
+                "value": "string",
+                "description": "The scopes for the access token.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+          },
+          "AdminApiContext": {
+            "filePath": "src/server/clients/admin/types.ts",
+            "name": "AdminApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rest",
+                "value": "RestClientWithResources<Resources>",
+                "description": "Methods for interacting with the Shopify Admin REST API\n\nThere are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n\n\n\n\n",
+                "examples": [
+                  {
+                    "title": "Using REST resources",
+                    "description": "Getting the number of orders in a store using REST resources. Visit the [Admin REST API references](/docs/api/admin-rest) for examples on using each resource.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  return json(admin.rest.resources.Order.count({ session }));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Performing a GET request to the REST API",
+                    "description": "Use `admin.rest.get` to make custom requests to make a request to to the `customer/count` endpoint",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  const response = await admin.rest.get({ path: \"/customers/count.json\" });\n  const customers = await response.json();\n  return json({ customers });\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Performing a POST request to the REST API",
+                    "description": "Use `admin.rest.post` to make custom requests to make a request to to the `customers.json` endpoint to send a welcome email",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  const response = admin.rest.post({\n    path: \"customers/7392136888625/send_invite.json\",\n    body: {\n      customer_invite: {\n        to: \"new_test_email@shopify.com\",\n        from: \"j.limited@example.com\",\n        bcc: [\"j.limited@example.com\"],\n        subject: \"Welcome to my new shop\",\n        custom_message: \"My awesome new store\",\n      },\n    },\n});\n  const customerInvite = await response.json();\n  return json({ customerInvite });\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "graphql",
+                "value": "GraphQLClient<AdminOperations>",
+                "description": "Methods for interacting with the Shopify Admin GraphQL API\n\n\n\n\n\n\n\n\n\n",
+                "examples": [
+                  {
+                    "title": "Querying the GraphQL API",
+                    "description": "Use `admin.graphql` to make query / mutation requests.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.admin(request);\n\n  const response = await admin.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      },
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const unauthenticated = shopify.unauthenticated;",
+                        "title": "/app/shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface AdminApiContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * Methods for interacting with the Shopify Admin REST API\n   *\n   * There are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n   *\n   * {@link https://shopify.dev/docs/api/admin-rest}\n   *\n   * @example\n   * <caption>Using REST resources.</caption>\n   * <description>Getting the number of orders in a store using REST resources. Visit the [Admin REST API references](/docs/api/admin-rest) for examples on using each resource. </description>\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   return json(admin.rest.resources.Order.count({ session }));\n   * };\n   * ```\n   *\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   *\n   * @example\n   * <caption>Performing a GET request to the REST API.</caption>\n   * <description>Use `admin.rest.get` to make custom requests to make a request to to the `customer/count` endpoint</description>\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   const response = await admin.rest.get({ path: \"/customers/count.json\" });\n   *   const customers = await response.json();\n   *   return json({ customers });\n   * };\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * @example\n   * <caption>Performing a POST request to the REST API.</caption>\n   * <description>Use `admin.rest.post` to make custom requests to make a request to to the `customers.json` endpoint to send a welcome email</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   const response = admin.rest.post({\n   *     path: \"customers/7392136888625/send_invite.json\",\n   *     body: {\n   *       customer_invite: {\n   *         to: \"new_test_email@shopify.com\",\n   *         from: \"j.limited@example.com\",\n   *         bcc: [\"j.limited@example.com\"],\n   *         subject: \"Welcome to my new shop\",\n   *         custom_message: \"My awesome new store\",\n   *       },\n   *     },\n   * });\n   *   const customerInvite = await response.json();\n   *   return json({ customerInvite });\n   * };\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  rest: RestClientWithResources<Resources>;\n\n  /**\n   * Methods for interacting with the Shopify Admin GraphQL API\n   *\n   * {@link https://shopify.dev/docs/api/admin-graphql}\n   * {@link https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/docs/reference/clients/Graphql.md}\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `admin.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.admin(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  graphql: GraphQLClient<AdminOperations>;\n}"
+          },
+          "RestClientWithResources": {
+            "filePath": "src/server/clients/admin/rest.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RestClientWithResources",
+            "value": "RemixRestClient & {resources: Resources}",
+            "description": ""
+          },
+          "RemixRestClient": {
+            "filePath": "src/server/clients/admin/rest.ts",
+            "name": "RemixRestClient",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/clients/admin/rest.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/clients/admin/rest.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "get",
+                "value": "(params: GetRequestParams) => Promise<Response>",
+                "description": "Performs a GET request on the given path."
+              },
+              {
+                "filePath": "src/server/clients/admin/rest.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "post",
+                "value": "(params: PostRequestParams) => Promise<Response>",
+                "description": "Performs a POST request on the given path."
+              },
+              {
+                "filePath": "src/server/clients/admin/rest.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "put",
+                "value": "(params: PostRequestParams) => Promise<Response>",
+                "description": "Performs a PUT request on the given path."
+              },
+              {
+                "filePath": "src/server/clients/admin/rest.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "delete",
+                "value": "(params: GetRequestParams) => Promise<Response>",
+                "description": "Performs a DELETE request on the given path."
+              }
+            ],
+            "value": "class RemixRestClient {\n  public session: Session;\n  private params: AdminClientOptions['params'];\n  private handleClientError: AdminClientOptions['handleClientError'];\n\n  constructor({params, session, handleClientError}: AdminClientOptions) {\n    this.params = params;\n    this.handleClientError = handleClientError;\n    this.session = session;\n  }\n\n  /**\n   * Performs a GET request on the given path.\n   */\n  public async get(params: GetRequestParams) {\n    return this.makeRequest({\n      method: 'GET' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a POST request on the given path.\n   */\n  public async post(params: PostRequestParams) {\n    return this.makeRequest({\n      method: 'POST' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a PUT request on the given path.\n   */\n  public async put(params: PutRequestParams) {\n    return this.makeRequest({\n      method: 'PUT' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a DELETE request on the given path.\n   */\n  public async delete(params: DeleteRequestParams) {\n    return this.makeRequest({\n      method: 'DELETE' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  protected async makeRequest(params: RequestParams): Promise<Response> {\n    const originalClient = new this.params.api.clients.Rest({\n      session: this.session,\n    });\n    const originalRequest = Reflect.get(originalClient, 'request');\n\n    try {\n      const apiResponse = await originalRequest.call(originalClient, params);\n\n      // We use a separate client for REST requests and REST resources because we want to override the API library\n      // client class to return a Response object instead.\n      return new Response(JSON.stringify(apiResponse.body), {\n        headers: apiResponse.headers,\n      });\n    } catch (error) {\n      if (this.handleClientError) {\n        throw await this.handleClientError({\n          error,\n          session: this.session,\n          params: this.params,\n        });\n      } else throw new Error(error);\n    }\n  }\n}"
+          },
+          "GetRequestParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+            "name": "GetRequestParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "path",
+                "value": "string",
+                "description": "The path to the resource, relative to the API version root."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "type",
+                "value": "DataType",
+                "description": "The type of data expected in the response.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "data",
+                "value": "string | Record<string, any>",
+                "description": "The request body.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "SearchParams",
+                "description": "Query parameters to be sent with the request.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "extraHeaders",
+                "value": "HeaderParams",
+                "description": "Additional headers to be sent with the request.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "tries",
+                "value": "number",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
+          },
+          "DataType": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "DataType",
+            "value": "export declare enum DataType {\n    JSON = \"application/json\",\n    GraphQL = \"application/graphql\",\n    URLEncoded = \"application/x-www-form-urlencoded\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "name": "JSON",
+                "value": "application/json"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "name": "GraphQL",
+                "value": "application/graphql"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+                "name": "URLEncoded",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ]
+          },
+          "HeaderParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "HeaderParams",
+            "value": "Record<string, string | number | string[]>",
+            "description": "Headers to be sent with the request.",
+            "members": []
+          },
+          "PostRequestParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "PostRequestParams",
+            "value": "GetRequestParams & {\n    data: Record<string, any> | string;\n}",
+            "description": ""
+          },
+          "GraphQLClient": {
+            "filePath": "src/server/clients/types.ts",
+            "name": "GraphQLClient",
+            "description": "",
+            "params": [
+              {
+                "name": "query",
+                "description": "",
+                "value": "Operation extends keyof Operations",
+                "filePath": "src/server/clients/types.ts"
+              },
+              {
+                "name": "options",
+                "description": "",
+                "value": "GraphQLQueryOptions<Operation, Operations>",
+                "isOptional": true,
+                "filePath": "src/server/clients/types.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/server/clients/types.ts",
+              "description": "",
+              "name": "interface Promise<T> {\n    /**\n     * Attaches callbacks for the resolution and/or rejection of the Promise.\n     * @param onfulfilled The callback to execute when the Promise is resolved.\n     * @param onrejected The callback to execute when the Promise is rejected.\n     * @returns A Promise for the completion of which ever callback is executed.\n     */\n    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;\n\n    /**\n     * Attaches a callback for only the rejection of the Promise.\n     * @param onrejected The callback to execute when the Promise is rejected.\n     * @returns A Promise for the completion of the callback.\n     */\n    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;\n}, interface Promise<T> {}, Promise: PromiseConstructor, interface Promise<T> {\n    readonly [Symbol.toStringTag]: string;\n}, interface Promise<T> {\n    /**\n     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The\n     * resolved value cannot be modified from the callback.\n     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).\n     * @returns A Promise for the completion of the callback.\n     */\n    finally(onfinally?: (() => void) | undefined | null): Promise<T>;\n}",
+              "value": "interface Promise<T> {\n    /**\n     * Attaches callbacks for the resolution and/or rejection of the Promise.\n     * @param onfulfilled The callback to execute when the Promise is resolved.\n     * @param onrejected The callback to execute when the Promise is rejected.\n     * @returns A Promise for the completion of which ever callback is executed.\n     */\n    then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): Promise<TResult1 | TResult2>;\n\n    /**\n     * Attaches a callback for only the rejection of the Promise.\n     * @param onrejected The callback to execute when the Promise is rejected.\n     * @returns A Promise for the completion of the callback.\n     */\n    catch<TResult = never>(onrejected?: ((reason: any) => TResult | PromiseLike<TResult>) | undefined | null): Promise<T | TResult>;\n}, interface Promise<T> {}, Promise: PromiseConstructor, interface Promise<T> {\n    readonly [Symbol.toStringTag]: string;\n}, interface Promise<T> {\n    /**\n     * Attaches a callback that is invoked when the Promise is settled (fulfilled or rejected). The\n     * resolved value cannot be modified from the callback.\n     * @param onfinally The callback to execute when the Promise is settled (fulfilled or rejected).\n     * @returns A Promise for the completion of the callback.\n     */\n    finally(onfinally?: (() => void) | undefined | null): Promise<T>;\n}"
+            },
+            "value": "export type GraphQLClient<Operations extends AllOperations> = <\n  Operation extends keyof Operations,\n>(\n  query: Operation,\n  options?: GraphQLQueryOptions<Operation, Operations>,\n) => Promise<\n  ResponseWithType<FetchResponseBody<ReturnData<Operation, Operations>>>\n>;"
+          },
+          "GraphQLQueryOptions": {
+            "filePath": "src/server/clients/types.ts",
+            "name": "GraphQLQueryOptions",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/clients/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "variables",
+                "value": "ApiClientRequestOptions<Operation, Operations>[\"variables\"]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/server/clients/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "apiVersion",
+                "value": "ApiVersion",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/server/clients/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "Record<string, any>",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "src/server/clients/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "tries",
+                "value": "number",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  apiVersion?: ApiVersion;\n  headers?: Record<string, any>;\n  tries?: number;\n}"
+          },
+          "ApiVersion": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    Unstable = \"unstable\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "April23",
+                "value": "2023-04"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "July23",
+                "value": "2023-07"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "October23",
+                "value": "2023-10"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "January24",
+                "value": "2024-01"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "jsDocTypeExamples": [
+      "FlowContext"
+    ],
+    "related": [
+      {
+        "name": "Admin API context",
+        "subtitle": "Interact with the Admin API.",
+        "url": "/docs/api/shopify-app-remix/apis/admin-api"
+      },
+      {
+        "name": "Flow action endpoints",
+        "subtitle": "Receive requests from Flow.",
+        "url": "/docs/apps/flow/actions/endpoints",
+        "type": "shopify"
+      }
+    ],
+    "examples": {
+      "description": "",
+      "exampleGroups": [
+        {
+          "title": "session",
+          "examples": [
+            {
+              "description": "Use the session associated with this request to use REST resources.",
+              "codeblock": {
+                "title": "Shopify session for the Flow request",
+                "tabs": [
+                  {
+                    "title": "/app/routes/flow.tsx",
+                    "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) =&gt; {\n  const { session, admin } = await authenticate.flow(request);\n\n  const products = await admin?.rest.resources.Product.all({ session });\n  // Use products\n\n  return new Response();\n};",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "title": "payload",
+          "examples": [
+            {
+              "description": "Get the request's POST payload.",
+              "codeblock": {
+                "title": "Flow payload",
+                "tabs": [
+                  {
+                    "title": "/app/routes/flow.tsx",
+                    "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) =&gt; {\n  const { payload } = await authenticate.flow(request);\n  return new Response();\n};",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "title": "admin",
+          "examples": [
+            {
+              "description": "Use the `admin` object in the context to interact with the Admin API.",
+              "codeblock": {
+                "title": "Flow admin context",
+                "tabs": [
+                  {
+                    "title": "/app/routes/flow.tsx",
+                    "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.flow(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
                     "language": "typescript"
                   }
                 ]
@@ -2419,101 +3169,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -2525,60 +3275,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -2590,35 +3340,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -2626,7 +3376,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -2634,7 +3384,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -2642,11 +3392,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "AdminApiContext": {
             "filePath": "src/server/clients/admin/types.ts",
@@ -2790,14 +3540,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -2805,7 +3555,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -2813,7 +3563,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -2821,7 +3571,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -2829,11 +3579,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -2863,7 +3613,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -3218,66 +3968,66 @@
                 "syntaxKind": "PropertySignature",
                 "name": "iss",
                 "value": "string",
-                "description": ""
+                "description": "The shop's admin domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "dest",
                 "value": "string",
-                "description": ""
+                "description": "The shop's domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "aud",
                 "value": "string",
-                "description": ""
+                "description": "The client ID of the receiving app."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sub",
                 "value": "string",
-                "description": ""
+                "description": "The User that the session token is intended for."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "exp",
                 "value": "number",
-                "description": ""
+                "description": "When the session token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "nbf",
                 "value": "number",
-                "description": ""
+                "description": "When the session token activates."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "iat",
                 "value": "number",
-                "description": ""
+                "description": "When the session token was issued."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "jti",
                 "value": "string",
-                "description": ""
+                "description": "A secure random UUID."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sid",
                 "value": "string",
-                "description": ""
+                "description": "A unique session ID per user and app."
               }
             ],
-            "value": "export interface JwtPayload {\n    iss: string;\n    dest: string;\n    aud: string;\n    sub: string;\n    exp: number;\n    nbf: number;\n    iat: number;\n    jti: string;\n    sid: string;\n}"
+            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           },
           "EnsureCORSFunction": {
             "filePath": "src/server/authenticate/helpers/ensure-cors-headers.ts",
@@ -3743,14 +4493,14 @@
               {
                 "filePath": "src/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@iterator@1701",
+                "name": "__@iterator@176",
                 "value": "() => IterableIterator<JSONValue>",
                 "description": "Iterator"
               },
               {
                 "filePath": "src/server/types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "__@unscopables@1703",
+                "name": "__@unscopables@178",
                 "value": "{ [x: number]: boolean; length?: boolean; toString?: boolean; toLocaleString?: boolean; pop?: boolean; push?: boolean; concat?: boolean; join?: boolean; reverse?: boolean; shift?: boolean; slice?: boolean; sort?: boolean; splice?: boolean; unshift?: boolean; indexOf?: boolean; lastIndexOf?: boolean; every?: boolean; some?: boolean; forEach?: boolean; map?: boolean; filter?: boolean; reduce?: boolean; reduceRight?: boolean; find?: boolean; findIndex?: boolean; fill?: boolean; copyWithin?: boolean; entries?: boolean; keys?: boolean; values?: boolean; includes?: boolean; flatMap?: boolean; flat?: boolean; [Symbol.iterator]?: boolean; readonly [Symbol.unscopables]?: boolean; at?: boolean; }",
                 "description": "Is an object whose properties have the value 'true' when they will be absent when used in a 'with' statement."
               },
@@ -3913,101 +4663,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -4019,60 +4769,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -4084,35 +4834,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -4120,7 +4870,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -4128,7 +4878,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -4136,11 +4886,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "WebhookAdminContext": {
             "filePath": "src/server/authenticate/webhooks/types.ts",
@@ -4376,14 +5126,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -4391,7 +5141,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -4399,7 +5149,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -4407,7 +5157,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -4415,11 +5165,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -4449,7 +5199,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -4681,7 +5431,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "RequireBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -4707,7 +5457,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -4723,24 +5473,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "hasActivePayment",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the user has an active payment method."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchases",
                 "value": "OneTimePurchase[]",
-                "description": ""
+                "description": "The one-time purchases the shop has."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscriptions",
                 "value": "AppSubscription[]",
-                "description": ""
+                "description": "The active subscriptions the shop has."
               }
             ],
-            "value": "export interface BillingCheckResponseObject {\n    hasActivePayment: boolean;\n    oneTimePurchases: OneTimePurchase[];\n    appSubscriptions: AppSubscription[];\n}"
+            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
           },
           "OneTimePurchase": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -4752,31 +5502,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the one-time purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "status",
                 "value": "string",
-                "description": ""
+                "description": "The status of the one-time purchase."
               }
             ],
-            "value": "export interface OneTimePurchase {\n    id: string;\n    name: string;\n    test: boolean;\n    status: string;\n}"
+            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "AppSubscription": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -4788,24 +5538,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the app subscription."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test subscription."
               }
             ],
-            "value": "export interface AppSubscription {\n    id: string;\n    name: string;\n    test: boolean;\n}"
+            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n}"
           },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -4824,7 +5574,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -5039,66 +5789,66 @@
                 "syntaxKind": "PropertySignature",
                 "name": "iss",
                 "value": "string",
-                "description": ""
+                "description": "The shop's admin domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "dest",
                 "value": "string",
-                "description": ""
+                "description": "The shop's domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "aud",
                 "value": "string",
-                "description": ""
+                "description": "The client ID of the receiving app."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sub",
                 "value": "string",
-                "description": ""
+                "description": "The User that the session token is intended for."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "exp",
                 "value": "number",
-                "description": ""
+                "description": "When the session token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "nbf",
                 "value": "number",
-                "description": ""
+                "description": "When the session token activates."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "iat",
                 "value": "number",
-                "description": ""
+                "description": "When the session token was issued."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "jti",
                 "value": "string",
-                "description": ""
+                "description": "A secure random UUID."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sid",
                 "value": "string",
-                "description": ""
+                "description": "A unique session ID per user and app."
               }
             ],
-            "value": "export interface JwtPayload {\n    iss: string;\n    dest: string;\n    aud: string;\n    sub: string;\n    exp: number;\n    nbf: number;\n    iat: number;\n    jti: string;\n    sid: string;\n}"
+            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           },
           "RedirectFunction": {
             "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
@@ -5409,9 +6159,16 @@
                 "name": "rest",
                 "value": "Resources",
                 "description": ""
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/index.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "flow",
+                "value": "ShopifyFlow",
+                "description": ""
               }
             ],
-            "value": "export interface Shopify<Params extends ConfigParams = ConfigParams, Resources extends ShopifyRestResources = ShopifyRestResources, Future extends FutureFlagOptions = FutureFlagOptions> {\n    config: ConfigInterface<Params>;\n    clients: ShopifyClients;\n    auth: ShopifyAuth<Future>;\n    session: ShopifySession;\n    utils: ShopifyUtils;\n    webhooks: ShopifyWebhooks;\n    billing: ShopifyBilling;\n    logger: ShopifyLogger;\n    rest: Resources;\n}"
+            "value": "export interface Shopify<Params extends ConfigParams = ConfigParams, Resources extends ShopifyRestResources = ShopifyRestResources, Future extends FutureFlagOptions = FutureFlagOptions> {\n    config: ConfigInterface<Params>;\n    clients: ShopifyClients;\n    auth: ShopifyAuth<Future>;\n    session: ShopifySession;\n    utils: ShopifyUtils;\n    webhooks: ShopifyWebhooks;\n    billing: ShopifyBilling;\n    logger: ShopifyLogger;\n    rest: Resources;\n    flow: ShopifyFlow;\n}"
           },
           "ConfigInterface": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/base-types.d.ts",
@@ -5925,16 +6682,400 @@
           },
           "BillingConfig": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
             "name": "BillingConfig",
-            "value": "Record<string, BillingConfigItem<Future>>",
+            "description": "Billing configuration options, indexed by an app-specific plan name.",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "name": "[plan: string]",
+                "value": "BillingConfigItem<Future>"
+              }
+            ],
+            "value": "export interface BillingConfig<Future extends FutureFlagOptions = FutureFlagOptions> {\n    /**\n     * An individual billing plan.\n     */\n    [plan: string]: BillingConfigItem<Future>;\n}"
+          },
+          "BillingConfigItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "BillingConfigItem",
+            "value": "FeatureEnabled<Future, 'unstable_lineItemBilling'> extends true ? BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan : BillingConfigLegacyItem",
+            "description": ""
+          },
+          "BillingConfigOneTimePlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigOneTimePlan",
             "description": "",
-            "members": []
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.OneTime",
+                "description": "Interval for this plan.\n\nMust be set to `OneTime`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `OneTime`.\n     */\n    interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
+          },
+          "BillingConfigSubscriptionLineItemPlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionLineItemPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The replacement behavior to use for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "lineItems",
+                "value": "(BillingConfigRecurringLineItem | BillingConfigUsageLineItem)[]",
+                "description": "The line items for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionLineItemPlan {\n    /**\n     * The replacement behavior to use for this plan.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The line items for this plan.\n     */\n    lineItems: (BillingConfigRecurringLineItem | BillingConfigUsageLineItem)[];\n}"
+          },
+          "BillingReplacementBehavior": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingReplacementBehavior",
+            "value": "export declare enum BillingReplacementBehavior {\n    ApplyImmediately = \"APPLY_IMMEDIATELY\",\n    ApplyOnNextBillingCycle = \"APPLY_ON_NEXT_BILLING_CYCLE\",\n    Standard = \"STANDARD\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "ApplyImmediately",
+                "value": "APPLY_IMMEDIATELY"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "ApplyOnNextBillingCycle",
+                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Standard",
+                "value": "STANDARD"
+              }
+            ]
+          },
+          "BillingConfigRecurringLineItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigRecurringLineItem",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
+                "description": "The recurring interval for this line item.\n\nMust be either `Every30Days` or `Annual`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "discount",
+                "value": "BillingConfigSubscriptionPlanDiscount",
+                "description": "An optional discount to apply for this line item.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to charge for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "The currency code for this line item."
+              }
+            ],
+            "value": "export interface BillingConfigRecurringLineItem extends BillingConfigLineItem {\n    /**\n     * The recurring interval for this line item.\n     *\n     * Must be either `Every30Days` or `Annual`.\n     */\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    /**\n     * An optional discount to apply for this line item.\n     */\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscount": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "durationLimitInIntervals",
+                "value": "number",
+                "description": "The number of intervals to apply the discount for.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "value",
+                "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
+                "description": "The discount to apply."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    /**\n     * The number of intervals to apply the discount for.\n     */\n    durationLimitInIntervals?: number;\n    /**\n     * The discount to apply.\n     */\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountAmount": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountAmount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "never",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountPercentage": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "never",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "number",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
+          },
+          "BillingConfigUsageLineItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigUsageLineItem",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": "The usage interval for this line item.\n\nMust be set to `Usage`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "terms",
+                "value": "string",
+                "description": "Usage terms for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to charge for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "The currency code for this line item."
+              }
+            ],
+            "value": "export interface BillingConfigUsageLineItem extends BillingConfigLineItem {\n    /**\n     * The usage interval for this line item.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * Usage terms for this line item.\n     */\n    terms: string;\n}"
+          },
+          "BillingConfigLegacyItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "BillingConfigLegacyItem",
+            "value": "BillingConfigOneTimePlan | BillingConfigSubscriptionPlan | BillingConfigUsagePlan",
+            "description": ""
+          },
+          "BillingConfigSubscriptionPlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "Exclude<RecurringBillingIntervals, BillingInterval.Usage>",
+                "description": "Recurring interval for this plan.\n\nMust be either `Every30Days` or `Annual`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The behavior to use when replacing an existing subscription with a new one.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "discount",
+                "value": "BillingConfigSubscriptionPlanDiscount",
+                "description": "The discount to apply to this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n    /**\n     * Recurring interval for this plan.\n     *\n     * Must be either `Every30Days` or `Annual`.\n     */\n    interval: Exclude<RecurringBillingIntervals, BillingInterval.Usage>;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The behavior to use when replacing an existing subscription with a new one.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n    /**\n     * The discount to apply to this plan.\n     */\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
+          },
+          "RecurringBillingIntervals": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RecurringBillingIntervals",
+            "value": "RecurringBillingIntervals",
+            "description": ""
+          },
+          "BillingConfigUsagePlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigUsagePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": "Interval for this plan.\n\nMust be set to `Usage`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "usageTerms",
+                "value": "string",
+                "description": "Usage terms for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The behavior to use when replacing an existing subscription with a new one.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * Usage terms for this plan.\n     */\n    usageTerms: string;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The behavior to use when replacing an existing subscription with a new one.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n}"
           },
           "LogFunction": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/base-types.d.ts",
             "name": "LogFunction",
-            "description": "",
+            "description": "A function used by the library to log events related to Shopify.",
             "params": [
               {
                 "name": "severity",
@@ -6082,17 +7223,17 @@
                 "syntaxKind": "PropertySignature",
                 "name": "body",
                 "value": "T",
-                "description": ""
+                "description": "The response body."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "headers",
                 "value": "Headers",
-                "description": ""
+                "description": "The response headers."
               }
             ],
-            "value": "export interface RequestReturn<T = unknown> {\n    body: T;\n    headers: Headers;\n}"
+            "value": "export interface RequestReturn<T = unknown> {\n    /**\n     * The response body.\n     */\n    body: T;\n    /**\n     * The response headers.\n     */\n    headers: Headers;\n}"
           },
           "GraphqlQueryOptions": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -6104,7 +7245,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "variables",
                 "value": "ApiClientRequestOptions<Operation, Operations>[\"variables\"]",
-                "description": "",
+                "description": "The variables to include in the operation.",
                 "isOptional": true
               },
               {
@@ -6112,7 +7253,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "headers",
                 "value": "Record<string, string | number>",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -6120,11 +7261,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "retries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times to retry the request if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GraphqlQueryOptions<Operation extends keyof Operations, Operations extends AllOperations> {\n    variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n    headers?: Record<string, string | number>;\n    retries?: number;\n}"
+            "value": "export interface GraphqlQueryOptions<Operation extends keyof Operations, Operations extends AllOperations> {\n    /**\n     * The variables to include in the operation.\n     */\n    variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n    /**\n     * Additional headers to be sent with the request.\n     */\n    headers?: Record<string, string | number>;\n    /**\n     * The maximum number of times to retry the request if it fails with a throttling or server error.\n     */\n    retries?: number;\n}"
           },
           "StorefrontClient": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/storefront/client.d.ts",
@@ -6269,14 +7410,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -6326,14 +7467,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -6408,14 +7549,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -6569,14 +7710,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -7072,14 +8213,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/webhooks/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -7102,14 +8243,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/webhooks/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -7293,21 +8434,21 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this check."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "plans",
                 "value": "string | string[]",
-                "description": ""
+                "description": "The plans to accept for this check."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               },
               {
@@ -7315,11 +8456,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "returnObject",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to return the full response object.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingCheckParams {\n    session: Session;\n    plans: string[] | string;\n    isTest?: boolean;\n    returnObject?: boolean;\n}"
+            "value": "export interface BillingCheckParams {\n    /**\n     * The session to use for this check.\n     */\n    session: Session;\n    /**\n     * The plans to accept for this check.\n     */\n    plans: string[] | string;\n    /**\n     * Whether to consider test purchases.\n     */\n    isTest?: boolean;\n    /**\n     * Whether to return the full response object.\n     */\n    returnObject?: boolean;\n}"
           },
           "BillingCheckResponse": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -7332,7 +8473,7 @@
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "BillingRequestParams",
-            "value": "{\n    session: Session;\n    plan: string;\n    isTest?: boolean;\n    returnUrl?: string;\n    returnObject?: boolean;\n} & RequestConfigOverrides",
+            "value": "{\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n    /**\n     * The plan to request.\n     */\n    plan: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    isTest?: boolean;\n    /**\n     * Override the return URL after the purchase is complete.\n     */\n    returnUrl?: string;\n    /**\n     * Whether to return the full response object.\n     */\n    returnObject?: boolean;\n} & RequestConfigOverrides",
             "description": ""
           },
           "RequestConfigOverrides": {
@@ -7341,267 +8482,6 @@
             "name": "RequestConfigOverrides",
             "value": "Partial<BillingConfigOneTimePlan> | Partial<BillingConfigSubscriptionPlan> | Partial<BillingConfigUsagePlan>",
             "description": ""
-          },
-          "BillingConfigOneTimePlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigOneTimePlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.OneTime",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    interval: BillingInterval.OneTime;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "BillingConfigSubscriptionPlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "Exclude<RecurringBillingIntervals, BillingInterval.Usage>",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "trialDays",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "replacementBehavior",
-                "value": "BillingReplacementBehavior",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "BillingConfigSubscriptionPlanDiscount",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n    interval: Exclude<RecurringBillingIntervals, BillingInterval.Usage>;\n    trialDays?: number;\n    replacementBehavior?: BillingReplacementBehavior;\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
-          },
-          "RecurringBillingIntervals": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "RecurringBillingIntervals",
-            "value": "RecurringBillingIntervals",
-            "description": ""
-          },
-          "BillingReplacementBehavior": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingReplacementBehavior",
-            "value": "export declare enum BillingReplacementBehavior {\n    ApplyImmediately = \"APPLY_IMMEDIATELY\",\n    ApplyOnNextBillingCycle = \"APPLY_ON_NEXT_BILLING_CYCLE\",\n    Standard = \"STANDARD\"\n}",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "ApplyImmediately",
-                "value": "APPLY_IMMEDIATELY"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "ApplyOnNextBillingCycle",
-                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Standard",
-                "value": "STANDARD"
-              }
-            ]
-          },
-          "BillingConfigSubscriptionPlanDiscount": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    durationLimitInIntervals?: number;\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    amount: number;\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    amount?: never;\n    percentage: number;\n}"
-          },
-          "BillingConfigUsagePlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigUsagePlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Usage",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "usageTerms",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "trialDays",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "replacementBehavior",
-                "value": "BillingReplacementBehavior",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n    interval: BillingInterval.Usage;\n    usageTerms: string;\n    trialDays?: number;\n    replacementBehavior?: BillingReplacementBehavior;\n}"
           },
           "BillingRequestResponse": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -7620,14 +8500,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "confirmationUrl",
                 "value": "string",
-                "description": ""
+                "description": "The confirmation URL for this request."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchase",
                 "value": "OneTimePurchase",
-                "description": "",
+                "description": "The one-time purchase created by this request.",
                 "isOptional": true
               },
               {
@@ -7635,11 +8515,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscription",
                 "value": "AppSubscription",
-                "description": "",
+                "description": "The app subscription created by this request.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingRequestResponseObject {\n    confirmationUrl: string;\n    oneTimePurchase?: OneTimePurchase;\n    appSubscription?: AppSubscription;\n}"
+            "value": "export interface BillingRequestResponseObject {\n    /**\n     * The confirmation URL for this request.\n     */\n    confirmationUrl: string;\n    /**\n     * The one-time purchase created by this request.\n     */\n    oneTimePurchase?: OneTimePurchase;\n    /**\n     * The app subscription created by this request.\n     */\n    appSubscription?: AppSubscription;\n}"
           },
           "BillingCancelParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -7651,21 +8531,21 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this request."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "subscriptionId",
                 "value": "string",
-                "description": ""
+                "description": "The subscription ID to cancel."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "prorate",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to prorate the cancellation.",
                 "isOptional": true
               },
               {
@@ -7673,11 +8553,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingCancelParams {\n    session: Session;\n    subscriptionId: string;\n    prorate?: boolean;\n    isTest?: boolean;\n}"
+            "value": "export interface BillingCancelParams {\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n    /**\n     * The subscription ID to cancel.\n     */\n    subscriptionId: string;\n    /**\n     * Whether to prorate the cancellation.\n     */\n    prorate?: boolean;\n    /**\n     * Whether to consider test purchases.\n     */\n    isTest?: boolean;\n}"
           },
           "BillingSubscriptionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -7689,10 +8569,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this request."
               }
             ],
-            "value": "export interface BillingSubscriptionParams {\n    session: Session;\n}"
+            "value": "export interface BillingSubscriptionParams {\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n}"
           },
           "ActiveSubscriptions": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -7800,6 +8680,112 @@
             "value": "Record<string, any>",
             "description": "",
             "members": []
+          },
+          "ShopifyFlow": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/index.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyFlow",
+            "value": "ReturnType<typeof shopifyFlow>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/index.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "validate",
+                "value": "({ rawBody, ...adapterArgs }: FlowValidateParams) => Promise<FlowValidationInvalid | FlowValidationValid>",
+                "description": ""
+              }
+            ]
+          },
+          "FlowValidateParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidateParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawBody",
+                "value": "string",
+                "description": "The raw body of the request."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The raw request, from the app's framework."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface FlowValidateParams extends AdapterArgs {\n    /**\n     * The raw body of the request.\n     */\n    rawBody: string;\n}"
+          },
+          "FlowValidationInvalid": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidationInvalid",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "valid",
+                "value": "false",
+                "description": "Whether the request is a valid Flow request from Shopify."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "reason",
+                "value": "FlowValidationErrorReason",
+                "description": "The reason why the request is not valid."
+              }
+            ],
+            "value": "export interface FlowValidationInvalid {\n    /**\n     * Whether the request is a valid Flow request from Shopify.\n     */\n    valid: false;\n    /**\n     * The reason why the request is not valid.\n     */\n    reason: FlowValidationErrorReason;\n}"
+          },
+          "FlowValidationErrorReason": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "FlowValidationErrorReason",
+            "value": "export declare enum FlowValidationErrorReason {\n    MissingBody = \"missing_body\",\n    MissingHmac = \"missing_hmac\",\n    InvalidHmac = \"invalid_hmac\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "MissingBody",
+                "value": "missing_body"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "MissingHmac",
+                "value": "missing_hmac"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "InvalidHmac",
+                "value": "invalid_hmac"
+              }
+            ]
+          },
+          "FlowValidationValid": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidationValid",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "valid",
+                "value": "true",
+                "description": "Whether the request is a valid Flow request from Shopify."
+              }
+            ],
+            "value": "export interface FlowValidationValid {\n    /**\n     * Whether the request is a valid Flow request from Shopify.\n     */\n    valid: true;\n}"
           }
         }
       }
@@ -8095,101 +9081,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -8201,60 +9187,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -8266,35 +9252,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -8302,7 +9288,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -8310,7 +9296,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -8318,11 +9304,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "GetRequestParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -8334,14 +9320,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -8349,7 +9335,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -8357,7 +9343,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -8365,7 +9351,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -8373,11 +9359,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -8407,7 +9393,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -8854,7 +9840,7 @@
               "name": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>",
               "value": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>"
             },
-            "value": "export function shopifyApp<\n  Config extends AppConfigArg<Resources, Storage>,\n  Resources extends ShopifyRestResources,\n  Storage extends SessionStorage,\n>(appConfig: Config): ShopifyApp<Config> {\n  const api = deriveApi(appConfig);\n  const config = deriveConfig<Storage>(appConfig, api.config);\n  const logger = overrideLogger(api.logger);\n\n  if (appConfig.webhooks) {\n    api.webhooks.addHandlers(appConfig.webhooks);\n  }\n\n  const params: BasicParams = {api, config, logger};\n  const authStrategy = authStrategyFactory<Config, Resources>({\n    ...params,\n    strategy:\n      config.future.unstable_newEmbeddedAuthStrategy && config.isEmbeddedApp\n        ? new TokenExchangeStrategy(params)\n        : new AuthCodeFlowStrategy(params),\n  });\n\n  const shopify:\n    | AdminApp<Config>\n    | AppStoreApp<Config>\n    | SingleMerchantApp<Config> = {\n    sessionStorage: config.sessionStorage,\n    addDocumentResponseHeaders: addDocumentResponseHeadersFactory(params),\n    registerWebhooks: registerWebhooksFactory(params),\n    authenticate: {\n      admin: authStrategy,\n      public: authenticatePublicFactory<Config['future'], Resources>(params),\n      webhook: authenticateWebhookFactory<\n        Config['future'],\n        Resources,\n        keyof Config['webhooks'] | MandatoryTopics\n      >(params),\n    },\n    unauthenticated: {\n      admin: unauthenticatedAdminContextFactory(params),\n      storefront: unauthenticatedStorefrontContextFactory(params),\n    },\n  };\n\n  if (\n    isAppStoreApp(shopify, appConfig) ||\n    isSingleMerchantApp(shopify, appConfig)\n  ) {\n    shopify.login = loginFactory(params);\n  }\n\n  return shopify as ShopifyApp<Config>;\n}",
+            "value": "export function shopifyApp<\n  Config extends AppConfigArg<Resources, Storage>,\n  Resources extends ShopifyRestResources,\n  Storage extends SessionStorage,\n>(appConfig: Config): ShopifyApp<Config> {\n  const api = deriveApi(appConfig);\n  const config = deriveConfig<Storage>(appConfig, api.config);\n  const logger = overrideLogger(api.logger);\n\n  if (appConfig.webhooks) {\n    api.webhooks.addHandlers(appConfig.webhooks);\n  }\n\n  const params: BasicParams = {api, config, logger};\n  const authStrategy = authStrategyFactory<Config, Resources>({\n    ...params,\n    strategy:\n      config.future.unstable_newEmbeddedAuthStrategy && config.isEmbeddedApp\n        ? new TokenExchangeStrategy(params)\n        : new AuthCodeFlowStrategy(params),\n  });\n\n  const shopify:\n    | AdminApp<Config>\n    | AppStoreApp<Config>\n    | SingleMerchantApp<Config> = {\n    sessionStorage: config.sessionStorage,\n    addDocumentResponseHeaders: addDocumentResponseHeadersFactory(params),\n    registerWebhooks: registerWebhooksFactory(params),\n    authenticate: {\n      admin: authStrategy,\n      flow: authenticateFlowFactory<Resources>(params),\n      public: authenticatePublicFactory<Config['future'], Resources>(params),\n      webhook: authenticateWebhookFactory<\n        Config['future'],\n        Resources,\n        keyof Config['webhooks'] | MandatoryTopics\n      >(params),\n    },\n    unauthenticated: {\n      admin: unauthenticatedAdminContextFactory(params),\n      storefront: unauthenticatedStorefrontContextFactory(params),\n    },\n  };\n\n  if (\n    isAppStoreApp(shopify, appConfig) ||\n    isSingleMerchantApp(shopify, appConfig)\n  ) {\n    shopify.login = loginFactory(params);\n  }\n\n  return shopify as ShopifyApp<Config>;\n}",
             "examples": [
               {
                 "title": "The minimum viable configuration",
@@ -9020,7 +10006,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "apiKey",
                 "value": "string",
-                "description": "",
+                "description": "The API key for your app.\n\nAlso known as Client ID in your Partner Dashboard.",
                 "isOptional": true
               },
               {
@@ -9028,14 +10014,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "apiSecretKey",
                 "value": "string",
-                "description": ""
+                "description": "The API secret key for your app.\n\nAlso known as Client Secret in your Partner Dashboard."
               },
               {
                 "filePath": "src/server/config-types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scopes",
                 "value": "string[] | AuthScopes",
-                "description": "",
+                "description": "The scopes your app needs to access the API.",
                 "isOptional": true
               },
               {
@@ -9043,7 +10029,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "adminApiAccessToken",
                 "value": "string",
-                "description": "",
+                "description": "An app-wide API access token.\n\nOnly applies to custom apps.",
                 "isOptional": true
               },
               {
@@ -9051,7 +10037,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "userAgentPrefix",
                 "value": "string",
-                "description": "",
+                "description": "The user agent prefix to use for API requests.",
                 "isOptional": true
               },
               {
@@ -9059,7 +10045,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "privateAppStorefrontAccessToken",
                 "value": "string",
-                "description": "",
+                "description": "An app-wide API access token for the storefront API.\n\nOnly applies to custom apps.",
                 "isOptional": true
               },
               {
@@ -9067,7 +10053,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "customShopDomains",
                 "value": "(string | RegExp)[]",
-                "description": "",
+                "description": "Override values for Shopify shop domains.",
                 "isOptional": true
               },
               {
@@ -9075,7 +10061,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "billing",
                 "value": "BillingConfig<Future>",
-                "description": "",
+                "description": "Billing configurations for the app.",
                 "isOptional": true
               },
               {
@@ -9083,7 +10069,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "restResources",
                 "value": "Resources",
-                "description": "",
+                "description": "REST resources to access the Admin API.\n\nYou can import these from `@shopify/shopify-api/rest/admin/*`.",
                 "isOptional": true
               },
               {
@@ -9091,7 +10077,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "logger",
                 "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
-                "description": "",
+                "description": "Customization options for Shopify logs.",
                 "isOptional": true
               }
             ],
@@ -9165,101 +10151,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -9271,60 +10257,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -9336,35 +10322,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -9372,7 +10358,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -9380,7 +10366,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -9388,11 +10374,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "AdminApiContext": {
             "filePath": "src/server/clients/admin/types.ts",
@@ -9536,14 +10522,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -9551,7 +10537,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -9559,7 +10545,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -9567,7 +10553,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -9575,11 +10561,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -9609,7 +10595,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -9762,16 +10748,400 @@
           },
           "BillingConfig": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
             "name": "BillingConfig",
-            "value": "Record<string, BillingConfigItem<Future>>",
+            "description": "Billing configuration options, indexed by an app-specific plan name.",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "name": "[plan: string]",
+                "value": "BillingConfigItem<Future>"
+              }
+            ],
+            "value": "export interface BillingConfig<Future extends FutureFlagOptions = FutureFlagOptions> {\n    /**\n     * An individual billing plan.\n     */\n    [plan: string]: BillingConfigItem<Future>;\n}"
+          },
+          "BillingConfigItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "BillingConfigItem",
+            "value": "FeatureEnabled<Future, 'unstable_lineItemBilling'> extends true ? BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan : BillingConfigLegacyItem",
+            "description": ""
+          },
+          "BillingConfigOneTimePlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigOneTimePlan",
             "description": "",
-            "members": []
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.OneTime",
+                "description": "Interval for this plan.\n\nMust be set to `OneTime`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `OneTime`.\n     */\n    interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
+          },
+          "BillingConfigSubscriptionLineItemPlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionLineItemPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The replacement behavior to use for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "lineItems",
+                "value": "(BillingConfigRecurringLineItem | BillingConfigUsageLineItem)[]",
+                "description": "The line items for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionLineItemPlan {\n    /**\n     * The replacement behavior to use for this plan.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The line items for this plan.\n     */\n    lineItems: (BillingConfigRecurringLineItem | BillingConfigUsageLineItem)[];\n}"
+          },
+          "BillingReplacementBehavior": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingReplacementBehavior",
+            "value": "export declare enum BillingReplacementBehavior {\n    ApplyImmediately = \"APPLY_IMMEDIATELY\",\n    ApplyOnNextBillingCycle = \"APPLY_ON_NEXT_BILLING_CYCLE\",\n    Standard = \"STANDARD\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "ApplyImmediately",
+                "value": "APPLY_IMMEDIATELY"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "ApplyOnNextBillingCycle",
+                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+                "name": "Standard",
+                "value": "STANDARD"
+              }
+            ]
+          },
+          "BillingConfigRecurringLineItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigRecurringLineItem",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
+                "description": "The recurring interval for this line item.\n\nMust be either `Every30Days` or `Annual`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "discount",
+                "value": "BillingConfigSubscriptionPlanDiscount",
+                "description": "An optional discount to apply for this line item.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to charge for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "The currency code for this line item."
+              }
+            ],
+            "value": "export interface BillingConfigRecurringLineItem extends BillingConfigLineItem {\n    /**\n     * The recurring interval for this line item.\n     *\n     * Must be either `Every30Days` or `Annual`.\n     */\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    /**\n     * An optional discount to apply for this line item.\n     */\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscount": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "durationLimitInIntervals",
+                "value": "number",
+                "description": "The number of intervals to apply the discount for.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "value",
+                "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
+                "description": "The discount to apply."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    /**\n     * The number of intervals to apply the discount for.\n     */\n    durationLimitInIntervals?: number;\n    /**\n     * The discount to apply.\n     */\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountAmount": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountAmount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "never",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountPercentage": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "never",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "number",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
+          },
+          "BillingConfigUsageLineItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigUsageLineItem",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": "The usage interval for this line item.\n\nMust be set to `Usage`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "terms",
+                "value": "string",
+                "description": "Usage terms for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to charge for this line item."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "The currency code for this line item."
+              }
+            ],
+            "value": "export interface BillingConfigUsageLineItem extends BillingConfigLineItem {\n    /**\n     * The usage interval for this line item.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * Usage terms for this line item.\n     */\n    terms: string;\n}"
+          },
+          "BillingConfigLegacyItem": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "BillingConfigLegacyItem",
+            "value": "BillingConfigOneTimePlan | BillingConfigSubscriptionPlan | BillingConfigUsagePlan",
+            "description": ""
+          },
+          "BillingConfigSubscriptionPlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "Exclude<RecurringBillingIntervals, BillingInterval.Usage>",
+                "description": "Recurring interval for this plan.\n\nMust be either `Every30Days` or `Annual`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The behavior to use when replacing an existing subscription with a new one.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "discount",
+                "value": "BillingConfigSubscriptionPlanDiscount",
+                "description": "The discount to apply to this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n    /**\n     * Recurring interval for this plan.\n     *\n     * Must be either `Every30Days` or `Annual`.\n     */\n    interval: Exclude<RecurringBillingIntervals, BillingInterval.Usage>;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The behavior to use when replacing an existing subscription with a new one.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n    /**\n     * The discount to apply to this plan.\n     */\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
+          },
+          "RecurringBillingIntervals": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RecurringBillingIntervals",
+            "value": "RecurringBillingIntervals",
+            "description": ""
+          },
+          "BillingConfigUsagePlan": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+            "name": "BillingConfigUsagePlan",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "interval",
+                "value": "BillingInterval.Usage",
+                "description": "Interval for this plan.\n\nMust be set to `Usage`."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "usageTerms",
+                "value": "string",
+                "description": "Usage terms for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "trialDays",
+                "value": "number",
+                "description": "How many trial days to give before charging for this plan.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "replacementBehavior",
+                "value": "BillingReplacementBehavior",
+                "description": "The behavior to use when replacing an existing subscription with a new one.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "Amount to charge for this plan."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "currencyCode",
+                "value": "string",
+                "description": "Currency code for this plan."
+              }
+            ],
+            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * Usage terms for this plan.\n     */\n    usageTerms: string;\n    /**\n     * How many trial days to give before charging for this plan.\n     */\n    trialDays?: number;\n    /**\n     * The behavior to use when replacing an existing subscription with a new one.\n     */\n    replacementBehavior?: BillingReplacementBehavior;\n}"
           },
           "LogFunction": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/base-types.d.ts",
             "name": "LogFunction",
-            "description": "",
+            "description": "A function used by the library to log events related to Shopify.",
             "params": [
               {
                 "name": "severity",
@@ -10046,12 +11416,35 @@
                     "description": "",
                     "tabs": [
                       {
-                        "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
-                        "title": "/app/shopify.server.ts"
-                      },
-                      {
                         "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderFunctionArgs) {\n  const {admin, session, sessionToken, billing} = authenticate.admin(request);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
                         "title": "/app/routes/**\\/*.jsx"
+                      },
+                      {
+                        "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "flow",
+                "value": "AuthenticateFlow<RestResourcesType<Config>>",
+                "description": "Authenticate a Flow extension Request and get back an authenticated context, containing an admin context to access the API, and the payload of the request.\n\nIf there is no session for the Request, this will return an HTTP 400 error.\n\nNote that this will always be a POST request.",
+                "examples": [
+                  {
+                    "title": "Authenticating a Flow extension request",
+                    "description": "",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const {admin, session, payload} = authenticate.flow(request);\n\n  // Perform flow extension logic\n\n  // Return a 200 response\n  return null;\n}",
+                        "title": "/app/routes/**\\/*.jsx"
+                      },
+                      {
+                        "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
                       }
                     ]
                   }
@@ -10100,10 +11493,10 @@
                 ]
               }
             ],
-            "value": "interface Authenticate<Config extends AppConfigArg> {\n  /**\n   * Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n   *\n   * Examples of when to use this are requests from your app's UI, or requests from admin extensions.\n   *\n   * If there is no session for the Request, this will redirect the merchant to correct auth flows.\n   *\n   * @example\n   * <caption>Authenticating a request for an embedded app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {admin, session, sessionToken, billing} = authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a public request and get back a session token.\n   *\n   * @example\n   * <caption>Authenticating a request from a checkout extension</caption>\n   *\n   * ```ts\n   * // /app/routes/api/checkout.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   * import { getWidgets } from \"~/db/widgets\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {sessionToken} = authenticate.public.checkout(request);\n   *\n   *   return json(await getWidgets(sessionToken));\n   * }\n   * ```\n   */\n  public: AuthenticatePublic<Config['future']>;\n\n  /**\n   * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request\n   *\n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *    APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *       callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop, session } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       if (session) {\n   *         await db.session.deleteMany({ where: { shop } });\n   *       }\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhook: AuthenticateWebhook<\n    Config['future'],\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >;\n}"
+            "value": "interface Authenticate<Config extends AppConfigArg> {\n  /**\n   * Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n   *\n   * Examples of when to use this are requests from your app's UI, or requests from admin extensions.\n   *\n   * If there is no session for the Request, this will redirect the merchant to correct auth flows.\n   *\n   * @example\n   * <caption>Authenticating a request for an embedded app.</caption>\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {admin, session, sessionToken, billing} = authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a Flow extension Request and get back an authenticated context, containing an admin context to access\n   * the API, and the payload of the request.\n   *\n   * If there is no session for the Request, this will return an HTTP 400 error.\n   *\n   * Note that this will always be a POST request.\n   *\n   * @example\n   * <caption>Authenticating a Flow extension request.</caption>\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { ActionFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const {admin, session, payload} = authenticate.flow(request);\n   *\n   *   // Perform flow extension logic\n   *\n   *   // Return a 200 response\n   *   return null;\n   * }\n   * ```\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  flow: AuthenticateFlow<RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a public request and get back a session token.\n   *\n   * @example\n   * <caption>Authenticating a request from a checkout extension</caption>\n   *\n   * ```ts\n   * // /app/routes/api/checkout.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   * import { getWidgets } from \"~/db/widgets\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {sessionToken} = authenticate.public.checkout(request);\n   *\n   *   return json(await getWidgets(sessionToken));\n   * }\n   * ```\n   */\n  public: AuthenticatePublic<Config['future']>;\n\n  /**\n   * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request\n   *\n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *    APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *       callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop, session } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       if (session) {\n   *         await db.session.deleteMany({ where: { shop } });\n   *       }\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhook: AuthenticateWebhook<\n    Config['future'],\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >;\n}"
           },
           "AuthenticateAdmin": {
-            "filePath": "src/server/types.ts",
+            "filePath": "src/server/authenticate/admin/types.ts",
             "name": "AuthenticateAdmin",
             "description": "",
             "params": [
@@ -10111,16 +11504,16 @@
                 "name": "request",
                 "description": "",
                 "value": "Request",
-                "filePath": "src/server/types.ts"
+                "filePath": "src/server/authenticate/admin/types.ts"
               }
             ],
             "returns": {
-              "filePath": "src/server/types.ts",
+              "filePath": "src/server/authenticate/admin/types.ts",
               "description": "",
               "name": "Promise<AdminContext<Config, Resources>>",
               "value": "Promise<AdminContext<Config, Resources>>"
             },
-            "value": "type AuthenticateAdmin<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> = (request: Request) => Promise<AdminContext<Config, Resources>>;"
+            "value": "export type AuthenticateAdmin<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> = (request: Request) => Promise<AdminContext<Config, Resources>>;"
           },
           "AdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -10319,7 +11712,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description> When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "RequireBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -10345,7 +11738,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -10361,24 +11754,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "hasActivePayment",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the user has an active payment method."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchases",
                 "value": "OneTimePurchase[]",
-                "description": ""
+                "description": "The one-time purchases the shop has."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscriptions",
                 "value": "AppSubscription[]",
-                "description": ""
+                "description": "The active subscriptions the shop has."
               }
             ],
-            "value": "export interface BillingCheckResponseObject {\n    hasActivePayment: boolean;\n    oneTimePurchases: OneTimePurchase[];\n    appSubscriptions: AppSubscription[];\n}"
+            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
           },
           "OneTimePurchase": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -10390,31 +11783,31 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the one-time purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test purchase."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "status",
                 "value": "string",
-                "description": ""
+                "description": "The status of the one-time purchase."
               }
             ],
-            "value": "export interface OneTimePurchase {\n    id: string;\n    name: string;\n    test: boolean;\n    status: string;\n}"
+            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "AppSubscription": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -10426,24 +11819,24 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The ID of the app subscription."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "name",
                 "value": "string",
-                "description": ""
+                "description": "The name of the purchased plan."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "test",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether this is a test subscription."
               }
             ],
-            "value": "export interface AppSubscription {\n    id: string;\n    name: string;\n    test: boolean;\n}"
+            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n}"
           },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -10462,7 +11855,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
@@ -10677,66 +12070,66 @@
                 "syntaxKind": "PropertySignature",
                 "name": "iss",
                 "value": "string",
-                "description": ""
+                "description": "The shop's admin domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "dest",
                 "value": "string",
-                "description": ""
+                "description": "The shop's domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "aud",
                 "value": "string",
-                "description": ""
+                "description": "The client ID of the receiving app."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sub",
                 "value": "string",
-                "description": ""
+                "description": "The User that the session token is intended for."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "exp",
                 "value": "number",
-                "description": ""
+                "description": "When the session token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "nbf",
                 "value": "number",
-                "description": ""
+                "description": "When the session token activates."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "iat",
                 "value": "number",
-                "description": ""
+                "description": "When the session token was issued."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "jti",
                 "value": "string",
-                "description": ""
+                "description": "A secure random UUID."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "sid",
                 "value": "string",
-                "description": ""
+                "description": "A unique session ID per user and app."
               }
             ],
-            "value": "export interface JwtPayload {\n    iss: string;\n    dest: string;\n    aud: string;\n    sub: string;\n    exp: number;\n    nbf: number;\n    iat: number;\n    jti: string;\n    sid: string;\n}"
+            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           },
           "RedirectFunction": {
             "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
@@ -10785,6 +12178,91 @@
             "name": "RestResourcesType",
             "value": "Config['restResources'] extends ShopifyRestResources\n    ? Config['restResources']\n    : ShopifyRestResources",
             "description": ""
+          },
+          "AuthenticateFlow": {
+            "filePath": "src/server/authenticate/flow/types.ts",
+            "name": "AuthenticateFlow",
+            "description": "",
+            "params": [
+              {
+                "name": "request",
+                "description": "",
+                "value": "Request",
+                "filePath": "src/server/authenticate/flow/types.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "src/server/authenticate/flow/types.ts",
+              "description": "",
+              "name": "Promise<FlowContext<Resources>>",
+              "value": "Promise<FlowContext<Resources>>"
+            },
+            "value": "export type AuthenticateFlow<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> = (request: Request) => Promise<FlowContext<Resources>>;"
+          },
+          "FlowContext": {
+            "filePath": "src/server/authenticate/flow/types.ts",
+            "name": "FlowContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "A session with an offline token for the shop.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "Shopify session for the Flow request",
+                    "description": "Use the session associated with this request to use REST resources.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { session, admin } = await authenticate.flow(request);\n\n  const products = await admin?.rest.resources.Product.all({ session });\n  // Use products\n\n  return new Response();\n};",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "payload",
+                "value": "any",
+                "description": "The payload from the Flow request.",
+                "examples": [
+                  {
+                    "title": "Flow payload",
+                    "description": "Get the request's POST payload.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { payload } = await authenticate.flow(request);\n  return new Response();\n};",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "src/server/authenticate/flow/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "admin",
+                "value": "AdminApiContext<Resources>",
+                "description": "An admin context for the Flow request.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "Flow admin context",
+                    "description": "Use the `admin` object in the context to interact with the Admin API.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.flow(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "/app/routes/flow.tsx"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface FlowContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Shopify session for the Flow request.</caption>\n   * <description>Use the session associated with this request to use REST resources.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunction } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action: ActionFunction = async ({ request }) => {\n   *   const { session, admin } = await authenticate.flow(request);\n   *\n   *   const products = await admin?.rest.resources.Product.all({ session });\n   *   // Use products\n   *\n   *   return new Response();\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * The payload from the Flow request.\n   *\n   * @example\n   * <caption>Flow payload.</caption>\n   * <description>Get the request's POST payload.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunction } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action: ActionFunction = async ({ request }) => {\n   *   const { payload } = await authenticate.flow(request);\n   *   return new Response();\n   * };\n   * ```\n   */\n  payload: any;\n\n  /**\n   * An admin context for the Flow request.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Flow admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.flow(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
           },
           "AuthenticatePublic": {
             "filePath": "src/server/authenticate/public/types.ts",
@@ -11553,14 +13031,14 @@
               {
                 "filePath": "src/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@iterator@1701",
+                "name": "__@iterator@176",
                 "value": "() => IterableIterator<JSONValue>",
                 "description": "Iterator"
               },
               {
                 "filePath": "src/server/types.ts",
                 "syntaxKind": "PropertySignature",
-                "name": "__@unscopables@1703",
+                "name": "__@unscopables@178",
                 "value": "{ [x: number]: boolean; length?: boolean; toString?: boolean; toLocaleString?: boolean; pop?: boolean; push?: boolean; concat?: boolean; join?: boolean; reverse?: boolean; shift?: boolean; slice?: boolean; sort?: boolean; splice?: boolean; unshift?: boolean; indexOf?: boolean; lastIndexOf?: boolean; every?: boolean; some?: boolean; forEach?: boolean; map?: boolean; filter?: boolean; reduce?: boolean; reduceRight?: boolean; find?: boolean; findIndex?: boolean; fill?: boolean; copyWithin?: boolean; entries?: boolean; keys?: boolean; values?: boolean; includes?: boolean; flatMap?: boolean; flat?: boolean; [Symbol.iterator]?: boolean; readonly [Symbol.unscopables]?: boolean; at?: boolean; }",
                 "description": "Is an object whose properties have the value 'true' when they will be absent when used in a 'with' statement."
               },
@@ -11980,9 +13458,16 @@
                 "name": "rest",
                 "value": "Resources",
                 "description": ""
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/index.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "flow",
+                "value": "ShopifyFlow",
+                "description": ""
               }
             ],
-            "value": "export interface Shopify<Params extends ConfigParams = ConfigParams, Resources extends ShopifyRestResources = ShopifyRestResources, Future extends FutureFlagOptions = FutureFlagOptions> {\n    config: ConfigInterface<Params>;\n    clients: ShopifyClients;\n    auth: ShopifyAuth<Future>;\n    session: ShopifySession;\n    utils: ShopifyUtils;\n    webhooks: ShopifyWebhooks;\n    billing: ShopifyBilling;\n    logger: ShopifyLogger;\n    rest: Resources;\n}"
+            "value": "export interface Shopify<Params extends ConfigParams = ConfigParams, Resources extends ShopifyRestResources = ShopifyRestResources, Future extends FutureFlagOptions = FutureFlagOptions> {\n    config: ConfigInterface<Params>;\n    clients: ShopifyClients;\n    auth: ShopifyAuth<Future>;\n    session: ShopifySession;\n    utils: ShopifyUtils;\n    webhooks: ShopifyWebhooks;\n    billing: ShopifyBilling;\n    logger: ShopifyLogger;\n    rest: Resources;\n    flow: ShopifyFlow;\n}"
           },
           "ConfigInterface": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/base-types.d.ts",
@@ -12591,17 +14076,17 @@
                 "syntaxKind": "PropertySignature",
                 "name": "body",
                 "value": "T",
-                "description": ""
+                "description": "The response body."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "headers",
                 "value": "Headers",
-                "description": ""
+                "description": "The response headers."
               }
             ],
-            "value": "export interface RequestReturn<T = unknown> {\n    body: T;\n    headers: Headers;\n}"
+            "value": "export interface RequestReturn<T = unknown> {\n    /**\n     * The response body.\n     */\n    body: T;\n    /**\n     * The response headers.\n     */\n    headers: Headers;\n}"
           },
           "GraphqlQueryOptions": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -12613,7 +14098,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "variables",
                 "value": "ApiClientRequestOptions<Operation, Operations>[\"variables\"]",
-                "description": "",
+                "description": "The variables to include in the operation.",
                 "isOptional": true
               },
               {
@@ -12621,7 +14106,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "headers",
                 "value": "Record<string, string | number>",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -12629,11 +14114,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "retries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times to retry the request if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GraphqlQueryOptions<Operation extends keyof Operations, Operations extends AllOperations> {\n    variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n    headers?: Record<string, string | number>;\n    retries?: number;\n}"
+            "value": "export interface GraphqlQueryOptions<Operation extends keyof Operations, Operations extends AllOperations> {\n    /**\n     * The variables to include in the operation.\n     */\n    variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n    /**\n     * Additional headers to be sent with the request.\n     */\n    headers?: Record<string, string | number>;\n    /**\n     * The maximum number of times to retry the request if it fails with a throttling or server error.\n     */\n    retries?: number;\n}"
           },
           "StorefrontClient": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/storefront/client.d.ts",
@@ -12778,14 +14263,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -12835,14 +14320,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -12917,14 +14402,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -13078,14 +14563,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -13573,14 +15058,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/webhooks/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -13603,14 +15088,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "rawRequest",
                 "value": "AdapterRequest",
-                "description": ""
+                "description": "The raw request, from the app's framework."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/webhooks/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "rawResponse",
                 "value": "AdapterResponse",
-                "description": "",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
                 "isOptional": true
               }
             ],
@@ -13794,21 +15279,21 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this check."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "plans",
                 "value": "string | string[]",
-                "description": ""
+                "description": "The plans to accept for this check."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               },
               {
@@ -13816,11 +15301,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "returnObject",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to return the full response object.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingCheckParams {\n    session: Session;\n    plans: string[] | string;\n    isTest?: boolean;\n    returnObject?: boolean;\n}"
+            "value": "export interface BillingCheckParams {\n    /**\n     * The session to use for this check.\n     */\n    session: Session;\n    /**\n     * The plans to accept for this check.\n     */\n    plans: string[] | string;\n    /**\n     * Whether to consider test purchases.\n     */\n    isTest?: boolean;\n    /**\n     * Whether to return the full response object.\n     */\n    returnObject?: boolean;\n}"
           },
           "BillingCheckResponse": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -13833,7 +15318,7 @@
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "BillingRequestParams",
-            "value": "{\n    session: Session;\n    plan: string;\n    isTest?: boolean;\n    returnUrl?: string;\n    returnObject?: boolean;\n} & RequestConfigOverrides",
+            "value": "{\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n    /**\n     * The plan to request.\n     */\n    plan: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    isTest?: boolean;\n    /**\n     * Override the return URL after the purchase is complete.\n     */\n    returnUrl?: string;\n    /**\n     * Whether to return the full response object.\n     */\n    returnObject?: boolean;\n} & RequestConfigOverrides",
             "description": ""
           },
           "RequestConfigOverrides": {
@@ -13842,267 +15327,6 @@
             "name": "RequestConfigOverrides",
             "value": "Partial<BillingConfigOneTimePlan> | Partial<BillingConfigSubscriptionPlan> | Partial<BillingConfigUsagePlan>",
             "description": ""
-          },
-          "BillingConfigOneTimePlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigOneTimePlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.OneTime",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    interval: BillingInterval.OneTime;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "BillingConfigSubscriptionPlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "Exclude<RecurringBillingIntervals, BillingInterval.Usage>",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "trialDays",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "replacementBehavior",
-                "value": "BillingReplacementBehavior",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "BillingConfigSubscriptionPlanDiscount",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlan extends BillingConfigPlan {\n    interval: Exclude<RecurringBillingIntervals, BillingInterval.Usage>;\n    trialDays?: number;\n    replacementBehavior?: BillingReplacementBehavior;\n    discount?: BillingConfigSubscriptionPlanDiscount;\n}"
-          },
-          "RecurringBillingIntervals": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "RecurringBillingIntervals",
-            "value": "RecurringBillingIntervals",
-            "description": ""
-          },
-          "BillingReplacementBehavior": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingReplacementBehavior",
-            "value": "export declare enum BillingReplacementBehavior {\n    ApplyImmediately = \"APPLY_IMMEDIATELY\",\n    ApplyOnNextBillingCycle = \"APPLY_ON_NEXT_BILLING_CYCLE\",\n    Standard = \"STANDARD\"\n}",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "ApplyImmediately",
-                "value": "APPLY_IMMEDIATELY"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "ApplyOnNextBillingCycle",
-                "value": "APPLY_ON_NEXT_BILLING_CYCLE"
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/types.d.ts",
-                "name": "Standard",
-                "value": "STANDARD"
-              }
-            ]
-          },
-          "BillingConfigSubscriptionPlanDiscount": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    durationLimitInIntervals?: number;\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    amount: number;\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    amount?: never;\n    percentage: number;\n}"
-          },
-          "BillingConfigUsagePlan": {
-            "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-            "name": "BillingConfigUsagePlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Usage",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "usageTerms",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "trialDays",
-                "value": "number",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "replacementBehavior",
-                "value": "BillingReplacementBehavior",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface BillingConfigUsagePlan extends BillingConfigPlan {\n    interval: BillingInterval.Usage;\n    usageTerms: string;\n    trialDays?: number;\n    replacementBehavior?: BillingReplacementBehavior;\n}"
           },
           "BillingRequestResponse": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -14121,14 +15345,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "confirmationUrl",
                 "value": "string",
-                "description": ""
+                "description": "The confirmation URL for this request."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "oneTimePurchase",
                 "value": "OneTimePurchase",
-                "description": "",
+                "description": "The one-time purchase created by this request.",
                 "isOptional": true
               },
               {
@@ -14136,11 +15360,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "appSubscription",
                 "value": "AppSubscription",
-                "description": "",
+                "description": "The app subscription created by this request.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingRequestResponseObject {\n    confirmationUrl: string;\n    oneTimePurchase?: OneTimePurchase;\n    appSubscription?: AppSubscription;\n}"
+            "value": "export interface BillingRequestResponseObject {\n    /**\n     * The confirmation URL for this request.\n     */\n    confirmationUrl: string;\n    /**\n     * The one-time purchase created by this request.\n     */\n    oneTimePurchase?: OneTimePurchase;\n    /**\n     * The app subscription created by this request.\n     */\n    appSubscription?: AppSubscription;\n}"
           },
           "BillingCancelParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -14152,21 +15376,21 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this request."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "subscriptionId",
                 "value": "string",
-                "description": ""
+                "description": "The subscription ID to cancel."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "prorate",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to prorate the cancellation.",
                 "isOptional": true
               },
               {
@@ -14174,11 +15398,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "",
+                "description": "Whether to consider test purchases.",
                 "isOptional": true
               }
             ],
-            "value": "export interface BillingCancelParams {\n    session: Session;\n    subscriptionId: string;\n    prorate?: boolean;\n    isTest?: boolean;\n}"
+            "value": "export interface BillingCancelParams {\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n    /**\n     * The subscription ID to cancel.\n     */\n    subscriptionId: string;\n    /**\n     * Whether to prorate the cancellation.\n     */\n    prorate?: boolean;\n    /**\n     * Whether to consider test purchases.\n     */\n    isTest?: boolean;\n}"
           },
           "BillingSubscriptionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -14190,10 +15414,10 @@
                 "syntaxKind": "PropertySignature",
                 "name": "session",
                 "value": "Session",
-                "description": ""
+                "description": "The session to use for this request."
               }
             ],
-            "value": "export interface BillingSubscriptionParams {\n    session: Session;\n}"
+            "value": "export interface BillingSubscriptionParams {\n    /**\n     * The session to use for this request.\n     */\n    session: Session;\n}"
           },
           "ActiveSubscriptions": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/billing/types.d.ts",
@@ -14301,6 +15525,112 @@
             "value": "Record<string, any>",
             "description": "",
             "members": []
+          },
+          "ShopifyFlow": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/index.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ShopifyFlow",
+            "value": "ReturnType<typeof shopifyFlow>",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/index.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "validate",
+                "value": "({ rawBody, ...adapterArgs }: FlowValidateParams) => Promise<FlowValidationInvalid | FlowValidationValid>",
+                "description": ""
+              }
+            ]
+          },
+          "FlowValidateParams": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidateParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawBody",
+                "value": "string",
+                "description": "The raw body of the request."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawRequest",
+                "value": "AdapterRequest",
+                "description": "The raw request, from the app's framework."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rawResponse",
+                "value": "AdapterResponse",
+                "description": "The raw response, from the app's framework. Only applies to frameworks that expose an API similar to Node's HTTP module.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface FlowValidateParams extends AdapterArgs {\n    /**\n     * The raw body of the request.\n     */\n    rawBody: string;\n}"
+          },
+          "FlowValidationInvalid": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidationInvalid",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "valid",
+                "value": "false",
+                "description": "Whether the request is a valid Flow request from Shopify."
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "reason",
+                "value": "FlowValidationErrorReason",
+                "description": "The reason why the request is not valid."
+              }
+            ],
+            "value": "export interface FlowValidationInvalid {\n    /**\n     * Whether the request is a valid Flow request from Shopify.\n     */\n    valid: false;\n    /**\n     * The reason why the request is not valid.\n     */\n    reason: FlowValidationErrorReason;\n}"
+          },
+          "FlowValidationErrorReason": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "FlowValidationErrorReason",
+            "value": "export declare enum FlowValidationErrorReason {\n    MissingBody = \"missing_body\",\n    MissingHmac = \"missing_hmac\",\n    InvalidHmac = \"invalid_hmac\"\n}",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "MissingBody",
+                "value": "missing_body"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "MissingHmac",
+                "value": "missing_hmac"
+              },
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "name": "InvalidHmac",
+                "value": "invalid_hmac"
+              }
+            ]
+          },
+          "FlowValidationValid": {
+            "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+            "name": "FlowValidationValid",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../../node_modules/@shopify/shopify-api/lib/flow/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "valid",
+                "value": "true",
+                "description": "Whether the request is a valid Flow request from Shopify."
+              }
+            ],
+            "value": "export interface FlowValidationValid {\n    /**\n     * Whether the request is a valid Flow request from Shopify.\n     */\n    valid: true;\n}"
           },
           "MandatoryTopics": {
             "filePath": "src/server/types.ts",
@@ -15026,101 +16356,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -15132,60 +16462,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -15197,35 +16527,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -15233,7 +16563,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -15241,7 +16571,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -15249,11 +16579,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "AdminApiContext": {
             "filePath": "src/server/clients/admin/types.ts",
@@ -15397,14 +16727,14 @@
                 "syntaxKind": "PropertySignature",
                 "name": "path",
                 "value": "string",
-                "description": ""
+                "description": "The path to the resource, relative to the API version root."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "type",
                 "value": "DataType",
-                "description": "",
+                "description": "The type of data expected in the response.",
                 "isOptional": true
               },
               {
@@ -15412,7 +16742,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "data",
                 "value": "string | Record<string, any>",
-                "description": "",
+                "description": "The request body.",
                 "isOptional": true
               },
               {
@@ -15420,7 +16750,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "query",
                 "value": "SearchParams",
-                "description": "",
+                "description": "Query parameters to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -15428,7 +16758,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "extraHeaders",
                 "value": "HeaderParams",
-                "description": "",
+                "description": "Additional headers to be sent with the request.",
                 "isOptional": true
               },
               {
@@ -15436,11 +16766,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "tries",
                 "value": "number",
-                "description": "",
+                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
                 "isOptional": true
               }
             ],
-            "value": "export interface GetRequestParams {\n    path: string;\n    type?: DataType;\n    data?: Record<string, any> | string;\n    query?: SearchParams;\n    extraHeaders?: HeaderParams;\n    tries?: number;\n}"
+            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
           },
           "DataType": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/clients/types.d.ts",
@@ -15470,7 +16800,7 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "HeaderParams",
             "value": "Record<string, string | number | string[]>",
-            "description": "",
+            "description": "Headers to be sent with the request.",
             "members": []
           },
           "PostRequestParams": {
@@ -15744,101 +17074,101 @@
                 "syntaxKind": "PropertyDeclaration",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "scope",
                 "value": "string",
-                "description": ""
+                "description": "The desired scopes for the access token, at the time the session was created."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "expires",
                 "value": "Date",
-                "description": ""
+                "description": "The date the access token expires."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "accessToken",
                 "value": "string",
-                "description": ""
+                "description": "The access token for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "PropertyDeclaration",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": ""
+                "description": "Information on the user for the session. Only present for online sessions."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isActive",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Whether the access token has the given scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "isExpired",
                 "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": ""
+                "description": "Whether the access token is expired."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toObject",
                 "value": "() => SessionParams",
-                "description": ""
+                "description": "Converts an object with data into a Session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(other: Session) => boolean",
-                "description": ""
+                "description": "Checks whether the given session is equal to this session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/session.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toPropertyArray",
                 "value": "() => [string, string | number | boolean][]",
-                "description": ""
+                "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    toObject(): SessionParams;\n    equals(other: Session | undefined): boolean;\n    toPropertyArray(): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][]): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has the given scopes.\n     */\n    isActive(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
@@ -15850,60 +17180,60 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires_in",
                 "value": "number",
-                "description": ""
+                "description": "How long the access token is valid for, in seconds."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user_scope",
                 "value": "string",
-                "description": ""
+                "description": "The effective set of scopes for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/oauth/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "associated_user",
                 "value": "{ id: number; first_name: string; last_name: string; email: string; email_verified: boolean; account_owner: boolean; locale: string; collaborator: boolean; }",
-                "description": ""
+                "description": "The user associated with the access token."
               }
             ],
-            "value": "export interface OnlineAccessInfo {\n    expires_in: number;\n    associated_user_scope: string;\n    associated_user: {\n        id: number;\n        first_name: string;\n        last_name: string;\n        email: string;\n        email_verified: boolean;\n        account_owner: boolean;\n        locale: string;\n        collaborator: boolean;\n    };\n}"
+            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: {\n        /**\n         * The user's ID.\n         */\n        id: number;\n        /**\n         * The user's first name.\n         */\n        first_name: string;\n        /**\n         * The user's last name.\n         */\n        last_name: string;\n        /**\n         * The user's email address.\n         */\n        email: string;\n        /**\n         * Whether the user has verified their email address.\n         */\n        email_verified: boolean;\n        /**\n         * Whether the user is the account owner.\n         */\n        account_owner: boolean;\n        /**\n         * The user's locale.\n         */\n        locale: string;\n        /**\n         * Whether the user is a collaborator.\n         */\n        collaborator: boolean;\n    };\n}"
           },
           "AuthScopes": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
             "name": "AuthScopes",
-            "description": "",
+            "description": "A class that represents a set of access token scopes.",
             "members": [
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "has",
                 "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes includes the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "equals",
                 "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": ""
+                "description": "Checks whether the current set of scopes equals the given one."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toString",
                 "value": "() => string",
-                "description": ""
+                "description": "Returns a comma-separated string with the current set of scopes."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/auth/scopes/index.d.ts",
                 "syntaxKind": "MethodDeclaration",
                 "name": "toArray",
                 "value": "() => string[]",
-                "description": ""
+                "description": "Returns an array with the current set of scopes."
               }
             ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    toString(): string;\n    toArray(): string[];\n    private getImpliedScopes;\n}"
+            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
           },
           "SessionParams": {
             "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
@@ -15915,35 +17245,35 @@
                 "syntaxKind": "PropertySignature",
                 "name": "id",
                 "value": "string",
-                "description": ""
+                "description": "The unique identifier for the session."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "shop",
                 "value": "string",
-                "description": ""
+                "description": "The Shopify shop domain."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "state",
                 "value": "string",
-                "description": ""
+                "description": "The state of the session. Used for the OAuth authentication code flow."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "isOnline",
                 "value": "boolean",
-                "description": ""
+                "description": "Whether the access token in the session is online or offline."
               },
               {
                 "filePath": "../../node_modules/@shopify/shopify-api/lib/session/types.d.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "scope",
                 "value": "string",
-                "description": "",
+                "description": "The scopes for the access token.",
                 "isOptional": true
               },
               {
@@ -15951,7 +17281,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "expires",
                 "value": "Date",
-                "description": "",
+                "description": "The date the access token expires.",
                 "isOptional": true
               },
               {
@@ -15959,7 +17289,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "accessToken",
                 "value": "string",
-                "description": "",
+                "description": "The access token for the session.",
                 "isOptional": true
               },
               {
@@ -15967,11 +17297,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "onlineAccessInfo",
                 "value": "OnlineAccessInfo",
-                "description": "",
+                "description": "Information on the user for the session. Only present for online sessions.",
                 "isOptional": true
               }
             ],
-            "value": "export interface SessionParams {\n    readonly id: string;\n    shop: string;\n    state: string;\n    isOnline: boolean;\n    scope?: string;\n    expires?: Date;\n    accessToken?: string;\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
+            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n}"
           },
           "StorefrontContext": {
             "filePath": "src/server/clients/storefront/types.ts",

--- a/packages/shopify-app-remix/src/server/authenticate/flow/__tests__/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/flow/__tests__/authenticate.test.ts
@@ -1,0 +1,142 @@
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
+import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+
+import {shopifyApp} from '../../..';
+import {
+  expectAdminApiClient,
+  getHmac,
+  getThrownResponse,
+  setUpValidSession,
+  testConfig,
+} from '../../../__test-helpers';
+
+const FLOW_URL = 'https://example.myapp.io/authenticate/flow';
+
+describe('authenticating flow requests', () => {
+  it('throws a 405 response if the request method is not POST', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.flow,
+      new Request(FLOW_URL, {method: 'GET'}),
+    );
+
+    // THEN
+    expect(response.status).toBe(405);
+    expect(response.statusText).toBe('Method not allowed');
+  });
+
+  it('throws a 400 response if the is missing the HMAC signature', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.flow,
+      new Request(FLOW_URL, {method: 'POST'}),
+    );
+
+    // THEN
+    expect(response.status).toBe(400);
+    expect(response.statusText).toBe('Bad Request');
+  });
+
+  it('throws a 400 response if the request has an invalid HMAC signature', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.flow,
+      new Request(FLOW_URL, {
+        method: 'POST',
+        headers: {
+          'X-Shopify-Hmac-Sha256': 'not-the-right-signature',
+        },
+      }),
+    );
+
+    // THEN
+    expect(response.status).toBe(400);
+    expect(response.statusText).toBe('Bad Request');
+  });
+
+  it('throws a 400 response if there is no session for the shop', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const body = {shopify_domain: 'not-the-right-shop.myshopify.io'};
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.flow,
+      new Request(FLOW_URL, {
+        body: JSON.stringify(body),
+        method: 'POST',
+        headers: {
+          'X-Shopify-Hmac-Sha256': getHmac(JSON.stringify(body)),
+        },
+      }),
+    );
+
+    // THEN
+    expect(response.status).toBe(400);
+    expect(response.statusText).toBe('Bad Request');
+  });
+
+  it('valid requests with a session succeed', async () => {
+    // GIVEN
+    const sessionStorage = new MemorySessionStorage();
+    const shopify = shopifyApp(testConfig({sessionStorage}));
+
+    const {
+      request,
+      body,
+      session: expectedSession,
+    } = await getValidRequest(sessionStorage);
+
+    // WHEN
+    const {payload, session} = await shopify.authenticate.flow(request);
+
+    // THEN
+    expect(session).toEqual(expectedSession);
+    expect(payload).toEqual(body);
+  });
+
+  describe('valid requests include an API client object', () => {
+    expectAdminApiClient(async () => {
+      const sessionStorage = new MemorySessionStorage();
+      const shopify = shopifyApp(testConfig({sessionStorage}));
+
+      const {request, session: expectedSession} =
+        await getValidRequest(sessionStorage);
+
+      const {admin, session: actualSession} =
+        await shopify.authenticate.flow(request);
+
+      if (!admin) {
+        throw new Error('No admin client');
+      }
+
+      return {admin, expectedSession, actualSession};
+    });
+  });
+});
+
+async function getValidRequest(sessionStorage: SessionStorage) {
+  const session = await setUpValidSession(sessionStorage, {isOnline: false});
+
+  const body = {shopify_domain: session.shop};
+  const bodyString = JSON.stringify(body);
+
+  const request = new Request(FLOW_URL, {
+    body: bodyString,
+    method: 'POST',
+    headers: {
+      'X-Shopify-Hmac-Sha256': getHmac(bodyString),
+    },
+  });
+
+  return {body, request, session};
+}

--- a/packages/shopify-app-remix/src/server/authenticate/flow/authenticate.flow.doc.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/flow/authenticate.flow.doc.ts
@@ -1,0 +1,34 @@
+import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
+
+const data: ReferenceEntityTemplateSchema = {
+  name: 'Flow',
+  description:
+    'Contains functions for verifying Shopify Flow extensions.' +
+    '\n\nSee the [Flow documentation](https://shopify.dev/docs/apps/flow/actions/endpoints) for more information.',
+  category: 'Authenticate',
+  type: 'object',
+  isVisualComponent: false,
+  definitions: [
+    {
+      title: 'authenticate.flow',
+      description: 'Verifies requests coming from Shopify Flow extensions.',
+      type: 'AuthenticateFlow',
+    },
+  ],
+  jsDocTypeExamples: ['FlowContext'],
+  related: [
+    {
+      name: 'Admin API context',
+      subtitle: 'Interact with the Admin API.',
+      url: '/docs/api/shopify-app-remix/apis/admin-api',
+    },
+    {
+      name: 'Flow action endpoints',
+      subtitle: 'Receive requests from Flow.',
+      url: '/docs/apps/flow/actions/endpoints',
+      type: 'shopify',
+    },
+  ],
+};
+
+export default data;

--- a/packages/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
@@ -1,0 +1,54 @@
+import {adminClientFactory} from 'src/server/clients/admin';
+import {BasicParams} from 'src/server/types';
+
+export function authenticateFlowFactory(params: BasicParams) {
+  const {api, config, logger} = params;
+
+  return async function authenticate(request: Request) {
+    logger.info('Authenticating flow request');
+
+    if (request.method !== 'POST') {
+      logger.debug(
+        'Received a non-POST request for flow. Only POST requests are allowed.',
+        {url: request.url, method: request.method},
+      );
+      throw new Response(undefined, {
+        status: 405,
+        statusText: 'Method not allowed',
+      });
+    }
+
+    const rawBody = await request.text();
+    const {valid} = await api.flow.validate({
+      rawBody,
+      rawRequest: request,
+    });
+
+    if (!valid) {
+      throw new Response(undefined, {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+    }
+
+    const payload = JSON.parse(rawBody);
+    const sessionId = api.session.getOfflineId(payload.shopify_domain);
+    const session = await config.sessionStorage.loadSession(sessionId);
+
+    if (!session) {
+      logger.info('Flow request could not find session', {
+        shop: payload.shopify_domain,
+      });
+      throw new Response(undefined, {
+        status: 400,
+        statusText: 'Bad Request',
+      });
+    }
+
+    return {
+      session,
+      payload,
+      admin: adminClientFactory({params, session}),
+    };
+  };
+}

--- a/packages/shopify-app-remix/src/server/authenticate/flow/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/flow/types.ts
@@ -5,8 +5,83 @@ import type {AdminApiContext} from '../../clients';
 export interface FlowContext<
   Resources extends ShopifyRestResources = ShopifyRestResources,
 > {
+  /**
+   * A session with an offline token for the shop.
+   *
+   * Returned only if there is a session for the shop.
+   *
+   * @example
+   * <caption>Shopify session for the Flow request.</caption>
+   * <description>Use the session associated with this request to use REST resources.</description>
+   * ```ts
+   * // /app/routes/flow.tsx
+   * import { ActionFunction } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   *
+   * export const action: ActionFunction = async ({ request }) => {
+   *   const { session, admin } = await authenticate.flow(request);
+   *
+   *   const products = await admin?.rest.resources.Product.all({ session });
+   *   // Use products
+   *
+   *   return new Response();
+   * };
+   * ```
+   */
   session: Session;
+
+  /**
+   * The payload from the Flow request.
+   *
+   * @example
+   * <caption>Flow payload.</caption>
+   * <description>Get the request's POST payload.</description>
+   * ```ts
+   * // /app/routes/flow.tsx
+   * import { ActionFunction } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   *
+   * export const action: ActionFunction = async ({ request }) => {
+   *   const { payload } = await authenticate.flow(request);
+   *   return new Response();
+   * };
+   * ```
+   */
   payload: any;
+
+  /**
+   * An admin context for the Flow request.
+   *
+   * Returned only if there is a session for the shop.
+   *
+   * @example
+   * <caption>Flow admin context.</caption>
+   * <description>Use the `admin` object in the context to interact with the Admin API.</description>
+   * ```ts
+   * // /app/routes/flow.tsx
+   * import { ActionFunctionArgs } from "@remix-run/node";
+   * import { authenticate } from "../shopify.server";
+   *
+   * export async function action({ request }: ActionFunctionArgs) {
+   *   const { admin } = await authenticate.flow(request);
+   *
+   *   const response = await admin?.graphql(
+   *     `#graphql
+   *     mutation populateProduct($input: ProductInput!) {
+   *       productCreate(input: $input) {
+   *         product {
+   *           id
+   *         }
+   *       }
+   *     }`,
+   *     { variables: { input: { title: "Product Name" } } }
+   *   );
+   *
+   *   const productData = await response.json();
+   *   return json({ data: productData.data });
+   * }
+   * ```
+   */
   admin: AdminApiContext<Resources>;
 }
 

--- a/packages/shopify-app-remix/src/server/authenticate/flow/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/flow/types.ts
@@ -1,0 +1,15 @@
+import {Session, ShopifyRestResources} from '@shopify/shopify-api';
+
+import type {AdminApiContext} from '../../clients';
+
+export interface FlowContext<
+  Resources extends ShopifyRestResources = ShopifyRestResources,
+> {
+  session: Session;
+  payload: any;
+  admin: AdminApiContext<Resources>;
+}
+
+export type AuthenticateFlow<
+  Resources extends ShopifyRestResources = ShopifyRestResources,
+> = (request: Request) => Promise<FlowContext<Resources>>;

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -32,6 +32,7 @@ import {unauthenticatedStorefrontContextFactory} from './unauthenticated/storefr
 import {AuthCodeFlowStrategy} from './authenticate/admin/strategies/auth-code-flow';
 import {TokenExchangeStrategy} from './authenticate/admin/strategies/token-exchange';
 import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promise-handler';
+import {authenticateFlowFactory} from './authenticate/flow/authenticate';
 
 /**
  * Creates an object your app will use to interact with Shopify.
@@ -85,6 +86,7 @@ export function shopifyApp<
     registerWebhooks: registerWebhooksFactory(params),
     authenticate: {
       admin: authStrategy,
+      flow: authenticateFlowFactory<Resources>(params),
       public: authenticatePublicFactory<Config['future'], Resources>(params),
       webhook: authenticateWebhookFactory<
         Config['future'],

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -148,7 +148,10 @@ interface Authenticate<Config extends AppConfigArg> {
    * export async function action({ request }: ActionFunctionArgs) {
    *   const {admin, session, payload} = authenticate.flow(request);
    *
-   *   return json(await admin.rest.resources.Product.count({ session }));
+   *   // Perform flow extension logic
+   *
+   *   // Return a 200 response
+   *   return null;
    * }
    * ```
    * ```ts


### PR DESCRIPTION
### WHY are these changes introduced?

With the changes in https://github.com/Shopify/shopify-api-js/pull/987, we'll be able to properly authenticate Flow extension requests in apps. We need to provide a public API for that kind of authentication in the Remix package.

### WHAT is this pull request doing?

Adding a new `shopify.authenticate.flow(request)` call that will perform the necessary checks and return the payload / API clients.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
