### PR TITLE
[Feature] - Extend AppConfig To Allow Flexibility On Bot Checks

### DIFF
--- a/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -68,7 +68,9 @@ export class AuthStrategy<
   ): Promise<AdminContext<Config, Resources>> {
     const {api, logger, config} = this;
 
-    rejectBotRequest({api, logger, config}, request);
+    if (!config.skipBotCheck) {
+      rejectBotRequest({api, logger, config}, request);
+    }
     respondToOptionsRequest({api, logger, config}, request);
 
     const cors = ensureCORSHeadersFactory({api, logger, config}, request);

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/reject-bot-request.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/reject-bot-request.ts
@@ -3,9 +3,13 @@ import isbot from 'isbot';
 import type {BasicParams} from '../../types';
 
 export function rejectBotRequest(
-  {logger}: BasicParams,
+  {config, logger}: BasicParams,
   request: Request,
 ): void | never {
+  if (config.extraAllowedUserAgents) {
+    isbot.exclude(config.extraAllowedUserAgents);
+  }
+
   if (isbot(request.headers.get('User-Agent'))) {
     logger.debug('Request is from a bot, skipping auth');
     throw new Response(undefined, {status: 410, statusText: 'Gone'});

--- a/packages/shopify-app-remix/src/server/authenticate/public/checkout/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/checkout/authenticate.ts
@@ -16,9 +16,13 @@ export function authenticateCheckoutFactory(
     request,
     options = {},
   ): Promise<CheckoutContext> {
-    const {logger} = params;
+    const {config, logger} = params;
 
     const corsHeaders = options.corsHeaders ?? [];
+
+    if (!config.skipBotCheck) {
+      rejectBotRequest(params, request);
+    }
 
     rejectBotRequest(params, request);
     respondToOptionsRequest(params, request, corsHeaders);

--- a/packages/shopify-app-remix/src/server/config-types.ts
+++ b/packages/shopify-app-remix/src/server/config-types.ts
@@ -221,6 +221,8 @@ export interface AppConfig<Storage extends SessionStorage = SessionStorage>
   sessionStorage: Storage;
   useOnlineTokens: boolean;
   hooks: HooksConfig;
+  extraAllowedUserAgents?: string[];
+  skipBotCheck?: boolean;
 }
 
 interface AuthConfig {


### PR DESCRIPTION
### WHY are these changes introduced?

There are situations where the app developer does not have full control over the underlying infrastructure (including how User-Agent headers are passed to the service). In the current version, the `rejectBotRequest` function is run unconditionally. This is a major problem, since this assumes that the developer has full control over the deployment infrastructure, which is typically not the case.

### WHAT is this pull request doing?

This change adds two configurations:
- `extraAllowedUserAgents`: can be used to exclude specific user agents from the `isbot` check
- `skipBotCheck`: can be used to fully skip the bot check. This can be used in situations where the developer's underlying infrastructure already has bot checking at a higher layer in the stack, and the developer doesn't necessarily know what user agents will be passed through.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
> I don't see any tests for this function? Tell me if there's something to add here
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
> Not sure which docs to change... please advise