### PR TITLE
Fixing test utils package version

### DIFF
--- a/.changeset/breezy-pandas-nail.md
+++ b/.changeset/breezy-pandas-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-session-storage-test-utils': patch
+---
+
+Dropping node 14 support

--- a/.changeset/chilled-bobcats-brush.md
+++ b/.changeset/chilled-bobcats-brush.md
@@ -11,7 +11,6 @@
 '@shopify/shopify-app-session-storage-prisma': major
 '@shopify/shopify-app-session-storage-redis': major
 '@shopify/shopify-app-session-storage-sqlite': major
-'@shopify/shopify-app-session-storage-test-utils': patch
 ---
 
 ### Removed support for Node 14


### PR DESCRIPTION
This is just a quick patch to fix the version of the internal package that will be published because of the node 14 change.