### PR TITLE
Update @shopify/shopify-api to 7.7.0

### DIFF
--- a/.changeset/honest-bikes-tease.md
+++ b/.changeset/honest-bikes-tease.md
@@ -1,0 +1,17 @@
+---
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+'@shopify/shopify-app-session-storage-dynamodb': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-prisma': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-remix': patch
+---
+
+Updating dependency on @shopify/shopify-api to 7.7.0

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9",
     "@shopify/shopify-app-session-storage-memory": "^1.0.12",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-remix/package.json
+++ b/packages/shopify-app-remix/package.json
@@ -68,7 +68,7 @@
   },
   "dependencies": {
     "@remix-run/server-runtime": "^1.17.1",
-    "@shopify/shopify-api": "7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9",
     "isbot": "^3.6.5",
     "semver": "^7.5.0",

--- a/packages/shopify-app-session-storage-dynamodb/package.json
+++ b/packages/shopify-app-session-storage-dynamodb/package.json
@@ -37,13 +37,13 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9",
     "@shopify/shopify-app-session-storage-test-utils": "^0.1.9",
     "eslint": "^8.40.0",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -37,7 +37,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-prisma/package.json
+++ b/packages/shopify-app-session-storage-prisma/package.json
@@ -35,13 +35,13 @@
   },
   "peerDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9",
     "prisma": "^4.13.0"
   },
   "devDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9",
     "prisma": "^4.13.0",
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -38,7 +38,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0",
+    "@shopify/shopify-api": "^7.7.0",
     "@shopify/shopify-app-session-storage": "^1.1.9"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.4.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^7.6.0"
+    "@shopify/shopify-api": "^7.7.0"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3145,10 +3145,10 @@
     jest-matcher-utils "^26.6.2"
     react-reconciler "^0.28.0"
 
-"@shopify/shopify-api@7.6.0", "@shopify/shopify-api@^7.6.0":
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-7.6.0.tgz#d181ca9fbd2ff3b3a7595e9e121fde707dbbb36a"
-  integrity sha512-XUyBkSrUHvqCknPdY3ylaGDyC3hA2aKmXTsbo7vpGzncMqC1hZ2pwRJbBMnffdbEWj14Um9zkEMS7MKf1k6PBw==
+"@shopify/shopify-api@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-7.7.0.tgz#0344b5ba90b4ac913c26193ffd6eaedc91d24889"
+  integrity sha512-VrOty3470GpGcf2nZDCUQGCHU5lz9X91RwAoHqlutKueBsS5d8d7P6wv667zCxh+DHoV+8BBcNwQr/esW5TsAg==
   dependencies:
     "@shopify/network" "^3.2.1"
     compare-versions "^5.0.3"


### PR DESCRIPTION
This PR updates all dependencies in this repo on `@shopify/shopify-api` to the latest version 7.7.0.