### PR TITLE
Future flags and webhook admin context update

### DIFF
--- a/.changeset/serious-nails-own.md
+++ b/.changeset/serious-nails-own.md
@@ -5,3 +5,63 @@
 Added support for `future` flags in the `shopifyApp` function, with a `v3_webhookContext` flag to have `authenticate.webhook` return a standard `admin` context, instead of a different type.
 
 Apps can opt in to the new future at any time, so this is not a breaking change (yet).
+
+<details>
+  <summary>See an example</summary>
+
+Without the `v3_webhookContext` flag, `graphql` provides a `query` function that takes the query string as the `data` param.
+When using variables, `data` needs to be an object containing `query` and `variables`.
+
+```ts
+import {json, ActionFunctionArgs} from '@remix-run/node';
+import {authenticate} from '../shopify.server';
+
+export async function action({request}: ActionFunctionArgs) {
+  const {admin} = await authenticate.webhook(request);
+
+  const response = await admin?.graphql.query<any>({
+    data: {
+      query: `#graphql
+      mutation populateProduct($input: ProductInput!) {
+        productCreate(input: $input) {
+          product {
+            id
+          }
+        }
+      }`,
+      variables: {input: {title: 'Product Name'}},
+    },
+  });
+
+  const productData = response?.body.data;
+  return json({data: productData.data});
+}
+```
+
+With the `v3_webhookContext` flag enabled, `graphql` _is_ a function that takes in the query string and an optional settings object, including `variables`.
+
+```ts
+import {ActionFunctionArgs} from '@remix-run/node';
+import {authenticate} from '../shopify.server';
+
+export async function action({request}: ActionFunctionArgs) {
+  const {admin} = await authenticate.webhook(request);
+
+  const response = await admin?.graphql(
+    `#graphql
+    mutation populateProduct($input: ProductInput!) {
+      productCreate(input: $input) {
+        product {
+          id
+        }
+      }
+    }`,
+    {variables: {input: {title: 'Product Name'}}},
+  );
+
+  const productData = await response.json();
+  return json({data: productData.data});
+}
+```
+
+</details>

--- a/.changeset/serious-nails-own.md
+++ b/.changeset/serious-nails-own.md
@@ -1,0 +1,7 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Added support for `future` flags in the `shopifyApp` function, with a `v3_webhookContext` flag to have `authenticate.webhook` return a standard `admin` context, instead of a different type.
+
+Apps can opt in to the new future at any time, so this is not a breaking change (yet).

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,5 @@
 .changeset/pre.json
 coverage
 
-packages/shopify-app-remix/docs/*
+packages/shopify-app-remix/docs/**/*.json
 packages/shopify-app-remix/**/*.example.tsx?

--- a/packages/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -1770,7 +1770,7 @@
   },
   {
     "name": "Webhook",
-    "description": "Contains functions for verifying Shopify webhooks.",
+    "description": "Contains functions for verifying Shopify webhooks.\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag.",
     "category": "Authenticate",
     "type": "object",
     "isVisualComponent": false,
@@ -1795,14 +1795,21 @@
             "returns": {
               "filePath": "/server/authenticate/webhooks/types.ts",
               "description": "",
-              "name": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>",
-              "value": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>"
+              "name": "Promise<WebhookContext<Future, Resources, Topics>>",
+              "value": "Promise<WebhookContext<Future, Resources, Topics>>"
             },
-            "value": "export type AuthenticateWebhook<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Topics = string | number | symbol,\n> = (\n  request: Request,\n) => Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>;"
+            "value": "export type AuthenticateWebhook<\n  Future extends FutureFlagOptions,\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> = (request: Request) => Promise<WebhookContext<Future, Resources, Topics>>;"
           },
           "WebhookContext": {
             "filePath": "/server/authenticate/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
             "name": "WebhookContext",
+            "value": "WebhookContextWithoutSession<Topics> | WebhookContextWithSession<Future, Resources, Topics>",
+            "description": ""
+          },
+          "WebhookContextWithoutSession": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "name": "WebhookContextWithoutSession",
             "description": "",
             "members": [
               {
@@ -1915,7 +1922,7 @@
                 ]
               }
             ],
-            "value": "export interface WebhookContext<Topics = string | number | symbol>\n  extends Context<Topics> {\n  session: undefined;\n  admin: undefined;\n}"
+            "value": "export interface WebhookContextWithoutSession<Topics = string | number | symbol>\n  extends Context<Topics> {\n  session: undefined;\n  admin: undefined;\n}"
           },
           "JSONValue": {
             "filePath": "/server/types.ts",
@@ -2169,14 +2176,14 @@
               {
                 "filePath": "/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@iterator@527",
+                "name": "__@iterator@540",
                 "value": "() => IterableIterator<JSONValue>",
                 "description": "Iterator"
               },
               {
                 "filePath": "/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@unscopables@529",
+                "name": "__@unscopables@542",
                 "value": "() => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }",
                 "description": "Returns an object whose properties have the value 'true'\r\nwhen they will be absent when used in a 'with' statement."
               },
@@ -2206,8 +2213,30 @@
                 "filePath": "/server/authenticate/webhooks/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "admin",
-                "value": "{ rest: RestClient & Resources; graphql: GraphqlClient; }",
-                "description": "An admin context for the webhook.\n\nReturned only if there is a session for the shop."
+                "value": "WebhookAdminContext<Future, Resources>",
+                "description": "An admin context for the webhook.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "[V3] Webhook admin context",
+                    "description": "With the `v3_webhookAdminContext` future flag enabled, use the `admin` object in the context to interact with the Admin API.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Webhook admin context",
+                    "description": "Use the `admin` object in the context to interact with the Admin API. This format will be removed in V3 of the package.",
+                    "tabs": [
+                      {
+                        "code": "import { json, ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql.query<any>({\n    data: {\n      query: `#graphql\n        mutation populateProduct($input: ProductInput!) {\n          productCreate(input: $input) {\n            product {\n              id\n            }\n          }\n        }`,\n      variables: { input: { title: \"Product Name\" } },\n    },\n  });\n\n  const productData = response?.body.data;\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "filePath": "/server/authenticate/webhooks/types.ts",
@@ -2305,7 +2334,554 @@
                 ]
               }
             ],
