### PR TITLE
[Feature] Make postgresql connection string extensible

### DIFF
--- a/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
@@ -7,6 +7,7 @@ import {
 import {migrationList} from './migrations';
 import {PostgresConnection} from './postgres-connection';
 import {PostgresSessionStorageMigrator} from './postgres-migrator';
+import type {PoolConfig} from 'pg';
 
 export interface PostgreSQLSessionStorageOptions
   extends RdbmsSessionStorageOptions {
@@ -47,12 +48,12 @@ export class PostgreSQLSessionStorage implements SessionStorage {
   private migrator: PostgresSessionStorageMigrator;
 
   constructor(
-    dbUrl: URL | string,
+    config: string | URL | PoolConfig,
     opts: Partial<PostgreSQLSessionStorageOptions> = {},
   ) {
     this.options = {...defaultPostgreSQLSessionStorageOptions, ...opts};
     this.internalInit = this.init(
-      typeof dbUrl === 'string' ? dbUrl : dbUrl.toString(),
+      config instanceof URL ? config.toString() : config,
     );
     this.migrator = new PostgresSessionStorageMigrator(
       this.client,
@@ -144,8 +145,8 @@ export class PostgreSQLSessionStorage implements SessionStorage {
     return this.client.disconnect();
   }
 
-  private async init(dbUrl: string) {
-    this.client = new PostgresConnection(dbUrl, this.options.sessionTableName);
+  private async init(config: string | PoolConfig) {
+    this.client = new PostgresConnection(config, this.options.sessionTableName);
     await this.connectClient();
     await this.createTable();
   }


### PR DESCRIPTION
### WHY are these changes introduced?

I wanted to us the PostgreSQL adapted with a database that uses SSL/TLS. So I wanted to updated the SSL option of the config with my CA. But I wasn't able to edit it because the constructor only takes a connection URI.

### WHAT is this pull request doing?

It add the possibility to pass an object to the init in addition of an URL/string. And in the case where the dev passes an object (that is not an instance of URL), it passes the object as is to the PgPool config.

Then making possible to use any pg param 

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