-            "value": "export interface WebhookContextWithSession<\n  Topics = string | number | symbol,\n  Resources extends ShopifyRestResources = any,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  admin: {\n    /** A REST client. */\n    rest: InstanceType<Shopify['clients']['Rest']> & Resources;\n    /** A GraphQL client. */\n    graphql: InstanceType<Shopify['clients']['Graphql']>;\n  };\n}"
+            "value": "export interface WebhookContextWithSession<\n  Future extends FutureFlagOptions,\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>[V3] Webhook admin context.</caption>\n   * <description>With the `v3_webhookAdminContext` future flag enabled, use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   *\n   * @example\n   * <caption>Webhook admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API. This format will be removed in V3 of the package.</description>\n   * ```ts\n   * import { json, ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   const response = await admin?.graphql.query<any>({\n   *     data: {\n   *       query: `#graphql\n   *         mutation populateProduct($input: ProductInput!) {\n   *           productCreate(input: $input) {\n   *             product {\n   *               id\n   *             }\n   *           }\n   *         }`,\n   *       variables: { input: { title: \"Product Name\" } },\n   *     },\n   *   });\n   *\n   *   const productData = response?.body.data;\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: WebhookAdminContext<Future, Resources>;\n}"
+          },
+          "WebhookAdminContext": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "WebhookAdminContext",
+            "value": "FeatureEnabled<Future, 'v3_webhookAdminContext'> extends true\n  ? AdminApiContext<Resources>\n  : LegacyWebhookAdminApiContext<Resources>",
+            "description": ""
+          },
+          "FeatureEnabled": {
+            "filePath": "/server/future/flags.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "FeatureEnabled",
+            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
+            "description": ""
+          },
+          "FutureFlags": {
+            "filePath": "/server/future/flags.ts",
+            "name": "FutureFlags",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "v3_webhookAdminContext",
+                "value": "boolean",
+                "description": "When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.\n   *\n   * @default false\n   */\n  v3_webhookAdminContext?: boolean;\n}"
+          },
+          "AdminContext": {
+            "filePath": "/server/authenticate/admin/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "AdminContext",
+            "value": "Config['isEmbeddedApp'] extends false\n  ? NonEmbeddedAdminContext<Config, Resources>\n  : EmbeddedAdminContext<Config, Resources>",
+            "description": ""
+          },
+          "NonEmbeddedAdminContext": {
+            "filePath": "/server/authenticate/admin/types.ts",
+            "name": "NonEmbeddedAdminContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "The session for the user who made the request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nUse this to get shop or user-specific data.",
+                "examples": [
+                  {
+                    "title": "Using offline sessions",
+                    "description": "Get your app's shop-specific data using an offline session.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Using online sessions",
+                    "description": "Get your app's user-specific data using an online session.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({user: session.onlineAccessInfo!.id}));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "admin",
+                "value": "AdminApiContext<Resources>",
+                "description": "Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request."
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "billing",
+                "value": "BillingContext<Config>",
+                "description": "Billing methods for this store, based on the plans defined in the `billing` config option.\n\n\n\n\n"
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cors",
+                "value": "EnsureCORSFunction",
+                "description": "A function that ensures the CORS headers are set correctly for the response.",
+                "examples": [
+                  {
+                    "title": "Setting CORS headers for a admin request",
+                    "description": "Use the `cors` helper to ensure your app can respond to requests from admin extensions.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session, cors } = await authenticate.admin(request);\n  return cors(json(await getMyAppData({user: session.onlineAccessInfo!.id})));\n};",
+                        "title": "/app/routes/admin/my-route.ts"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface NonEmbeddedAdminContext<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends AdminContextInternal<Config, Resources> {}"
+          },
+          "AdminApiContext": {
+            "filePath": "/server/clients/admin/types.ts",
+            "name": "AdminApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rest",
+                "value": "RestClientWithResources<Resources>",
+                "description": "Methods for interacting with the Shopify Admin REST API\n\nThere are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n\n\n\n\n",
+                "examples": [
+                  {
+                    "title": "Using REST resources",
+                    "description": "Getting the number of orders in a store using REST resources.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  return json(admin.rest.resources.Order.count({ session }));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Performing a GET request to the REST API",
+                    "description": "Use `admin.rest.<method>` to make custom requests to the API.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "/app/shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  const response = await admin.rest.get({ path: \"/customers/count.json\" });\n  const customers = await response.json();\n  return json({ customers });\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "graphql",
+                "value": "GraphQLClient",
+                "description": "Methods for interacting with the Shopify Admin GraphQL API\n\n\n\n\n\n\n\n\n\n",
+                "examples": [
+                  {
+                    "title": "Querying the GraphQL API",
+                    "description": "Use `admin.graphql` to make query / mutation requests.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.admin(request);\n\n  const response = await admin.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface AdminApiContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * Methods for interacting with the Shopify Admin REST API\n   *\n   * There are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n   *\n   * {@link https://shopify.dev/docs/api/admin-rest}\n   *\n   * @example\n   * <caption>Using REST resources.</caption>\n   * <description>Getting the number of orders in a store using REST resources.</description>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   return json(admin.rest.resources.Order.count({ session }));\n   * };\n   * ```\n   *\n   * @example\n   * <caption>Performing a GET request to the REST API.</caption>\n   * <description>Use `admin.rest.<method>` to make custom requests to the API.</description>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   const response = await admin.rest.get({ path: \"/customers/count.json\" });\n   *   const customers = await response.json();\n   *   return json({ customers });\n   * };\n   * ```\n   */\n  rest: RestClientWithResources<Resources>;\n\n  /**\n   * Methods for interacting with the Shopify Admin GraphQL API\n   *\n   * {@link https://shopify.dev/docs/api/admin-graphql}\n   * {@link https://github.com/Shopify/shopify-api-js/blob/main/packages/shopify-api/docs/reference/clients/Graphql.md}\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `admin.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.admin(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  graphql: GraphQLClient;\n}"
+          },
+          "RestClientWithResources": {
+            "filePath": "/server/clients/admin/rest.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RestClientWithResources",
+            "value": "RemixRestClient & {resources: Resources}",
+            "description": ""
+          },
+          "BillingContext": {
+            "filePath": "/server/authenticate/admin/billing/types.ts",
+            "name": "BillingContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "require",
+                "value": "(options: RequireBillingOptions<Config>) => Promise<BillingCheckResponseObject>",
+                "description": "Checks if the shop has an active payment for any plan defined in the `billing` config option.",
+                "examples": [
+                  {
+                    "title": "Requesting billing right away",
+                    "description": "Call `billing.request` in the `onFailure` callback to immediately request payment.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  await billing.require({\n    plans: [MONTHLY_PLAN],\n    isTest: true,\n    onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n  });\n\n  // App logic\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Using a plan selection page",
+                    "description": "Redirect to a different page in the `onFailure` callback, where the merchant can select a billing plan.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const billingCheck = await billing.require({\n    plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n    isTest: true,\n    onFailure: () => redirect('/select-plan'),\n  });\n\n  const subscription = billingCheck.appSubscriptions[0];\n  console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n\n  // App logic\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "request",
+                "value": "(options: RequestBillingOptions<Config>) => Promise<never>",
+                "description": "Requests payment for the plan.",
+                "examples": [
+                  {
+                    "title": "Using a custom return URL",
+                    "description": "Change where the merchant is returned to after approving the purchase using the `returnUrl` option.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  await billing.require({\n    plans: [MONTHLY_PLAN],\n    onFailure: async () => billing.request({\n      plan: MONTHLY_PLAN,\n      isTest: true,\n      returnUrl: '/billing-complete',\n    }),\n  });\n\n  // App logic\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cancel",
+                "value": "(options: CancelBillingOptions) => Promise<AppSubscription>",
+                "description": "Cancels an ongoing subscription, given its ID.",
+                "examples": [
+                  {
+                    "title": "Cancelling a subscription",
+                    "description": "Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const billingCheck = await billing.require({\n    plans: [MONTHLY_PLAN],\n    onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n  });\n\n  const subscription = billingCheck.appSubscriptions[0];\n  const cancelledSubscription = await billing.cancel({\n    subscriptionId: subscription.id,\n    isTest: true,\n    prorate: true,\n   });\n\n  // App logic\n};",
+                        "title": "/app/routes/cancel-subscription.ts"
+                      },
+                      {
+                        "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Using a plan selection page.</caption>\n   * <description>Redirect to a different page in the `onFailure` callback, where the merchant can select a billing plan.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: '/billing-complete',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+          },
+          "RequireBillingOptions": {
+            "filePath": "/server/authenticate/admin/billing/types.ts",
+            "name": "RequireBillingOptions",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "plans",
+                "value": "(keyof Config[\"billing\"])[]",
+                "description": "The plans to check for. Must be one of the values defined in the `billing` config option."
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "onFailure",
+                "value": "(error: any) => Promise<Response>",
+                "description": "How to handle the request if the shop doesn't have an active payment for any plan."
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isTest",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface RequireBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans: (keyof Config['billing'])[];\n  /**\n   * How to handle the request if the shop doesn't have an active payment for any plan.\n   */\n  onFailure: (error: any) => Promise<Response>;\n}"
+          },
+          "RequestBillingOptions": {
+            "filePath": "/server/authenticate/admin/billing/types.ts",
+            "name": "RequestBillingOptions",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "plan",
+                "value": "keyof Config[\"billing\"]",
+                "description": "The plan to request. Must be one of the values defined in the `billing` config option."
+              }
+            ],
+            "value": "export interface RequestBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingRequestParams, 'session' | 'plan' | 'returnObject'> {\n  /**\n   * The plan to request. Must be one of the values defined in the `billing` config option.\n   */\n  plan: keyof Config['billing'];\n}"
+          },
+          "CancelBillingOptions": {
+            "filePath": "/server/authenticate/admin/billing/types.ts",
+            "name": "CancelBillingOptions",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "subscriptionId",
+                "value": "string",
+                "description": "The ID of the subscription to cancel."
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "prorate",
+                "value": "boolean",
+                "description": "Whether to prorate the cancellation.\n\n\n\n\n",
+                "isOptional": true
+              },
+              {
+                "filePath": "/server/authenticate/admin/billing/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isTest",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to prorate the cancellation.\n   *\n   * {@link https://shopify.dev/docs/apps/billing/subscriptions/cancel-recurring-charges}\n   */\n  prorate?: boolean;\n  isTest?: boolean;\n}"
+          },
+          "EmbeddedAdminContext": {
+            "filePath": "/server/authenticate/admin/types.ts",
+            "name": "EmbeddedAdminContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "sessionToken",
+                "value": "JwtPayload",
+                "description": "The decoded and validated session token for the request.\n\nReturned only if `isEmbeddedApp` is `true`.\n\n\n\n\n",
+                "examples": [
+                  {
+                    "title": "Using the decoded session token",
+                    "description": "Get user-specific data using the `sessionToken` object.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { sessionToken } = await authenticate.public.checkout(\n    request\n  );\n  return json(await getMyAppData({user: sessionToken.sub}));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "redirect",
+                "value": "RedirectFunction",
+                "description": "A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded apps.\n\nReturned only if `isEmbeddedApp` is `true`.",
+                "examples": [
+                  {
+                    "title": "Redirecting to an app route",
+                    "description": "Use the `redirect` helper to safely redirect between pages.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session, redirect } = await authenticate.admin(request);\n  return redirect(\"/\");\n};",
+                        "title": "/app/routes/admin/my-route.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Redirecting outside of Shopify admin",
+                    "description": "Pass in a `target` option of `_top` or `_parent` to go to an external URL.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session, redirect } = await authenticate.admin(request);\n  return redirect(\"/\", { target: '_parent' });\n};",
+                        "title": "/app/routes/admin/my-route.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": "The session for the user who made the request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nUse this to get shop or user-specific data.",
+                "examples": [
+                  {
+                    "title": "Using offline sessions",
+                    "description": "Get your app's shop-specific data using an offline session.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Using online sessions",
+                    "description": "Get your app's user-specific data using an online session.",
+                    "tabs": [
+                      {
+                        "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                        "title": "shopify.server.ts"
+                      },
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({user: session.onlineAccessInfo!.id}));\n};",
+                        "title": "/app/routes/**\\/*.ts"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "admin",
+                "value": "AdminApiContext<Resources>",
+                "description": "Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request."
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "billing",
+                "value": "BillingContext<Config>",
+                "description": "Billing methods for this store, based on the plans defined in the `billing` config option.\n\n\n\n\n"
+              },
+              {
+                "filePath": "/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "cors",
+                "value": "EnsureCORSFunction",
+                "description": "A function that ensures the CORS headers are set correctly for the response.",
+                "examples": [
+                  {
+                    "title": "Setting CORS headers for a admin request",
+                    "description": "Use the `cors` helper to ensure your app can respond to requests from admin extensions.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { session, cors } = await authenticate.admin(request);\n  return cors(json(await getMyAppData({user: session.onlineAccessInfo!.id})));\n};",
+                        "title": "/app/routes/admin/my-route.ts"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            "value": "export interface EmbeddedAdminContext<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends AdminContextInternal<Config, Resources> {\n  /**\n   * The decoded and validated session token for the request.\n   *\n   * Returned only if `isEmbeddedApp` is `true`.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload}\n   *\n   * @example\n   * <caption>Using the decoded session token.</caption>\n   * <description>Get user-specific data using the `sessionToken` object.</description>\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   useOnlineTokens: true,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { sessionToken } = await authenticate.public.checkout(\n   *     request\n   *   );\n   *   return json(await getMyAppData({user: sessionToken.sub}));\n   * };\n   * ```\n   */\n  sessionToken: JwtPayload;\n\n  /**\n   * A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded\n   * apps.\n   *\n   * Returned only if `isEmbeddedApp` is `true`.\n   *\n   * @example\n   * <caption>Redirecting to an app route.</caption>\n   * <description>Use the `redirect` helper to safely redirect between pages.</description>\n   * ```ts\n   * // /app/routes/admin/my-route.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { session, redirect } = await authenticate.admin(request);\n   *   return redirect(\"/\");\n   * };\n   * ```\n   *\n   * @example\n   * <caption>Redirecting outside of Shopify admin.</caption>\n   * <description>Pass in a `target` option of `_top` or `_parent` to go to an external URL.</description>\n   * ```ts\n   * // /app/routes/admin/my-route.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { session, redirect } = await authenticate.admin(request);\n   *   return redirect(\"/\", { target: '_parent' });\n   * };\n   * ```\n   */\n  redirect: RedirectFunction;\n}"
+          },
+          "RedirectFunction": {
+            "filePath": "/server/authenticate/admin/helpers/redirect.ts",
+            "name": "RedirectFunction",
+            "description": "",
+            "params": [
+              {
+                "name": "url",
+                "description": "",
+                "value": "string",
+                "filePath": "/server/authenticate/admin/helpers/redirect.ts"
+              },
+              {
+                "name": "init",
+                "description": "",
+                "value": "RedirectInit",
+                "isOptional": true,
+                "filePath": "/server/authenticate/admin/helpers/redirect.ts"
+              }
+            ],
+            "returns": {
+              "filePath": "/server/authenticate/admin/helpers/redirect.ts",
+              "description": "",
+              "name": "TypedResponse<never>",
+              "value": "TypedResponse<never>"
+            },
+            "value": "export type RedirectFunction = (\n  url: string,\n  init?: RedirectInit,\n) => TypedResponse<never>;"
+          },
+          "RedirectInit": {
+            "filePath": "/server/authenticate/admin/helpers/redirect.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RedirectInit",
+            "value": "number | (ResponseInit & {target?: RedirectTarget})",
+            "description": ""
+          },
+          "RedirectTarget": {
+            "filePath": "/server/authenticate/admin/helpers/redirect.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "RedirectTarget",
+            "value": "'_self' | '_parent' | '_top'",
+            "description": ""
+          },
+          "LegacyWebhookAdminApiContext": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "name": "LegacyWebhookAdminApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rest",
+                "value": "RestClient & Resources",
+                "description": "A REST client."
+              },
+              {
+                "filePath": "/server/authenticate/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "graphql",
+                "value": "InstanceType<Shopify['clients']['Graphql']>",
+                "description": "A GraphQL client."
+              }
+            ],
+            "value": "export interface LegacyWebhookAdminApiContext<\n  Resources extends ShopifyRestResources,\n> {\n  /** A REST client. */\n  rest: InstanceType<Shopify['clients']['Rest']> & Resources;\n  /** A GraphQL client. */\n  graphql: InstanceType<Shopify['clients']['Graphql']>;\n}"
           }
         }
       }
@@ -2313,10 +2889,47 @@
     "jsDocTypeExamples": [
       "WebhookContextWithSession"
     ],
-    "related": [],
+    "related": [
+      {
+        "name": "Admin API context",
+        "subtitle": "Interact with the Admin API.",
+        "url": "/docs/api/shopify-app-remix/apis/admin-api"
+      }
+    ],
     "examples": {
       "description": "",
       "exampleGroups": [
+        {
+          "title": "admin",
+          "examples": [
+            {
+              "description": "With the `v3_webhookAdminContext` future flag enabled, use the `admin` object in the context to interact with the Admin API.",
+              "codeblock": {
+                "title": "[V3] Webhook admin context",
+                "tabs": [
+                  {
+                    "title": "Example",
+                    "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Use the `admin` object in the context to interact with the Admin API. This format will be removed in V3 of the package.",
+              "codeblock": {
+                "title": "Webhook admin context",
+                "tabs": [
+                  {
+                    "title": "Example",
+                    "code": "import { json, ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql.query&lt;any&gt;({\n    data: {\n      query: `#graphql\n        mutation populateProduct($input: ProductInput!) {\n          productCreate(input: $input) {\n            product {\n              id\n            }\n          }\n        }`,\n      variables: { input: { title: \"Product Name\" } },\n    },\n  });\n\n  const productData = response?.body.data;\n  return json({ data: productData.data });\n}",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            }
+          ]
+        },
         {
           "title": "apiVersion",
           "examples": [
@@ -2687,7 +3300,7 @@
               "name": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>",
               "value": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>"
             },
-            "value": "export function shopifyApp<\n  Config extends AppConfigArg<Resources, Storage>,\n  Resources extends ShopifyRestResources,\n  Storage extends SessionStorage,\n>(appConfig: Config): ShopifyApp<Config> {\n  const api = deriveApi<Resources>(appConfig);\n  const config = deriveConfig<Storage>(appConfig, api.config);\n  const logger = overrideLogger(api.logger);\n\n  if (appConfig.webhooks) {\n    api.webhooks.addHandlers(appConfig.webhooks);\n  }\n\n  const params: BasicParams = {api, config, logger};\n  const oauth = new AuthStrategy<Config, Resources>(params);\n\n  const shopify:\n    | AdminApp<Config>\n    | AppStoreApp<Config>\n    | SingleMerchantApp<Config> = {\n    sessionStorage: config.sessionStorage,\n    addDocumentResponseHeaders: addDocumentResponseHeadersFactory(params),\n    registerWebhooks: registerWebhooksFactory(params),\n    authenticate: {\n      admin: oauth.authenticateAdmin.bind(oauth),\n      public: authenticatePublicFactory<Resources>(params),\n      webhook: authenticateWebhookFactory<\n        Resources,\n        keyof Config['webhooks'] | MandatoryTopics\n      >(params),\n    },\n    unauthenticated: {\n      admin: unauthenticatedAdminContextFactory(params),\n      storefront: unauthenticatedStorefrontContextFactory(params),\n    },\n  };\n\n  if (\n    isAppStoreApp(shopify, appConfig) ||\n    isSingleMerchantApp(shopify, appConfig)\n  ) {\n    shopify.login = loginFactory(params);\n  }\n\n  return shopify as ShopifyApp<Config>;\n}",
+            "value": "export function shopifyApp<\n  Config extends AppConfigArg<Resources, Storage>,\n  Resources extends ShopifyRestResources,\n  Storage extends SessionStorage,\n>(appConfig: Config): ShopifyApp<Config> {\n  const api = deriveApi<Resources>(appConfig);\n  const config = deriveConfig<Storage>(appConfig, api.config);\n  const logger = overrideLogger(api.logger);\n\n  if (appConfig.webhooks) {\n    api.webhooks.addHandlers(appConfig.webhooks);\n  }\n\n  const params: BasicParams = {api, config, logger};\n  const oauth = new AuthStrategy<Config, Resources>(params);\n\n  const shopify:\n    | AdminApp<Config>\n    | AppStoreApp<Config>\n    | SingleMerchantApp<Config> = {\n    sessionStorage: config.sessionStorage,\n    addDocumentResponseHeaders: addDocumentResponseHeadersFactory(params),\n    registerWebhooks: registerWebhooksFactory(params),\n    authenticate: {\n      admin: oauth.authenticateAdmin.bind(oauth),\n      public: authenticatePublicFactory<Resources>(params),\n      webhook: authenticateWebhookFactory<\n        Config['future'],\n        Resources,\n        keyof Config['webhooks'] | MandatoryTopics\n      >(params),\n    },\n    unauthenticated: {\n      admin: unauthenticatedAdminContextFactory(params),\n      storefront: unauthenticatedStorefrontContextFactory(params),\n    },\n  };\n\n  if (\n    isAppStoreApp(shopify, appConfig) ||\n    isSingleMerchantApp(shopify, appConfig)\n  ) {\n    shopify.login = loginFactory(params);\n  }\n\n  return shopify as ShopifyApp<Config>;\n}",
             "examples": [
               {
                 "title": "The minimum viable configuration",
@@ -2843,6 +3456,14 @@
               {
                 "filePath": "/server/config-types.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "future",
+                "value": "FutureFlags",
+                "description": "Features that will be introduced in future releases of this package.\n\nYou can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future releases in advance and provide feedback on the new features.",
+                "isOptional": true
+              },
+              {
+                "filePath": "/server/config-types.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "apiKey",
                 "value": "string",
                 "description": "",
@@ -2920,7 +3541,7 @@
                 "isOptional": true
               }
             ],
-            "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n> extends Omit<\n    ApiConfigArg<Resources>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n}"
+            "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n> extends Omit<\n    ApiConfigArg<Resources>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n\n  /**\n   * Features that will be introduced in future releases of this package.\n   *\n   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future\n   * releases in advance and provide feedback on the new features.\n   */\n  future?: FutureFlags;\n}"
           },
           "WebhookConfig": {
             "filePath": "/server/config-types.ts",
@@ -3078,6 +3699,23 @@
                 "value": "shopify_admin"
               }
             ]
+          },
+          "FutureFlags": {
+            "filePath": "/server/future/flags.ts",
+            "name": "FutureFlags",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "v3_webhookAdminContext",
+                "value": "boolean",
+                "description": "When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.\n   *\n   * @default false\n   */\n  v3_webhookAdminContext?: boolean;\n}"
           },
           "ShopifyApp": {
             "filePath": "/server/types.ts",
@@ -3321,7 +3959,7 @@
                 "filePath": "/server/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "webhook",
-                "value": "AuthenticateWebhook<\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >",
+                "value": "AuthenticateWebhook<\n    Config['future'],\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >",
                 "description": "Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request",
                 "examples": [
                   {
@@ -3341,7 +3979,7 @@
                 ]
               }
             ],
-            "value": "interface Authenticate<Config extends AppConfigArg> {\n  /**\n   * Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n   *\n   * Examples of when to use this are requests from your app's UI, or requests from admin extensions.\n   *\n   * If there is no session for the Request, this will redirect the merchant to correct auth flows.\n   *\n   * @example\n   * <caption>Authenticating a request for an embedded app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {admin, session, sessionToken, billing} = authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a public request and get back a session token.\n   *\n   * @example\n   * <caption>Authenticating a request from a checkout extension</caption>\n   *\n   * ```ts\n   * // /app/routes/api/checkout.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   * import { getWidgets } from \"~/db/widgets\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {sessionToken} = authenticate.public.checkout(request);\n   *\n   *   return json(await getWidgets(sessionToken));\n   * }\n   * ```\n   */\n  public: AuthenticatePublic;\n\n  /**\n   * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request\n   *\n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *    APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *       callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop, session } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       if (session) {\n   *         await db.session.deleteMany({ where: { shop } });\n   *       }\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhook: AuthenticateWebhook<\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >;\n}"
+            "value": "interface Authenticate<Config extends AppConfigArg> {\n  /**\n   * Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n   *\n   * Examples of when to use this are requests from your app's UI, or requests from admin extensions.\n   *\n   * If there is no session for the Request, this will redirect the merchant to correct auth flows.\n   *\n   * @example\n   * <caption>Authenticating a request for an embedded app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {admin, session, sessionToken, billing} = authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a public request and get back a session token.\n   *\n   * @example\n   * <caption>Authenticating a request from a checkout extension</caption>\n   *\n   * ```ts\n   * // /app/routes/api/checkout.jsx\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   * import { getWidgets } from \"~/db/widgets\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   const {sessionToken} = authenticate.public.checkout(request);\n   *\n   *   return json(await getWidgets(sessionToken));\n   * }\n   * ```\n   */\n  public: AuthenticatePublic;\n\n  /**\n   * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request\n   *\n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *    APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *       callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop, session } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       if (session) {\n   *         await db.session.deleteMany({ where: { shop } });\n   *       }\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhook: AuthenticateWebhook<\n    Config['future'],\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >;\n}"
           },
           "AuthenticateAdmin": {
             "filePath": "/server/types.ts",
@@ -4172,14 +4810,21 @@
             "returns": {
               "filePath": "/server/authenticate/webhooks/types.ts",
               "description": "",
-              "name": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>",
-              "value": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>"
+              "name": "Promise<WebhookContext<Future, Resources, Topics>>",
+              "value": "Promise<WebhookContext<Future, Resources, Topics>>"
             },
-            "value": "export type AuthenticateWebhook<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Topics = string | number | symbol,\n> = (\n  request: Request,\n) => Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>;"
+            "value": "export type AuthenticateWebhook<\n  Future extends FutureFlagOptions,\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> = (request: Request) => Promise<WebhookContext<Future, Resources, Topics>>;"
           },
           "WebhookContext": {
             "filePath": "/server/authenticate/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
             "name": "WebhookContext",
+            "value": "WebhookContextWithoutSession<Topics> | WebhookContextWithSession<Future, Resources, Topics>",
+            "description": ""
+          },
+          "WebhookContextWithoutSession": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "name": "WebhookContextWithoutSession",
             "description": "",
             "members": [
               {
@@ -4292,7 +4937,7 @@
                 ]
               }
             ],
-            "value": "export interface WebhookContext<Topics = string | number | symbol>\n  extends Context<Topics> {\n  session: undefined;\n  admin: undefined;\n}"
+            "value": "export interface WebhookContextWithoutSession<Topics = string | number | symbol>\n  extends Context<Topics> {\n  session: undefined;\n  admin: undefined;\n}"
           },
           "JSONValue": {
             "filePath": "/server/types.ts",
@@ -4546,14 +5191,14 @@
               {
                 "filePath": "/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@iterator@527",
+                "name": "__@iterator@540",
                 "value": "() => IterableIterator<JSONValue>",
                 "description": "Iterator"
               },
               {
                 "filePath": "/server/types.ts",
                 "syntaxKind": "MethodSignature",
-                "name": "__@unscopables@529",
+                "name": "__@unscopables@542",
                 "value": "() => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }",
                 "description": "Returns an object whose properties have the value 'true'\r\nwhen they will be absent when used in a 'with' statement."
               },
@@ -4583,8 +5228,30 @@
                 "filePath": "/server/authenticate/webhooks/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "admin",
-                "value": "{ rest: RestClient & Resources; graphql: GraphqlClient; }",
-                "description": "An admin context for the webhook.\n\nReturned only if there is a session for the shop."
+                "value": "WebhookAdminContext<Future, Resources>",
+                "description": "An admin context for the webhook.\n\nReturned only if there is a session for the shop.",
+                "examples": [
+                  {
+                    "title": "[V3] Webhook admin context",
+                    "description": "With the `v3_webhookAdminContext` future flag enabled, use the `admin` object in the context to interact with the Admin API.",
+                    "tabs": [
+                      {
+                        "code": "import { ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Webhook admin context",
+                    "description": "Use the `admin` object in the context to interact with the Admin API. This format will be removed in V3 of the package.",
+                    "tabs": [
+                      {
+                        "code": "import { json, ActionFunctionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionFunctionArgs) {\n  const { admin } = await authenticate.webhook(request);\n\n  const response = await admin?.graphql.query<any>({\n    data: {\n      query: `#graphql\n        mutation populateProduct($input: ProductInput!) {\n          productCreate(input: $input) {\n            product {\n              id\n            }\n          }\n        }`,\n      variables: { input: { title: \"Product Name\" } },\n    },\n  });\n\n  const productData = response?.body.data;\n  return json({ data: productData.data });\n}",
+                        "title": "Example"
+                      }
+                    ]
+                  }
+                ]
               },
               {
                 "filePath": "/server/authenticate/webhooks/types.ts",
@@ -4682,7 +5349,43 @@
                 ]
               }
             ],
-            "value": "export interface WebhookContextWithSession<\n  Topics = string | number | symbol,\n  Resources extends ShopifyRestResources = any,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  admin: {\n    /** A REST client. */\n    rest: InstanceType<Shopify['clients']['Rest']> & Resources;\n    /** A GraphQL client. */\n    graphql: InstanceType<Shopify['clients']['Graphql']>;\n  };\n}"
+            "value": "export interface WebhookContextWithSession<\n  Future extends FutureFlagOptions,\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>[V3] Webhook admin context.</caption>\n   * <description>With the `v3_webhookAdminContext` future flag enabled, use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   *\n   * @example\n   * <caption>Webhook admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API. This format will be removed in V3 of the package.</description>\n   * ```ts\n   * import { json, ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   const response = await admin?.graphql.query<any>({\n   *     data: {\n   *       query: `#graphql\n   *         mutation populateProduct($input: ProductInput!) {\n   *           productCreate(input: $input) {\n   *             product {\n   *               id\n   *             }\n   *           }\n   *         }`,\n   *       variables: { input: { title: \"Product Name\" } },\n   *     },\n   *   });\n   *\n   *   const productData = response?.body.data;\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: WebhookAdminContext<Future, Resources>;\n}"
+          },
+          "WebhookAdminContext": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "WebhookAdminContext",
+            "value": "FeatureEnabled<Future, 'v3_webhookAdminContext'> extends true\n  ? AdminApiContext<Resources>\n  : LegacyWebhookAdminApiContext<Resources>",
+            "description": ""
+          },
+          "FeatureEnabled": {
+            "filePath": "/server/future/flags.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "FeatureEnabled",
+            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
+            "description": ""
+          },
+          "LegacyWebhookAdminApiContext": {
+            "filePath": "/server/authenticate/webhooks/types.ts",
+            "name": "LegacyWebhookAdminApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/authenticate/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "rest",
+                "value": "RestClient & Resources",
+                "description": "A REST client."
+              },
+              {
+                "filePath": "/server/authenticate/webhooks/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "graphql",
+                "value": "InstanceType<Shopify['clients']['Graphql']>",
+                "description": "A GraphQL client."
+              }
+            ],
+            "value": "export interface LegacyWebhookAdminApiContext<\n  Resources extends ShopifyRestResources,\n> {\n  /** A REST client. */\n  rest: InstanceType<Shopify['clients']['Rest']> & Resources;\n  /** A GraphQL client. */\n  graphql: InstanceType<Shopify['clients']['Graphql']>;\n}"
           },
           "MandatoryTopics": {
             "filePath": "/server/types.ts",
@@ -5062,6 +5765,30 @@
             "name": "AppStoreApp",
             "value": "ShopifyAppBase<Config> & ShopifyAppLogin",
             "description": ""
+          }
+        }
+      },
+      {
+        "title": "Future flags",
+        "description": "Set future flags using the `future` configuration field to opt in to upcoming breaking changes.\n\nWith this feature, you can prepare for major releases ahead of time, as well as try out new features before they are released.",
+        "type": "FutureFlags",
+        "typeDefinitions": {
+          "FutureFlags": {
+            "filePath": "/server/future/flags.ts",
+            "name": "FutureFlags",
+            "description": "",
+            "members": [
+              {
+                "filePath": "/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "v3_webhookAdminContext",
+                "value": "boolean",
+                "description": "When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.\n   *\n   * @default false\n   */\n  v3_webhookAdminContext?: boolean;\n}"
           }
         }
       }

--- a/packages/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -1770,7 +1770,7 @@
   },
   {
     "name": "Webhook",
-    "description": "Contains functions for verifying Shopify webhooks.\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag.",
+    "description": "Contains functions for verifying Shopify webhooks.\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag. Learn more about [gradual feature adoption](/docs/api/shopify-app-remix/guide-future-flags).",
     "category": "Authenticate",
     "type": "object",
     "isVisualComponent": false,

--- a/packages/shopify-app-remix/docs/generated/generated_static_pages.json
+++ b/packages/shopify-app-remix/docs/generated/generated_static_pages.json
@@ -103,6 +103,65 @@
     ]
   },
   {
+    "id": "guide-future-flags",
+    "title": "Future flags",
+    "description": "Similarly to how [Remix approaches breaking changes](https://remix.run/docs/en/main/start/future-flags), the `@shopify/shopify-app-remix` package also uses future flags.\n\nBigger features are breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function.\n\nThis allows apps to gradually adopt new features, and prepare for breaking changes and major releases ahead of time.",
+    "sections": [
+      {
+        "type": "Generic",
+        "anchorLink": "configuration",
+        "title": "Setting future flags",
+        "sectionContent": "To opt in to a feature, simply enable the appropriate flag in the `future` option of the `shopifyApp` function.\n\nOnce a flag is set, the returned `shopify` object will start using the new APIs, including using any new types. That allows apps to rely on TypeScript to use a feature regardless of a flag being enabled or not.",
+        "codeblock": {
+          "title": "/app/shopify.server.ts",
+          "tabs": [
+            {
+              "title": "/app/shopify.server.ts",
+              "language": "ts",
+              "code": "import {shopifyApp} from '@shopify/shopify-app-remix/server';\n\nexport const shopify = shopifyApp({\n  // ...\n  future: {\n    unstable_newFeature: true,\n  },\n});\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "unstable-apis",
+        "title": "Unstable APIs",
+        "sectionContent": "When introducing new features to the package for which we want to gather feedback, we will add them behind a future flag, starting with the `unstable_` prefix.\n\nThat allows early adopters to try them out individually, without having to install a release candidate package.\n\nWhen the feature is ready for release, the future flag will be removed and it will be available by default.\n\nIn this example, `shopify` has a new function called `newFeature`. If the future flag is disabled, TypeScript will be unaware of the new function, and the app will fail to compile if it tries to use it.",
+        "codeblock": {
+          "title": "/app/routes/*.tsx",
+          "tabs": [
+            {
+              "title": "/app/routes/*.tsx",
+              "language": "ts",
+              "code": "import type {LoaderFunctionArgs} from '@remix-run/node';\n\nimport {shopify} from '~/shopify.server';\n\nexport const loader = async ({request}: LoaderFunctionArgs) =&gt; {\n  const result = shopify.newFeature(params);\n\n  return null;\n};\n"
+            }
+          ]
+        }
+      },
+      {
+        "type": "Generic",
+        "anchorLink": "breaking-changes",
+        "title": "Breaking changes",
+        "sectionContent": "Similarly to unstable APIs, breaking changes will be introduced behind a future flag, but the prefix will be the next major version (e.g. `v3_`).\n\nThis allows apps to prepare for the next major version ahead of time, and to gradually adopt the new APIs.\n\nWhen the next major version is released, the future flag will be removed, and the old code it changes will be removed. Apps that adopted the flag before then will continue to work the same way with no new changes."
+      },
+      {
+        "type": "GenericList",
+        "anchorLink": "flags",
+        "title": "Supported flags",
+        "sectionContent": "These are the future flags supported in the current version.",
+        "listItems": [
+          {
+            "name": "v3_webhookAdminContext",
+            "value": "",
+            "description": "Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.",
+            "isOptional": true
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "shopify-app-remix",
     "title": "Shopify App package for Remix",
     "description": "The [@shopify/shopify-app-remix](https://www.npmjs.com/package/@shopify/shopify-app-remix) package enables Remix apps to authenticate with Shopify and make API calls. It uses [App Bridge](/docs/api/app-bridge-library) to enable apps to embed themselves in the Shopify Admin.\n\nIn this page we'll go over the main components you need to integrate an app with Shopify.",

--- a/packages/shopify-app-remix/docs/generated/generated_static_pages.json
+++ b/packages/shopify-app-remix/docs/generated/generated_static_pages.json
@@ -105,7 +105,7 @@
   {
     "id": "guide-future-flags",
     "title": "Future flags",
-    "description": "Similarly to how [Remix approaches breaking changes](https://remix.run/docs/en/main/start/future-flags), the `@shopify/shopify-app-remix` package also uses future flags.\n\nBigger features are breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function.\n\nThis allows apps to gradually adopt new features, and prepare for breaking changes and major releases ahead of time.",
+    "description": "Similarly to how [Remix approaches breaking changes](https://remix.run/docs/en/main/start/future-flags), the `@shopify/shopify-app-remix` package also uses future flags.\n\nBigger features and breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function.\n\nThis allows apps to gradually adopt new features, and prepare for breaking changes and major releases ahead of time.",
     "sections": [
       {
         "type": "Generic",
@@ -154,7 +154,7 @@
           {
             "name": "v3_webhookAdminContext",
             "value": "",
-            "description": "Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.",
+            "description": "Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.\n\nSee [authenticate.webhook](/docs/api/shopify-app-remix/authenticate/webhook#example-admin) for more details.",
             "isOptional": true
           }
         ]

--- a/packages/shopify-app-remix/docs/staticPages/examples/guides/future-flags/config.example.ts
+++ b/packages/shopify-app-remix/docs/staticPages/examples/guides/future-flags/config.example.ts
@@ -1,0 +1,8 @@
+import {shopifyApp} from '@shopify/shopify-app-remix/server';
+
+export const shopify = shopifyApp({
+  // ...
+  future: {
+    unstable_newFeature: true,
+  },
+});

--- a/packages/shopify-app-remix/docs/staticPages/examples/guides/future-flags/unstable.example.ts
+++ b/packages/shopify-app-remix/docs/staticPages/examples/guides/future-flags/unstable.example.ts
@@ -1,0 +1,9 @@
+import type {LoaderFunctionArgs} from '@remix-run/node';
+
+import {shopify} from '~/shopify.server';
+
+export const loader = async ({request}: LoaderFunctionArgs) => {
+  const result = shopify.newFeature(params);
+
+  return null;
+};

--- a/packages/shopify-app-remix/docs/staticPages/future-flags.doc.ts
+++ b/packages/shopify-app-remix/docs/staticPages/future-flags.doc.ts
@@ -5,7 +5,7 @@ const data: LandingTemplateSchema = {
   title: 'Future flags',
   description:
     'Similarly to how [Remix approaches breaking changes](https://remix.run/docs/en/main/start/future-flags), the `@shopify/shopify-app-remix` package also uses future flags.' +
-    "\n\nBigger features are breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function." +
+    "\n\nBigger features and breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function." +
     '\n\nThis allows apps to gradually adopt new features, and prepare for breaking changes and major releases ahead of time.',
   sections: [
     {
@@ -66,7 +66,8 @@ const data: LandingTemplateSchema = {
           name: 'v3_webhookAdminContext',
           value: '',
           description:
-            'Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.',
+            'Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.' +
+            '\n\nSee [authenticate.webhook](/docs/api/shopify-app-remix/authenticate/webhook#example-admin) for more details.',
           isOptional: true,
         },
       ],

--- a/packages/shopify-app-remix/docs/staticPages/future-flags.doc.ts
+++ b/packages/shopify-app-remix/docs/staticPages/future-flags.doc.ts
@@ -1,0 +1,77 @@
+import {LandingTemplateSchema} from '@shopify/generate-docs';
+
+const data: LandingTemplateSchema = {
+  id: 'guide-future-flags',
+  title: 'Future flags',
+  description:
+    'Similarly to how [Remix approaches breaking changes](https://remix.run/docs/en/main/start/future-flags), the `@shopify/shopify-app-remix` package also uses future flags.' +
+    "\n\nBigger features are breaking changes are initially added behind a future flag. This means that they're disabled by default, and must be manually enabled by setting the appropriate flag in the `future` option of the `shopifyApp` function." +
+    '\n\nThis allows apps to gradually adopt new features, and prepare for breaking changes and major releases ahead of time.',
+  sections: [
+    {
+      type: 'Generic',
+      anchorLink: 'configuration',
+      title: 'Setting future flags',
+      sectionContent:
+        'To opt in to a feature, simply enable the appropriate flag in the `future` option of the `shopifyApp` function.' +
+        '\n\nOnce a flag is set, the returned `shopify` object will start using the new APIs, including using any new types. That allows apps to rely on TypeScript to use a feature regardless of a flag being enabled or not.',
+      codeblock: {
+        title: '/app/shopify.server.ts',
+        tabs: [
+          {
+            title: '/app/shopify.server.ts',
+            language: 'ts',
+            code: './examples/guides/future-flags/config.example.ts',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'unstable-apis',
+      title: 'Unstable APIs',
+      sectionContent:
+        'When introducing new features to the package for which we want to gather feedback, we will add them behind a future flag, starting with the `unstable_` prefix.' +
+        '\n\nThat allows early adopters to try them out individually, without having to install a release candidate package.' +
+        '\n\nWhen the feature is ready for release, the future flag will be removed and it will be available by default.' +
+        '\n\nIn this example, `shopify` has a new function called `newFeature`. If the future flag is disabled, TypeScript will be unaware of the new function, and the app will fail to compile if it tries to use it.',
+      codeblock: {
+        title: '/app/routes/*.tsx',
+        tabs: [
+          {
+            title: '/app/routes/*.tsx',
+            language: 'ts',
+            code: './examples/guides/future-flags/unstable.example.ts',
+          },
+        ],
+      },
+    },
+    {
+      type: 'Generic',
+      anchorLink: 'breaking-changes',
+      title: 'Breaking changes',
+      sectionContent:
+        'Similarly to unstable APIs, breaking changes will be introduced behind a future flag, but the prefix will be the next major version (e.g. `v3_`).' +
+        '\n\nThis allows apps to prepare for the next major version ahead of time, and to gradually adopt the new APIs.' +
+        '\n\nWhen the next major version is released, the future flag will be removed, and the old code it changes will be removed. Apps that adopted the flag before then will continue to work the same way with no new changes.',
+    },
+    {
+      type: 'GenericList',
+      anchorLink: 'flags',
+      title: 'Supported flags',
+      sectionContent:
+        'These are the future flags supported in the current version.',
+      listItems: [
+        {
+          name: 'v3_webhookAdminContext',
+          value: '',
+          description:
+            'Returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.',
+          isOptional: true,
+        },
+      ],
+    },
+  ],
+};
+
+export default data;

--- a/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -1,14 +1,32 @@
-import {SessionStorage} from '@shopify/shopify-app-session-storage';
 import {LATEST_API_VERSION, LogSeverity} from '@shopify/shopify-api';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
 
-import {AppConfigArg} from '../config-types';
+import type {AppConfigArg} from '../config-types';
+import type {FutureFlags} from '../future/flags';
 
 import {API_KEY, API_SECRET_KEY, APP_URL} from './const';
 
-export function testConfig(
-  overrides: Partial<AppConfigArg> = {},
-): AppConfigArg & {sessionStorage: SessionStorage} {
+type DefaultedFutureFlag<
+  Overrides extends Partial<AppConfigArg>,
+  Flag extends keyof FutureFlags,
+> = Overrides['future'] extends FutureFlags ? Overrides['future'][Flag] : true;
+
+type TestConfig<Overrides extends Partial<AppConfigArg>> =
+  // We omit billing so we use the actual values when set, rather than the generic type
+  Omit<AppConfigArg, 'billing'> &
+    Overrides & {
+      // Create an object with all future flags defaulted to active to ensure our tests are updated when we introduce new flags
+      future: {
+        v3_webhookAdminContext: DefaultedFutureFlag<
+          Overrides,
+          'v3_webhookAdminContext'
+        >;
+      };
+    };
+
+export function testConfig<Overrides extends Partial<AppConfigArg>>(
+  overrides: Overrides = {} as Overrides,
+): TestConfig<Overrides> {
   return {
     apiKey: API_KEY,
     apiSecretKey: API_SECRET_KEY,
@@ -22,5 +40,9 @@ export function testConfig(
     isEmbeddedApp: true,
     sessionStorage: new MemorySessionStorage(),
     ...overrides,
+    future: {
+      v3_webhookAdminContext: true,
+      ...(overrides.future as Overrides['future']),
+    },
   };
 }

--- a/packages/shopify-app-remix/src/server/__tests__/shopify-app.test.ts
+++ b/packages/shopify-app-remix/src/server/__tests__/shopify-app.test.ts
@@ -45,10 +45,9 @@ describe('shopifyApp', () => {
 
   it('does not have login function when distribution is ShopifyAdmin', () => {
     // GIVEN
-    const shopify = shopifyApp({
-      ...testConfig(),
-      distribution: AppDistribution.ShopifyAdmin,
-    });
+    const shopify = shopifyApp(
+      testConfig({distribution: AppDistribution.ShopifyAdmin}),
+    );
 
     // THEN
     expect(shopify).not.toHaveProperty('login');

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/admin-client.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/admin-client.test.ts
@@ -21,8 +21,8 @@ import {
   expectAdminApiClient,
 } from '../../../__test-helpers';
 import {shopifyApp} from '../../..';
-import {AdminApiContext} from '../../../config-types';
 import {REAUTH_URL_HEADER} from '../../const';
+import {AdminApiContext} from '../../../clients';
 
 describe('admin.authenticate context', () => {
   expectAdminApiClient(async () => {
@@ -196,7 +196,7 @@ describe('admin.authenticate context', () => {
 });
 
 async function setUpEmbeddedFlow() {
-  const shopify = shopifyApp({...testConfig(), restResources});
+  const shopify = shopifyApp(testConfig({restResources}));
   const expectedSession = await setUpValidSession(shopify.sessionStorage);
 
   const {token} = getJwt();
@@ -212,7 +212,7 @@ async function setUpEmbeddedFlow() {
 }
 
 async function setUpFetchFlow() {
-  const shopify = shopifyApp({...testConfig(), restResources});
+  const shopify = shopifyApp(testConfig({restResources}));
   await setUpValidSession(shopify.sessionStorage);
 
   const {token} = getJwt();
@@ -227,11 +227,7 @@ async function setUpFetchFlow() {
 }
 
 async function setUpNonEmbeddedFlow() {
-  const shopify = shopifyApp({
-    ...testConfig(),
-    restResources,
-    isEmbeddedApp: false,
-  });
+  const shopify = shopifyApp(testConfig({restResources, isEmbeddedApp: false}));
   const session = await setUpValidSession(shopify.sessionStorage);
 
   const request = new Request(`${APP_URL}?shop=${TEST_SHOP}`);

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
@@ -387,7 +387,7 @@ describe('authorize.admin doc request path', () => {
 
       it('returns the context if the session is valid and the app is not embedded', async () => {
         // GIVEN
-        const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+        const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
@@ -419,7 +419,7 @@ describe('authorize.admin doc request path', () => {
 
   it('loads a session from the cookie from a request with no search params when not embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
     const testSession = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN
@@ -438,7 +438,7 @@ describe('authorize.admin doc request path', () => {
 
   it('returns a 400 response when no shop is available', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
     await setUpValidSession(shopify.sessionStorage);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
@@ -113,11 +113,9 @@ describe('authorize.session token header path', () => {
 
       it('returns context when session exists for non-embedded apps', async () => {
         // GIVEN
-        const shopify = shopifyApp({
-          ...testConfig(),
-          isEmbeddedApp: false,
-          useOnlineTokens: isOnline,
-        });
+        const shopify = shopifyApp(
+          testConfig({isEmbeddedApp: false, useOnlineTokens: isOnline}),
+        );
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
@@ -1,8 +1,8 @@
 import {
+  BillingConfigSubscriptionPlan,
   BillingInterval,
   HttpResponseError,
   SESSION_COOKIE_NAME,
-  Shopify,
 } from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../../..';
@@ -24,18 +24,18 @@ import {REAUTH_URL_HEADER} from '../../../const';
 
 import * as responses from './mock-responses';
 
-const BILLING_CONFIG: Shopify['config']['billing'] = {
+const BILLING_CONFIG = {
   [responses.PLAN_1]: {
     amount: 5,
     currencyCode: 'USD',
     interval: BillingInterval.Every30Days,
-  },
+  } as BillingConfigSubscriptionPlan,
 };
 
 describe('Cancel billing', () => {
   it('returns an AppSubscription when the cancellation is successful', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     const {billing} = await shopify.authenticate.admin(
@@ -62,12 +62,8 @@ describe('Cancel billing', () => {
 
   it('redirects to authentication when at the top level when Shopify invalidated the session', async () => {
     // GIVEN
-    const config = testConfig();
-    const shopify = shopifyApp({
-      ...config,
-      isEmbeddedApp: false,
-      billing: BILLING_CONFIG,
-    });
+    const config = testConfig({isEmbeddedApp: false, billing: BILLING_CONFIG});
+    const shopify = shopifyApp(config);
     const session = await setUpValidSession(shopify.sessionStorage);
 
     const request = new Request(`${APP_URL}/billing?shop=${TEST_SHOP}`);
@@ -104,7 +100,7 @@ describe('Cancel billing', () => {
 
   it('redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     const {token} = getJwt();
@@ -139,7 +135,7 @@ describe('Cancel billing', () => {
 
   it('returns redirection headers during fetch requests when Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     const request = new Request(`${APP_URL}/billing`, {
@@ -181,11 +177,9 @@ describe('Cancel billing', () => {
 
   it('throws errors other than authentication errors', async () => {
     // GIVEN
-    const shopify = shopifyApp({
-      ...testConfig(),
-      isEmbeddedApp: false,
-      billing: BILLING_CONFIG,
-    });
+    const shopify = shopifyApp(
+      testConfig({isEmbeddedApp: false, billing: BILLING_CONFIG}),
+    );
     const session = await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
@@ -1,9 +1,9 @@
 import {
+  BillingConfigSubscriptionPlan,
   BillingError,
   BillingInterval,
   HttpResponseError,
   SESSION_COOKIE_NAME,
-  Shopify,
 } from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../../..';
@@ -26,22 +26,20 @@ import {REAUTH_URL_HEADER} from '../../../const';
 
 import * as responses from './mock-responses';
 
-const BILLING_CONFIG: Shopify['config']['billing'] = {
+const BILLING_CONFIG = {
   [responses.PLAN_1]: {
     amount: 5,
     currencyCode: 'USD',
     interval: BillingInterval.Every30Days,
-  },
+  } as BillingConfigSubscriptionPlan,
 };
 
 describe('Billing request', () => {
   it('redirects to payment confirmation URL when successful and at the top level for non-embedded apps', async () => {
     // GIVEN
-    const shopify = shopifyApp({
-      ...testConfig(),
-      isEmbeddedApp: false,
-      billing: BILLING_CONFIG,
-    });
+    const shopify = shopifyApp(
+      testConfig({isEmbeddedApp: false, billing: BILLING_CONFIG}),
+    );
     const session = await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequests({
@@ -73,7 +71,7 @@ describe('Billing request', () => {
 
   it('redirects to exit-iframe with payment confirmation URL when successful using app bridge when embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({
@@ -102,7 +100,7 @@ describe('Billing request', () => {
 
   it('returns redirection headers when successful during fetch requests', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({
@@ -134,11 +132,9 @@ describe('Billing request', () => {
   it('redirects to authentication when at the top level when Shopify invalidated the session', async () => {
     // GIVEN
     const config = testConfig();
-    const shopify = shopifyApp({
-      ...config,
-      isEmbeddedApp: false,
-      billing: BILLING_CONFIG,
-    });
+    const shopify = shopifyApp(
+      testConfig({isEmbeddedApp: false, billing: BILLING_CONFIG}),
+    );
     const session = await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequests({
@@ -170,7 +166,7 @@ describe('Billing request', () => {
 
   it('redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({
@@ -200,7 +196,7 @@ describe('Billing request', () => {
 
   it('returns redirection headers during fetch requests when Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({
@@ -235,11 +231,9 @@ describe('Billing request', () => {
 
   it('throws errors other than authentication errors', async () => {
     // GIVEN
-    const shopify = shopifyApp({
-      ...testConfig(),
-      isEmbeddedApp: false,
-      billing: BILLING_CONFIG,
-    });
+    const shopify = shopifyApp(
+      testConfig({isEmbeddedApp: false, billing: BILLING_CONFIG}),
+    );
     const session = await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequests({
@@ -267,7 +261,7 @@ describe('Billing request', () => {
 
   it('throws a BillingError when the response contains user errors', async () => {
     // GIVEN
-    const shopify = shopifyApp({...testConfig(), billing: BILLING_CONFIG});
+    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/__tests__/redirect.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/__tests__/redirect.test.ts
@@ -293,7 +293,7 @@ describe('Redirect helper', () => {
   describe('when not embedded', () => {
     it('is not returned as part of the context', async () => {
       // GIVEN
-      const shopify = shopifyApp({...testConfig(), isEmbeddedApp: false});
+      const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
       const testSession = await setUpValidSession(shopify.sessionStorage);
 
       const request = new Request(APP_URL);

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/__tests__/add-response-headers.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/__tests__/add-response-headers.test.ts
@@ -11,8 +11,7 @@ describe('addDocumentResponseHeaders', () => {
     'adds frame-ancestors CSP headers when embedded = %s',
     (isEmbeddedApp) => {
       // GIVEN
-      const config = {...testConfig(), isEmbeddedApp};
-      const shopify = shopifyApp(config);
+      const shopify = shopifyApp(testConfig({isEmbeddedApp}));
       const request = new Request(`${APP_URL}?shop=${TEST_SHOP}`);
       const response = new Response();
 

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
@@ -6,8 +6,10 @@ import {shopifyApp} from '../../..';
 import {
   APP_URL,
   TEST_SHOP,
+  expectAdminApiClient,
   getHmac,
   getThrownResponse,
+  setUpValidSession,
   testConfig,
 } from '../../../__test-helpers';
 
@@ -55,31 +57,64 @@ describe('Webhook validation', () => {
     expect(actualSession).toBeUndefined();
   });
 
-  it('returns context with session when there is a session', async () => {
-    // GIVEN
-    const sessionStorage = new MemorySessionStorage();
-    const shopify = shopifyApp(testConfig({sessionStorage, restResources}));
-    const body = {some: 'data'};
+  describe('returns context with session when there is a session', () => {
+    expectAdminApiClient(async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const shopify = shopifyApp(testConfig({sessionStorage, restResources}));
+      const body = {some: 'data'};
 
-    const session = new Session({
-      id: `offline_${TEST_SHOP}`,
-      shop: TEST_SHOP,
-      isOnline: false,
-      state: 'test',
-      accessToken: 'totally_real_token',
+      const expectedSession = new Session({
+        id: `offline_${TEST_SHOP}`,
+        shop: TEST_SHOP,
+        isOnline: false,
+        state: 'test',
+        accessToken: 'totally_real_token',
+      });
+      await sessionStorage.storeSession(expectedSession);
+
+      // WHEN
+      const {
+        admin,
+        apiVersion,
+        session: actualSession,
+        shop,
+        topic,
+        webhookId,
+        payload,
+      } = await shopify.authenticate.webhook(
+        new Request(`${APP_URL}/webhooks`, {
+          method: 'POST',
+          body: JSON.stringify(body),
+          headers: webhookHeaders(JSON.stringify(body)),
+        }),
+      );
+
+      // THEN
+      expect(apiVersion).toBe('2023-01');
+      expect(shop).toBe(TEST_SHOP);
+      expect(topic).toBe('APP_UNINSTALLED');
+      expect(webhookId).toBe('1234567890');
+      expect(actualSession).toBe(expectedSession);
+      expect(payload).toEqual(body);
+
+      if (!admin) throw new Error('Expected admin to be defined');
+      if (!actualSession) throw new Error('Expected session to be defined');
+
+      return {admin, expectedSession, actualSession};
     });
-    await sessionStorage.storeSession(session);
+  });
+
+  it('returns a legacy context when the future flag is disabled', async () => {
+    // GIVEN
+    const shopify = shopifyApp(
+      testConfig({restResources, future: {v3_webhookAdminContext: false}}),
+    );
+    const session = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN
-    const {
-      admin,
-      apiVersion,
-      session: actualSession,
-      shop,
-      topic,
-      webhookId,
-      payload,
-    } = await shopify.authenticate.webhook(
+    const body = {some: 'data'};
+    const {admin} = await shopify.authenticate.webhook(
       new Request(`${APP_URL}/webhooks`, {
         method: 'POST',
         body: JSON.stringify(body),
@@ -88,18 +123,11 @@ describe('Webhook validation', () => {
     );
 
     // THEN
-    expect(apiVersion).toBe('2023-01');
-    expect(shop).toBe(TEST_SHOP);
-    expect(topic).toBe('APP_UNINSTALLED');
-    expect(webhookId).toBe('1234567890');
-    expect(actualSession).toBe(session);
-    expect(payload).toEqual(body);
+    expect(admin?.rest.apiVersion).toBe('2023-01');
+    expect(admin?.rest.session).toBe(session);
 
-    expect(admin.rest.apiVersion).toBe('2023-01');
-    expect(admin.rest.session).toBe(session);
-
-    expect(admin.graphql.apiVersion).toBe('2023-01');
-    expect(admin.graphql.session).toBe(session);
+    expect(admin?.graphql.apiVersion).toBe('2023-01');
+    expect(admin?.graphql.session).toBe(session);
   });
 
   it('throws a 400 on invalid HMAC', async () => {

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
@@ -1,18 +1,28 @@
 import {ApiVersion, ShopifyRestResources} from '@shopify/shopify-api';
 
 import type {BasicParams, MandatoryTopics} from '../../types';
+import {AdminApiContext, adminClientFactory} from '../../clients';
+import {handleClientErrorFactory} from '../admin/helpers';
+import {FutureFlagOptions} from '../../future/flags';
 
-import type {WebhookContext, WebhookContextWithSession} from './types';
+import type {
+  AuthenticateWebhook,
+  LegacyWebhookAdminApiContext,
+  WebhookAdminContext,
+  WebhookContext,
+  WebhookContextWithoutSession,
+} from './types';
 
 export function authenticateWebhookFactory<
+  Future extends FutureFlagOptions,
   Resources extends ShopifyRestResources,
   Topics extends string | number | symbol | MandatoryTopics,
->({api, config, logger}: BasicParams) {
+>(params: BasicParams): AuthenticateWebhook<Future, Resources, Topics> {
+  const {api, config, logger} = params;
+
   return async function authenticate(
     request: Request,
-  ): Promise<
-    WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>
-  > {
+  ): Promise<WebhookContext<Future, Resources, Topics>> {
     if (request.method !== 'POST') {
       logger.debug(
         'Received a non-POST request for a webhook. Only POST requests are allowed.',
@@ -38,7 +48,7 @@ export function authenticateWebhookFactory<
 
     const sessionId = api.session.getOfflineId(check.domain);
     const session = await config.sessionStorage.loadSession(sessionId);
-    const webhookContext: WebhookContext<Topics> = {
+    const webhookContext: WebhookContextWithoutSession<Topics> = {
       apiVersion: check.apiVersion,
       shop: check.domain,
       topic: check.topic as Topics,
@@ -52,27 +62,39 @@ export function authenticateWebhookFactory<
       return webhookContext;
     }
 
-    const restClient = new api.clients.Rest({
-      session,
-      apiVersion: check.apiVersion as ApiVersion,
-    });
+    let admin:
+      | AdminApiContext<Resources>
+      | LegacyWebhookAdminApiContext<Resources>;
+    if (config.future.v3_webhookAdminContext) {
+      admin = adminClientFactory<Resources>({
+        params,
+        session,
+        handleClientError: handleClientErrorFactory({request}),
+      });
+    } else {
+      const restClient = new api.clients.Rest({
+        session,
+        apiVersion: check.apiVersion as ApiVersion,
+      });
+      const graphqlClient = new api.clients.Graphql({
+        session,
+        apiVersion: check.apiVersion as ApiVersion,
+      });
 
-    const graphqlClient = new api.clients.Graphql({
-      session,
-      apiVersion: check.apiVersion as ApiVersion,
-    });
+      Object.entries(api.rest).forEach(([name, resource]) => {
+        Reflect.set(restClient, name, resource);
+      });
 
-    Object.entries(api.rest).forEach(([name, resource]) => {
-      Reflect.set(restClient, name, resource);
-    });
+      admin = {
+        rest: restClient as typeof restClient & Resources,
+        graphql: graphqlClient,
+      };
+    }
 
     return {
       ...webhookContext,
       session,
-      admin: {
-        rest: restClient as typeof restClient & Resources,
-        graphql: graphqlClient,
-      },
+      admin: admin as WebhookAdminContext<Future, Resources>,
     };
   };
 }

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.webhooks.doc.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.webhooks.doc.ts
@@ -4,7 +4,7 @@ const data: ReferenceEntityTemplateSchema = {
   name: 'Webhook',
   description:
     'Contains functions for verifying Shopify webhooks.' +
-    '\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag.',
+    '\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag. Learn more about [gradual feature adoption](/docs/api/shopify-app-remix/guide-future-flags).',
   category: 'Authenticate',
   type: 'object',
   isVisualComponent: false,

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.webhooks.doc.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/authenticate.webhooks.doc.ts
@@ -2,7 +2,9 @@ import {ReferenceEntityTemplateSchema} from '@shopify/generate-docs';
 
 const data: ReferenceEntityTemplateSchema = {
   name: 'Webhook',
-  description: 'Contains functions for verifying Shopify webhooks.',
+  description:
+    'Contains functions for verifying Shopify webhooks.' +
+    '\n\n> Note: The format of the `admin` object returned by this function changes with the `v3_webhookAdminContext` future flag.',
   category: 'Authenticate',
   type: 'object',
   isVisualComponent: false,
@@ -14,7 +16,13 @@ const data: ReferenceEntityTemplateSchema = {
     },
   ],
   jsDocTypeExamples: ['WebhookContextWithSession'],
-  related: [],
+  related: [
+    {
+      name: 'Admin API context',
+      subtitle: 'Interact with the Admin API.',
+      url: '/docs/api/shopify-app-remix/apis/admin-api',
+    },
+  ],
 };
 
 export default data;

--- a/packages/shopify-app-remix/src/server/config-types.ts
+++ b/packages/shopify-app-remix/src/server/config-types.ts
@@ -8,6 +8,7 @@ import {
 } from '@shopify/shopify-api';
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
 
+import type {FutureFlags} from './future/flags';
 import type {AppDistribution} from './types';
 import type {AdminApiContext} from './clients';
 
@@ -211,6 +212,14 @@ export interface AppConfigArg<
    * ```
    */
   authPathPrefix?: string;
+
+  /**
+   * Features that will be introduced in future releases of this package.
+   *
+   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future
+   * releases in advance and provide feedback on the new features.
+   */
+  future?: FutureFlags;
 }
 
 export interface AppConfig<Storage extends SessionStorage = SessionStorage>
@@ -221,6 +230,7 @@ export interface AppConfig<Storage extends SessionStorage = SessionStorage>
   sessionStorage: Storage;
   useOnlineTokens: boolean;
   hooks: HooksConfig;
+  future: FutureFlags;
 }
 
 interface AuthConfig {

--- a/packages/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/shopify-app-remix/src/server/future/flags.ts
@@ -1,0 +1,19 @@
+export interface FutureFlags {
+  /**
+   * When enabled, returns the same `admin` context (`AdminApiContext`) from `authenticate.webhook` that is returned from `authenticate.admin`.
+   *
+   * @default false
+   */
+  v3_webhookAdminContext?: boolean;
+}
+
+export type FutureFlagOptions = FutureFlags | undefined;
+
+export type FeatureEnabled<
+  Future extends FutureFlagOptions,
+  Flag extends keyof FutureFlags,
+> = Future extends FutureFlags
+  ? Future[Flag] extends true
+    ? true
+    : false
+  : false;

--- a/packages/shopify-app-remix/src/server/shopify-app.doc.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.doc.ts
@@ -14,6 +14,13 @@ const data: ReferenceEntityTemplateSchema = {
       description: 'Function to create a new Shopify API object.',
       type: 'ShopifyAppGeneratedType',
     },
+    {
+      title: 'Future flags',
+      description:
+        'Set future flags using the `future` configuration field to opt in to upcoming breaking changes.' +
+        '\n\nWith this feature, you can prepare for major releases ahead of time, as well as try out new features before they are released.',
+      type: 'FutureFlags',
+    },
   ],
   jsDocTypeExamples: [
     'ShopifyAppGeneratedType',

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -79,6 +79,7 @@ export function shopifyApp<
       admin: oauth.authenticateAdmin.bind(oauth),
       public: authenticatePublicFactory<Resources>(params),
       webhook: authenticateWebhookFactory<
+        Config['future'],
         Resources,
         keyof Config['webhooks'] | MandatoryTopics
       >(params),
@@ -170,6 +171,7 @@ function deriveConfig<Storage extends SessionStorage>(
     useOnlineTokens: appConfig.useOnlineTokens ?? false,
     hooks: appConfig.hooks ?? {},
     sessionStorage: appConfig.sessionStorage as Storage,
+    future: appConfig.future ?? {},
     auth: {
       path: authPathPrefix,
       callbackPath: `${authPathPrefix}/callback`,

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -190,6 +190,7 @@ interface Authenticate<Config extends AppConfigArg> {
    * ```
    */
   webhook: AuthenticateWebhook<
+    Config['future'],
     RestResourcesType<Config>,
     keyof Config['webhooks'] | MandatoryTopics
   >;

--- a/packages/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
@@ -1,5 +1,6 @@
 import {Session} from '@shopify/shopify-api';
-import {BasicParams} from 'src/server/types';
+
+import {BasicParams} from '../../types';
 
 export async function getOfflineSession(
   shop: string,

--- a/packages/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
@@ -1,6 +1,6 @@
-import {BasicParams} from 'src/server/types';
 import {ShopifyError} from '@shopify/shopify-api';
 
+import {BasicParams} from '../../types';
 import {storefrontClientFactory} from '../../clients/storefront';
 import {getOfflineSession} from '../helpers';
 


### PR DESCRIPTION
### WHY are these changes introduced?

The format of `admin` in the return of `authenticate.webhook` is currently incorrect - it doesn't return the same `AdminApiContext` type we return elsewhere.

The main problem with updating that is that it is a breaking change. In order to avoid forcing developers to change their code to upgrade, we're introducing the concept of **future flags** to the `shopifyApp` configuration object.

### WHAT is this pull request doing?

Following the Remix standard, apps will be able to opt in to breaking changes ahead of time, which will enable us to continue making improvements while not breaking existing apps. Developers will also have time to update their apps before we make major releases.

The first flag we're introducing is `v3_webhookAdminContext`. This flag will change the output format of the `admin` context field in `authenticate.webhook`. If apps are using TS, they'll start getting type errors for this object as the return type is determined by the value of the flag in the config.

We're also including an example of each format to the documentation so that devs can more easily find the differences between the two.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
