### PR TITLE
Add token exchange

### DIFF
--- a/.changeset/pink-horses-unite.md
+++ b/.changeset/pink-horses-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Add new embedded authorization strategy relying on Shopify managed install and OAuth token exchange

--- a/packages/shopify-app-remix/src/server/__test-helpers/setup-valid-session.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/setup-valid-session.ts
@@ -6,13 +6,14 @@ import {TEST_SHOP, USER_ID} from './const';
 export async function setUpValidSession(
   sessionStorage: SessionStorage,
   isOnline = false,
+  expires: Date | undefined = undefined,
 ): Promise<Session> {
   const overrides: Partial<Session> = {};
   let id = `offline_${TEST_SHOP}`;
   if (isOnline) {
     id = `${TEST_SHOP}_${USER_ID}`;
     // Expires one day from now
-    overrides.expires = new Date(Date.now() + 1000 * 3600 * 24);
+    overrides.expires = expires || new Date(Date.now() + 1000 * 3600 * 24);
     overrides.onlineAccessInfo = {
       associated_user_scope: 'testScope',
       expires_in: 3600 * 24,

--- a/packages/shopify-app-remix/src/server/__test-helpers/setup-valid-session.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/setup-valid-session.ts
@@ -5,15 +5,15 @@ import {TEST_SHOP, USER_ID} from './const';
 
 export async function setUpValidSession(
   sessionStorage: SessionStorage,
-  isOnline = false,
-  expires: Date | undefined = undefined,
+  sessionParams?: Partial<Session>,
 ): Promise<Session> {
   const overrides: Partial<Session> = {};
   let id = `offline_${TEST_SHOP}`;
-  if (isOnline) {
+  if (sessionParams?.isOnline) {
     id = `${TEST_SHOP}_${USER_ID}`;
     // Expires one day from now
-    overrides.expires = expires || new Date(Date.now() + 1000 * 3600 * 24);
+    overrides.expires =
+      sessionParams.expires || new Date(Date.now() + 1000 * 3600 * 24);
     overrides.onlineAccessInfo = {
       associated_user_scope: 'testScope',
       expires_in: 3600 * 24,
@@ -33,7 +33,7 @@ export async function setUpValidSession(
   const session = new Session({
     id,
     shop: TEST_SHOP,
-    isOnline,
+    isOnline: Boolean(sessionParams?.isOnline),
     state: 'test',
     accessToken: 'totally_real_token',
     scope: 'testScope',

--- a/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -45,20 +45,6 @@ beforeEach(() => {
   (TEST_CONFIG as any).sessionStorage = new MemorySessionStorage();
 });
 
-export function testConfigAuthCodeFlow<
-  Overrides extends TestOverridesArg<Future>,
-  Future extends FutureFlagOptions,
->(
-  {future, ...overrides}: Overrides & {future?: Future} = {} as Overrides & {
-    future?: Future;
-  },
-) {
-  return testConfig({
-    ...overrides,
-    future: {...future, unstable_newEmbeddedAuthStrategy: false},
-  });
-}
-
 export function testConfig<
   Overrides extends TestOverridesArg<Future>,
   Future extends FutureFlagOptions,

--- a/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -45,6 +45,20 @@ beforeEach(() => {
   (TEST_CONFIG as any).sessionStorage = new MemorySessionStorage();
 });
 
+export function testConfigAuthCodeFlow<
+  Overrides extends TestOverridesArg<Future>,
+  Future extends FutureFlagOptions,
+>(
+  {future, ...overrides}: Overrides & {future?: Future} = {} as Overrides & {
+    future?: Future;
+  },
+) {
+  return testConfig({
+    ...overrides,
+    future: {...future, unstable_tokenExchange: false},
+  });
+}
+
 export function testConfig<
   Overrides extends TestOverridesArg<Future>,
   Future extends FutureFlagOptions,

--- a/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -21,6 +21,7 @@ import {API_KEY, API_SECRET_KEY, APP_URL} from './const';
 const TEST_FUTURE_FLAGS: Required<{[key in keyof FutureFlags]: true}> = {
   v3_authenticatePublic: true,
   v3_webhookAdminContext: true,
+  unstable_newEmbeddedAuthStrategy: true,
 } as const;
 
 const TEST_CONFIG = {

--- a/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -55,7 +55,7 @@ export function testConfigAuthCodeFlow<
 ) {
   return testConfig({
     ...overrides,
-    future: {...future, unstable_tokenExchange: false},
+    future: {...future, unstable_newEmbeddedAuthStrategy: false},
   });
 }
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
@@ -128,4 +128,24 @@ describe('authorize.admin doc request path', () => {
     // THEN
     expect(response.status).toBe(400);
   });
+
+  it("redirects to the embedded app URL if the app isn't embedded yet", async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp(config);
+    await setUpValidSession(shopify.sessionStorage);
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.admin,
+      new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`),
+    );
+
+    // THEN
+    const {hostname, pathname} = new URL(response.headers.get('location')!);
+
+    expect(response.status).toBe(302);
+    expect(hostname).toBe(SHOPIFY_HOST);
+    expect(pathname).toBe(`/apps/${API_KEY}`);
+  });
 });

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
@@ -39,10 +39,9 @@ describe('authorize.session token header path', () => {
         // GIVEN
         const shopify = shopifyApp(testConfig({useOnlineTokens: isOnline}));
 
-        const testSession = await setUpValidSession(
-          shopify.sessionStorage,
+        const testSession = await setUpValidSession(shopify.sessionStorage, {
           isOnline,
-        );
+        });
 
         // WHEN
         const {token, payload} = getJwt();
@@ -67,7 +66,9 @@ describe('authorize.session token header path', () => {
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
         if (isOnline) {
-          testSession = await setUpValidSession(shopify.sessionStorage, true);
+          testSession = await setUpValidSession(shopify.sessionStorage, {
+            isOnline: true,
+          });
         }
 
         // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
@@ -30,59 +30,6 @@ describe('authorize.session token header path', () => {
       // THEN
       expect(response.status).toBe(401);
     });
-
-    describe.each([true, false])('when isOnline: %s', (isOnline) => {
-      it(`returns app bridge redirection headers if there is no session`, async () => {
-        // GIVEN
-        const shopify = shopifyApp(testConfig({useOnlineTokens: isOnline}));
-
-        // WHEN
-        const {token} = getJwt();
-        const response = await getThrownResponse(
-          shopify.authenticate.admin,
-          new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`, {
-            headers: {Authorization: `Bearer ${token}`},
-          }),
-        );
-
-        // THEN
-        const {origin, pathname, searchParams} = new URL(
-          response.headers.get(REAUTH_URL_HEADER)!,
-        );
-
-        expect(response.status).toBe(401);
-        expect(origin).toBe(APP_URL);
-        expect(pathname).toBe('/auth');
-        expect(searchParams.get('shop')).toBe(TEST_SHOP);
-      });
-
-      it(`returns app bridge redirection headers if the session is no longer valid`, async () => {
-        // GIVEN
-        const shopify = shopifyApp(
-          testConfig({useOnlineTokens: isOnline, scopes: ['otherTestScope']}),
-        );
-        // The session scopes don't match the configured scopes, so it needs to be reset
-        await setUpValidSession(shopify.sessionStorage, isOnline);
-
-        // WHEN
-        const {token} = getJwt();
-        const response = await getThrownResponse(
-          shopify.authenticate.admin,
-          new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`, {
-            headers: {Authorization: `Bearer ${token}`},
-          }),
-        );
-
-        // THEN
-        const {origin, pathname, searchParams} = new URL(
-          response.headers.get(REAUTH_URL_HEADER)!,
-        );
-        expect(response.status).toBe(401);
-        expect(origin).toBe(APP_URL);
-        expect(pathname).toBe('/auth');
-        expect(searchParams.get('shop')).toBe(TEST_SHOP);
-      });
-    });
   });
 
   describe.each([true, false])(

--- a/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -157,10 +157,10 @@ async function getSessionTokenContext(
   const sessionToken = (headerSessionToken || searchParamSessionToken)!;
 
   logger.debug('Attempting to authenticate session token', {
-    sessionToken: {
+    sessionToken: JSON.stringify({
       header: headerSessionToken,
       search: searchParamSessionToken,
-    },
+    }),
   });
 
   if (config.isEmbeddedApp) {

--- a/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -116,21 +116,19 @@ export function authStrategyFactory<
 
       logger.info('Authenticating admin request');
 
-      const {payload, shop, sessionId} = await getSessionTokenContext(
-        params,
-        request,
-      );
+      const {payload, shop, sessionId, sessionToken} =
+        await getSessionTokenContext(params, request);
 
       logger.debug('Loading session from storage', {sessionId});
       const existingSession = sessionId
         ? await config.sessionStorage.loadSession(sessionId)
         : undefined;
 
-      const session = await strategy.authenticate(
-        request,
-        existingSession,
+      const session = await strategy.authenticate(request, {
+        session: existingSession,
+        sessionToken,
         shop,
-      );
+      });
 
       logger.debug('Request is valid, loaded session from session token', {
         shop: session.shop,
@@ -178,7 +176,7 @@ async function getSessionTokenContext(
       ? api.session.getJwtSessionId(shop, payload.sub)
       : api.session.getOfflineId(shop);
 
-    return {shop, payload, sessionId};
+    return {shop, payload, sessionId, sessionToken};
   }
 
   const url = new URL(request.url);
@@ -189,5 +187,5 @@ async function getSessionTokenContext(
     rawRequest: request,
   });
 
-  return {shop, sessionId, payload: undefined};
+  return {shop, sessionId, payload: undefined, sessionToken};
 }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
@@ -7,20 +7,17 @@ export const redirectToBouncePage = (params: BasicParams, url: URL): never => {
 
   // Make sure we always point to the configured app URL so it also works behind reverse proxies (that alter the Host
   // header).
-  // const searchParams = new URLSearchParams(url.search);
-  // searchParams.delete('id_token');
-  // searchParams.set(
-  //   'shopify-reload',
-  //   `${config.appUrl}${url.pathname}?${searchParams.toString()}`,
-  // );
-
-  url.searchParams.set(
+  const searchParams = new URLSearchParams(url.search);
+  searchParams.delete('id_token');
+  searchParams.set(
     'shopify-reload',
-    `${config.appUrl}${url.pathname}${url.search}`,
+    `${config.appUrl}${url.pathname}?${searchParams.toString()}`,
   );
 
   // eslint-disable-next-line no-warning-comments
   // TODO Make sure this works on chrome without a tunnel (weird HTTPS redirect issue)
   // https://github.com/orgs/Shopify/projects/6899/views/1?pane=issue&itemId=28376650
-  throw redirect(`${config.auth.patchSessionTokenPath}${url.search}`);
+  throw redirect(
+    `${config.auth.patchSessionTokenPath}?${searchParams.toString()}`,
+  );
 };

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
@@ -7,7 +7,7 @@ export const redirectToBouncePage = (params: BasicParams, url: URL): never => {
 
   // Make sure we always point to the configured app URL so it also works behind reverse proxies (that alter the Host
   // header).
-  const searchParams = new URLSearchParams(url.search);
+  const searchParams = url.searchParams;
   searchParams.delete('id_token');
   searchParams.set(
     'shopify-reload',

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-to-bounce-page.ts
@@ -7,6 +7,13 @@ export const redirectToBouncePage = (params: BasicParams, url: URL): never => {
 
   // Make sure we always point to the configured app URL so it also works behind reverse proxies (that alter the Host
   // header).
+  // const searchParams = new URLSearchParams(url.search);
+  // searchParams.delete('id_token');
+  // searchParams.set(
+  //   'shopify-reload',
+  //   `${config.appUrl}${url.pathname}?${searchParams.toString()}`,
+  // );
+
   url.searchParams.set(
     'shopify-reload',
     `${config.appUrl}${url.pathname}${url.search}`,

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-callback-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-callback-path.test.ts
@@ -1,6 +1,6 @@
 import {HashFormat, createSHA256HMAC} from '@shopify/shopify-api/runtime';
 
-import {shopifyApp} from '../../../../../..';
+import {shopifyApp} from '../../../../..';
 import {
   BASE64_HOST,
   TEST_SHOP,
@@ -8,13 +8,14 @@ import {
   signRequestCookie,
   testConfig,
   mockExternalRequest,
-} from '../../../../../../__test-helpers';
+  testConfigAuthCodeFlow,
+} from '../../../../../__test-helpers';
 
 describe('authorize.admin auth callback path', () => {
   describe('errors', () => {
     test('throws an error if the shop param is missing', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -30,7 +31,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws an error if the shop param is not valid', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -46,7 +47,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws an 302 Response to begin auth if CookieNotFound error', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -71,7 +72,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws a 400 if there is no HMAC param', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -98,7 +99,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws a 400 if the HMAC param is invalid', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -126,7 +127,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws a 500 if any other errors are thrown', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp({
         ...config,
         hooks: {
@@ -151,7 +152,7 @@ describe('authorize.admin auth callback path', () => {
   describe('Success states', () => {
     test('Exchanges the code for a token and saves it to SessionStorage', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -178,7 +179,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws an 302 Response to begin auth if token was offline and useOnlineTokens is true', async () => {
       // GIVEN
-      const config = testConfig({useOnlineTokens: true});
+      const config = testConfigAuthCodeFlow({useOnlineTokens: true});
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -203,7 +204,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('Does not throw a 302 Response to begin auth if token was online', async () => {
       // GIVEN
-      const config = testConfig({useOnlineTokens: true});
+      const config = testConfigAuthCodeFlow({useOnlineTokens: true});
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -221,7 +222,7 @@ describe('authorize.admin auth callback path', () => {
     test('Runs the afterAuth hooks passing', async () => {
       // GIVEN
       const afterAuthMock = jest.fn();
-      const config = testConfig({
+      const config = testConfigAuthCodeFlow({
         hooks: {
           afterAuth: afterAuthMock,
         },
@@ -241,7 +242,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws a 302 response to the emebdded app URL if isEmbeddedApp is true', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -260,7 +261,7 @@ describe('authorize.admin auth callback path', () => {
 
     test('throws a 302 to / if embedded is not true', async () => {
       // GIVEN
-      const config = testConfig({
+      const config = testConfigAuthCodeFlow({
         isEmbeddedApp: false,
       });
       const shopify = shopifyApp(config);

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-path.test.ts
@@ -5,13 +5,15 @@ import {
   expectBeginAuthRedirect,
   expectExitIframeRedirect,
   getThrownResponse,
-  testConfigAuthCodeFlow,
+  testConfig,
 } from '../../../../../__test-helpers';
 
 describe('authorize.admin auth path', () => {
   test('throws an 400 Response if the shop param is missing', async () => {
     // GIVEN
-    const config = testConfigAuthCodeFlow();
+    const config = testConfig({
+      future: {unstable_newEmbeddedAuthStrategy: false},
+    });
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -27,7 +29,9 @@ describe('authorize.admin auth path', () => {
 
   test('throws an 400 Response if the shop param is invalid', async () => {
     // GIVEN
-    const config = testConfigAuthCodeFlow();
+    const config = testConfig({
+      future: {unstable_newEmbeddedAuthStrategy: false},
+    });
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -43,7 +47,9 @@ describe('authorize.admin auth path', () => {
 
   test('throws an 302 Response to begin auth', async () => {
     // GIVEN
-    const config = testConfigAuthCodeFlow();
+    const config = testConfig({
+      future: {unstable_newEmbeddedAuthStrategy: false},
+    });
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -59,7 +65,9 @@ describe('authorize.admin auth path', () => {
 
   test('redirects to exit-iframe when loading the auth path while in an iframe request', async () => {
     // GIVEN
-    const config = testConfigAuthCodeFlow();
+    const config = testConfig({
+      future: {unstable_newEmbeddedAuthStrategy: false},
+    });
     const shopify = shopifyApp(config);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/auth-path.test.ts
@@ -1,17 +1,17 @@
-import {shopifyApp} from '../../../../../..';
+import {shopifyApp} from '../../../../..';
 import {
   APP_URL,
   TEST_SHOP,
   expectBeginAuthRedirect,
   expectExitIframeRedirect,
   getThrownResponse,
-  testConfig,
-} from '../../../../../../__test-helpers';
+  testConfigAuthCodeFlow,
+} from '../../../../../__test-helpers';
 
 describe('authorize.admin auth path', () => {
   test('throws an 400 Response if the shop param is missing', async () => {
     // GIVEN
-    const config = testConfig();
+    const config = testConfigAuthCodeFlow();
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -27,7 +27,7 @@ describe('authorize.admin auth path', () => {
 
   test('throws an 400 Response if the shop param is invalid', async () => {
     // GIVEN
-    const config = testConfig();
+    const config = testConfigAuthCodeFlow();
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -43,7 +43,7 @@ describe('authorize.admin auth path', () => {
 
   test('throws an 302 Response to begin auth', async () => {
     // GIVEN
-    const config = testConfig();
+    const config = testConfigAuthCodeFlow();
     const shopify = shopifyApp(config);
 
     // WHEN
@@ -59,7 +59,7 @@ describe('authorize.admin auth path', () => {
 
   test('redirects to exit-iframe when loading the auth path while in an iframe request', async () => {
     // GIVEN
-    const config = testConfig();
+    const config = testConfigAuthCodeFlow();
     const shopify = shopifyApp(config);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/authenticate.test.ts
@@ -1,6 +1,6 @@
 import {SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
 
-import {shopifyApp} from '../../../../../..';
+import {shopifyApp} from '../../../../..';
 import {
   APP_URL,
   BASE64_HOST,
@@ -10,15 +10,17 @@ import {
   getJwt,
   getThrownResponse,
   setUpValidSession,
-  testConfig,
+  testConfigAuthCodeFlow,
   signRequestCookie,
-} from '../../../../../../__test-helpers';
+} from '../../../../../__test-helpers';
 
 describe('authenticate', () => {
   describe('errors', () => {
     it('redirects to exit-iframe if app is embedded and the session is no longer valid for the id_token when embedded', async () => {
       // GIVEN
-      const shopify = shopifyApp(testConfig({scopes: ['otherTestScope']}));
+      const shopify = shopifyApp(
+        testConfigAuthCodeFlow({scopes: ['otherTestScope']}),
+      );
       await setUpValidSession(shopify.sessionStorage);
 
       // WHEN
@@ -37,8 +39,10 @@ describe('authenticate', () => {
     // manageAccessToken or ensureInstalledOnShop
     it('redirects to auth if there is no session cookie for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfig();
-      const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
+      const config = testConfigAuthCodeFlow();
+      const shopify = shopifyApp(
+        testConfigAuthCodeFlow({isEmbeddedApp: false}),
+      );
       await setUpValidSession(shopify.sessionStorage);
 
       // WHEN
@@ -57,7 +61,7 @@ describe('authenticate', () => {
 
     it('redirects to auth if the session is no longer valid for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfig({
+      const config = testConfigAuthCodeFlow({
         isEmbeddedApp: false,
         scopes: ['otherTestScope'],
       });
@@ -89,7 +93,9 @@ describe('authenticate', () => {
     (isOnline) => {
       it('returns the context if the session is valid and the app is embedded', async () => {
         // GIVEN
-        const shopify = shopifyApp(testConfig({useOnlineTokens: isOnline}));
+        const shopify = shopifyApp(
+          testConfigAuthCodeFlow({useOnlineTokens: isOnline}),
+        );
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
@@ -115,7 +121,9 @@ describe('authenticate', () => {
 
       it('returns the context if the session is valid and the app is not embedded', async () => {
         // GIVEN
-        const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
+        const shopify = shopifyApp(
+          testConfigAuthCodeFlow({isEmbeddedApp: false}),
+        );
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
@@ -148,7 +156,7 @@ describe('authenticate', () => {
   // manageAccessToken & ensureInstalledOnShop
   it('loads a session from the cookie from a request with no search params when not embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
+    const shopify = shopifyApp(testConfigAuthCodeFlow({isEmbeddedApp: false}));
     const testSession = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/authenticate.test.ts
@@ -10,7 +10,7 @@ import {
   getJwt,
   getThrownResponse,
   setUpValidSession,
-  testConfigAuthCodeFlow,
+  testConfig,
   signRequestCookie,
 } from '../../../../../__test-helpers';
 
@@ -19,7 +19,11 @@ describe('authenticate', () => {
     it('redirects to exit-iframe if app is embedded and the session is no longer valid for the id_token when embedded', async () => {
       // GIVEN
       const shopify = shopifyApp(
-        testConfigAuthCodeFlow({scopes: ['otherTestScope']}),
+        testConfig({
+          scopes: ['otherTestScope'],
+          future: {unstable_newEmbeddedAuthStrategy: false},
+          isEmbeddedApp: true,
+        }),
       );
       await setUpValidSession(shopify.sessionStorage);
 
@@ -39,10 +43,10 @@ describe('authenticate', () => {
     // manageAccessToken or ensureInstalledOnShop
     it('redirects to auth if there is no session cookie for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
-      const shopify = shopifyApp(
-        testConfigAuthCodeFlow({isEmbeddedApp: false}),
-      );
+      const config = testConfig({
+        isEmbeddedApp: false,
+      });
+      const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
       // WHEN
@@ -61,9 +65,9 @@ describe('authenticate', () => {
 
     it('redirects to auth if the session is no longer valid for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow({
-        isEmbeddedApp: false,
+      const config = testConfig({
         scopes: ['otherTestScope'],
+        isEmbeddedApp: false,
       });
       const shopify = shopifyApp(config);
       const session = await setUpValidSession(shopify.sessionStorage);
@@ -94,16 +98,19 @@ describe('authenticate', () => {
       it('returns the context if the session is valid and the app is embedded', async () => {
         // GIVEN
         const shopify = shopifyApp(
-          testConfigAuthCodeFlow({useOnlineTokens: isOnline}),
+          testConfig({
+            useOnlineTokens: isOnline,
+            future: {unstable_newEmbeddedAuthStrategy: false},
+            isEmbeddedApp: true,
+          }),
         );
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
         if (isOnline) {
-          testSession = await setUpValidSession(
-            shopify.sessionStorage,
+          testSession = await setUpValidSession(shopify.sessionStorage, {
             isOnline,
-          );
+          });
         }
 
         // WHEN
@@ -122,16 +129,17 @@ describe('authenticate', () => {
       it('returns the context if the session is valid and the app is not embedded', async () => {
         // GIVEN
         const shopify = shopifyApp(
-          testConfigAuthCodeFlow({isEmbeddedApp: false}),
+          testConfig({
+            isEmbeddedApp: false,
+          }),
         );
 
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
         if (isOnline) {
-          testSession = await setUpValidSession(
-            shopify.sessionStorage,
+          testSession = await setUpValidSession(shopify.sessionStorage, {
             isOnline,
-          );
+          });
         }
 
         // WHEN
@@ -156,7 +164,7 @@ describe('authenticate', () => {
   // manageAccessToken & ensureInstalledOnShop
   it('loads a session from the cookie from a request with no search params when not embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfigAuthCodeFlow({isEmbeddedApp: false}));
+    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
     const testSession = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
@@ -127,31 +127,6 @@ describe('authorize.admin doc request path', () => {
       );
     });
 
-    it("redirects to the embedded app URL if there is a valid session but the app isn't embedded yet", async () => {
-      // GIVEN
-      const config = testConfigAuthCodeFlow();
-      const shopify = shopifyApp(testConfigAuthCodeFlow());
-      await setUpValidSession(shopify.sessionStorage);
-
-      await mockExternalRequest({
-        request: new Request(GRAPHQL_URL, {method: 'POST'}),
-        response: new Response(undefined, {status: 200}),
-      });
-
-      // WHEN
-      const response = await getThrownResponse(
-        shopify.authenticate.admin,
-        new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`),
-      );
-
-      // THEN
-      const {hostname, pathname} = new URL(response.headers.get('location')!);
-
-      expect(response.status).toBe(302);
-      expect(hostname).toBe(SHOPIFY_HOST);
-      expect(pathname).toBe(`/apps/${API_KEY}`);
-    });
-
     it('redirects to exit-iframe if app is embedded and there is no session for the id_token when embedded', async () => {
       // GIVEN
       const shopify = shopifyApp(testConfigAuthCodeFlow());

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
@@ -1,6 +1,6 @@
 import {LogSeverity, SESSION_COOKIE_NAME} from '@shopify/shopify-api';
 
-import {shopifyApp} from '../../../../../..';
+import {shopifyApp} from '../../../../..';
 import {
   API_KEY,
   APP_URL,
@@ -13,16 +13,16 @@ import {
   getJwt,
   getThrownResponse,
   setUpValidSession,
-  testConfig,
+  testConfigAuthCodeFlow,
   signRequestCookie,
   mockExternalRequest,
-} from '../../../../../../__test-helpers';
+} from '../../../../../__test-helpers';
 
 describe('authorize.admin doc request path', () => {
   describe('errors', () => {
     it('redirects to auth when not embedded and there is no offline session', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -37,7 +37,7 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to exit-iframe when embedded and there is no offline session', async () => {
       // GIVEN
-      const shopify = shopifyApp(testConfig());
+      const shopify = shopifyApp(testConfigAuthCodeFlow());
 
       // WHEN
       const response = await getThrownResponse(
@@ -53,7 +53,7 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to auth when not embedded on an embedded app, and the API token is invalid', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -74,7 +74,7 @@ describe('authorize.admin doc request path', () => {
 
     it('returns non-401 codes when not embedded on an embedded app and the request fails', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -102,7 +102,7 @@ describe('authorize.admin doc request path', () => {
 
     it('returns a 500 when not embedded on an embedded app and the request fails', async () => {
       // GIVEN
-      const config = testConfig();
+      const config = testConfigAuthCodeFlow();
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -129,8 +129,8 @@ describe('authorize.admin doc request path', () => {
 
     it("redirects to the embedded app URL if there is a valid session but the app isn't embedded yet", async () => {
       // GIVEN
-      const config = testConfig();
-      const shopify = shopifyApp(testConfig());
+      const config = testConfigAuthCodeFlow();
+      const shopify = shopifyApp(testConfigAuthCodeFlow());
       await setUpValidSession(shopify.sessionStorage);
 
       await mockExternalRequest({
@@ -154,7 +154,7 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to exit-iframe if app is embedded and there is no session for the id_token when embedded', async () => {
       // GIVEN
-      const shopify = shopifyApp(testConfig());
+      const shopify = shopifyApp(testConfigAuthCodeFlow());
       await setUpValidSession(shopify.sessionStorage);
       const otherShopDomain = 'other-shop.myshopify.io';
 
@@ -174,8 +174,10 @@ describe('authorize.admin doc request path', () => {
     // manageAccessToken or ensureInstalledOnShop
     it('redirects to auth if there is no session cookie for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfig();
-      const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
+      const config = testConfigAuthCodeFlow();
+      const shopify = shopifyApp(
+        testConfigAuthCodeFlow({isEmbeddedApp: false}),
+      );
       await setUpValidSession(shopify.sessionStorage);
 
       // WHEN
@@ -194,7 +196,7 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to auth if there is no session for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfig({isEmbeddedApp: false});
+      const config = testConfigAuthCodeFlow({isEmbeddedApp: false});
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -221,7 +223,7 @@ describe('authorize.admin doc request path', () => {
   // manageAccessToken & ensureInstalledOnShop
   it('loads a session from the cookie from a request with no search params when not embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
+    const shopify = shopifyApp(testConfigAuthCodeFlow({isEmbeddedApp: false}));
     const testSession = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/ensure-installed-on-shop.test.ts
@@ -13,16 +13,16 @@ import {
   getJwt,
   getThrownResponse,
   setUpValidSession,
-  testConfigAuthCodeFlow,
   signRequestCookie,
   mockExternalRequest,
+  testConfig,
 } from '../../../../../__test-helpers';
 
 describe('authorize.admin doc request path', () => {
   describe('errors', () => {
     it('redirects to auth when not embedded and there is no offline session', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
+      const config = testConfig({isEmbeddedApp: false});
       const shopify = shopifyApp(config);
 
       // WHEN
@@ -37,7 +37,12 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to exit-iframe when embedded and there is no offline session', async () => {
       // GIVEN
-      const shopify = shopifyApp(testConfigAuthCodeFlow());
+      const shopify = shopifyApp(
+        testConfig({
+          future: {unstable_newEmbeddedAuthStrategy: false},
+          isEmbeddedApp: true,
+        }),
+      );
 
       // WHEN
       const response = await getThrownResponse(
@@ -53,7 +58,10 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to auth when not embedded on an embedded app, and the API token is invalid', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
+      const config = testConfig({
+        future: {unstable_newEmbeddedAuthStrategy: false},
+        isEmbeddedApp: true,
+      });
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -74,7 +82,10 @@ describe('authorize.admin doc request path', () => {
 
     it('returns non-401 codes when not embedded on an embedded app and the request fails', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
+      const config = testConfig({
+        future: {unstable_newEmbeddedAuthStrategy: false},
+        isEmbeddedApp: true,
+      });
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -102,7 +113,10 @@ describe('authorize.admin doc request path', () => {
 
     it('returns a 500 when not embedded on an embedded app and the request fails', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
+      const config = testConfig({
+        future: {unstable_newEmbeddedAuthStrategy: false},
+        isEmbeddedApp: true,
+      });
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -129,7 +143,12 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to exit-iframe if app is embedded and there is no session for the id_token when embedded', async () => {
       // GIVEN
-      const shopify = shopifyApp(testConfigAuthCodeFlow());
+      const shopify = shopifyApp(
+        testConfig({
+          future: {unstable_newEmbeddedAuthStrategy: false},
+          isEmbeddedApp: true,
+        }),
+      );
       await setUpValidSession(shopify.sessionStorage);
       const otherShopDomain = 'other-shop.myshopify.io';
 
@@ -146,13 +165,12 @@ describe('authorize.admin doc request path', () => {
       expectExitIframeRedirect(response, {shop: otherShopDomain});
     });
 
-    // manageAccessToken or ensureInstalledOnShop
     it('redirects to auth if there is no session cookie for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow();
-      const shopify = shopifyApp(
-        testConfigAuthCodeFlow({isEmbeddedApp: false}),
-      );
+      const config = testConfig({
+        isEmbeddedApp: false,
+      });
+      const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
       // WHEN
@@ -171,7 +189,7 @@ describe('authorize.admin doc request path', () => {
 
     it('redirects to auth if there is no session for non-embedded apps when at the top level', async () => {
       // GIVEN
-      const config = testConfigAuthCodeFlow({isEmbeddedApp: false});
+      const config = testConfig({isEmbeddedApp: false});
       const shopify = shopifyApp(config);
       await setUpValidSession(shopify.sessionStorage);
 
@@ -195,10 +213,9 @@ describe('authorize.admin doc request path', () => {
     });
   });
 
-  // manageAccessToken & ensureInstalledOnShop
   it('loads a session from the cookie from a request with no search params when not embedded', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfigAuthCodeFlow({isEmbeddedApp: false}));
+    const shopify = shopifyApp(testConfig({isEmbeddedApp: false}));
     const testSession = await setUpValidSession(shopify.sessionStorage);
 
     // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/session-token-header-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/session-token-header-path.test.ts
@@ -8,8 +8,7 @@ import {
   getJwt,
   getThrownResponse,
   setUpValidSession,
-  signRequestCookie,
-  testConfigAuthCodeFlow,
+  testConfig,
 } from '../../../../../__test-helpers';
 import {REAUTH_URL_HEADER} from '../../../../const';
 
@@ -19,7 +18,10 @@ describe('authorize.session token header path', () => {
       it(`returns app bridge redirection headers if there is no session`, async () => {
         // GIVEN
         const shopify = shopifyApp(
-          testConfigAuthCodeFlow({useOnlineTokens: isOnline}),
+          testConfig({
+            useOnlineTokens: isOnline,
+            future: {unstable_newEmbeddedAuthStrategy: false},
+          }),
         );
 
         // WHEN
@@ -45,13 +47,14 @@ describe('authorize.session token header path', () => {
       it(`returns app bridge redirection headers if the session is no longer valid`, async () => {
         // GIVEN
         const shopify = shopifyApp(
-          testConfigAuthCodeFlow({
+          testConfig({
             useOnlineTokens: isOnline,
             scopes: ['otherTestScope'],
+            future: {unstable_newEmbeddedAuthStrategy: false},
           }),
         );
         // The session scopes don't match the configured scopes, so it needs to be reset
-        await setUpValidSession(shopify.sessionStorage, isOnline);
+        await setUpValidSession(shopify.sessionStorage, {isOnline});
 
         // WHEN
         const {token} = getJwt();

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/session-token-header-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/auth-code-flow/session-token-header-path.test.ts
@@ -1,0 +1,76 @@
+import {SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
+
+import {shopifyApp} from '../../../../..';
+import {
+  APP_URL,
+  BASE64_HOST,
+  TEST_SHOP,
+  getJwt,
+  getThrownResponse,
+  setUpValidSession,
+  signRequestCookie,
+  testConfigAuthCodeFlow,
+} from '../../../../../__test-helpers';
+import {REAUTH_URL_HEADER} from '../../../../const';
+
+describe('authorize.session token header path', () => {
+  describe('errors', () => {
+    describe.each([true, false])('when isOnline: %s', (isOnline) => {
+      it(`returns app bridge redirection headers if there is no session`, async () => {
+        // GIVEN
+        const shopify = shopifyApp(
+          testConfigAuthCodeFlow({useOnlineTokens: isOnline}),
+        );
+
+        // WHEN
+        const {token} = getJwt();
+        const response = await getThrownResponse(
+          shopify.authenticate.admin,
+          new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`, {
+            headers: {Authorization: `Bearer ${token}`},
+          }),
+        );
+
+        // THEN
+        const {origin, pathname, searchParams} = new URL(
+          response.headers.get(REAUTH_URL_HEADER)!,
+        );
+
+        expect(response.status).toBe(401);
+        expect(origin).toBe(APP_URL);
+        expect(pathname).toBe('/auth');
+        expect(searchParams.get('shop')).toBe(TEST_SHOP);
+      });
+
+      it(`returns app bridge redirection headers if the session is no longer valid`, async () => {
+        // GIVEN
+        const shopify = shopifyApp(
+          testConfigAuthCodeFlow({
+            useOnlineTokens: isOnline,
+            scopes: ['otherTestScope'],
+          }),
+        );
+        // The session scopes don't match the configured scopes, so it needs to be reset
+        await setUpValidSession(shopify.sessionStorage, isOnline);
+
+        // WHEN
+        const {token} = getJwt();
+        const response = await getThrownResponse(
+          shopify.authenticate.admin,
+          new Request(`${APP_URL}?shop=${TEST_SHOP}&host=${BASE64_HOST}`, {
+            headers: {Authorization: `Bearer ${token}`},
+          }),
+        );
+
+        // THEN
+        const {origin, pathname, searchParams} = new URL(
+          response.headers.get(REAUTH_URL_HEADER)!,
+        );
+        expect(response.status).toBe(401);
+        expect(origin).toBe(APP_URL);
+        expect(pathname).toBe('/auth');
+        expect(searchParams.get('shop')).toBe(TEST_SHOP);
+      });
+    });
+  });
+});

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
@@ -1,0 +1,216 @@
+import {SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
+
+import {shopifyApp} from '../../../../..';
+import {
+  API_KEY,
+  API_SECRET_KEY,
+  APP_URL,
+  BASE64_HOST,
+  TEST_SHOP,
+  getJwt,
+  getThrownResponse,
+  mockExternalRequest,
+  setUpValidSession,
+  testConfig,
+} from '../../../../../__test-helpers';
+
+const USER_ID = 902541635;
+
+describe('authenticate', () => {
+  it('performs token exchange when there is no offline session', async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp(config);
+
+    const {token} = getJwt();
+    await mockTokenExchangeRequest(token, 'offline');
+
+    // WHEN
+    const {session} = await shopify.authenticate.admin(
+      new Request(
+        `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+      ),
+    );
+
+    // THEN
+    const [persistedSession] = await config.sessionStorage.findSessionsByShop(
+      TEST_SHOP,
+    );
+
+    expect(persistedSession).toEqual(session);
+    expect(session).toMatchObject({
+      accessToken: '123abc-exchanged-from-session-token',
+      id: `offline_${TEST_SHOP}`,
+      isOnline: false,
+      scope: 'read_orders',
+      shop: TEST_SHOP,
+      state: '',
+    });
+  });
+
+  it('performs token exchange when existing session is no longer valid', async () => {
+    // GIVEN
+    const config = testConfig({useOnlineTokens: true});
+    const shopify = shopifyApp(config);
+    const anHourAgo = new Date(Date.now() - 1000 * 3600);
+    await setUpValidSession(shopify.sessionStorage, true, anHourAgo);
+
+    const {token} = getJwt();
+    await mockTokenExchangeRequest(token, 'offline');
+    await mockTokenExchangeRequest(token, 'online');
+
+    // WHEN
+    const {session} = await shopify.authenticate.admin(
+      new Request(
+        `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+      ),
+    );
+
+    // THEN
+    const [_, onlineSession] = await config.sessionStorage.findSessionsByShop(
+      TEST_SHOP,
+    );
+
+    expect(onlineSession).toEqual(session);
+    expect(session).toMatchObject({
+      accessToken: '123abc-exchanged-from-session-token',
+      id: `${TEST_SHOP}_${USER_ID}`,
+      isOnline: true,
+      scope: 'read_orders',
+      shop: TEST_SHOP,
+      state: '',
+      onlineAccessInfo: expect.any(Object),
+    });
+  });
+
+  describe.each([true, false])(
+    'existing sessions when isOnline: %s',
+    (isOnline) => {
+      it('returns the context if the session is valid', async () => {
+        // GIVEN
+        const shopify = shopifyApp(testConfig({useOnlineTokens: isOnline}));
+
+        let testSession: Session;
+        testSession = await setUpValidSession(shopify.sessionStorage);
+        if (isOnline) {
+          testSession = await setUpValidSession(
+            shopify.sessionStorage,
+            isOnline,
+          );
+        }
+
+        // WHEN
+        const {token} = getJwt();
+        const {admin, session} = await shopify.authenticate.admin(
+          new Request(
+            `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+          ),
+        );
+
+        // THEN
+        expect(session).toBe(testSession);
+        expect(admin.rest.session).toBe(testSession);
+        expect(session.isOnline).toEqual(isOnline);
+      });
+    },
+  );
+
+  test('throws a 500 if afterAuth hook throws an error', async () => {
+    // GIVEN
+    const config = testConfig();
+    const shopify = shopifyApp({
+      ...config,
+      hooks: {
+        afterAuth: () => {
+          throw new Error('test');
+        },
+      },
+    });
+
+    const {token} = getJwt();
+    await mockTokenExchangeRequest(token, 'offline');
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.admin,
+      new Request(
+        `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+      ),
+    );
+
+    // THEN
+    expect(response.status).toBe(500);
+  });
+
+  test('Runs the afterAuth hooks passing', async () => {
+    // GIVEN
+    const afterAuthMock = jest.fn();
+    const config = testConfig({
+      hooks: {
+        afterAuth: afterAuthMock,
+      },
+    });
+    const shopify = shopifyApp(config);
+
+    const {token} = getJwt();
+    await mockTokenExchangeRequest(token, 'offline');
+
+    // WHEN
+    const {session} = await shopify.authenticate.admin(
+      new Request(
+        `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+      ),
+    );
+
+    // THEN
+    expect(session).toBeDefined();
+    expect(afterAuthMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+async function mockTokenExchangeRequest(
+  sessionToken,
+  tokenType: 'online' | 'offline' = 'offline',
+) {
+  const responseBody = {
+    access_token: '123abc-exchanged-from-session-token',
+    scope: 'read_orders',
+  };
+
+  await mockExternalRequest({
+    request: new Request(`https://${TEST_SHOP}/admin/oauth/access_token`, {
+      method: 'POST',
+      body: JSON.stringify({
+        client_id: API_KEY,
+        client_secret: API_SECRET_KEY,
+        grant_type: 'urn:ietf:params:oauth:grant-type:token-exchange',
+        subject_token: sessionToken,
+        subject_token_type: 'urn:ietf:params:oauth:token-type:id_token',
+        requested_token_type:
+          tokenType === 'offline'
+            ? 'urn:shopify:params:oauth:token-type:offline-access-token'
+            : 'urn:shopify:params:oauth:token-type:online-access-token',
+      }),
+    }),
+    response:
+      tokenType === 'offline'
+        ? new Response(JSON.stringify(responseBody))
+        : new Response(
+            JSON.stringify({
+              ...responseBody,
+              expires_in: Math.trunc(Date.now() / 1000) + 3600,
+              associated_user_scope: 'read_orders',
+              associated_user: {
+                id: USER_ID,
+                first_name: 'John',
+                last_name: 'Smith',
+                email: 'john@example.com',
+                email_verified: true,
+                account_owner: true,
+                locale: 'en',
+                collaborator: false,
+              },
+            }),
+          ),
+  });
+}

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
@@ -1,4 +1,4 @@
-import {SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
+import {Session} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../../../..';
 import {

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
@@ -53,7 +53,10 @@ describe('authenticate', () => {
     const config = testConfig({useOnlineTokens: true});
     const shopify = shopifyApp(config);
     const anHourAgo = new Date(Date.now() - 1000 * 3600);
-    await setUpValidSession(shopify.sessionStorage, true, anHourAgo);
+    await setUpValidSession(shopify.sessionStorage, {
+      isOnline: true,
+      expires: anHourAgo,
+    });
 
     const {token} = getJwt();
     await mockTokenExchangeRequest(token, 'offline');
@@ -93,10 +96,9 @@ describe('authenticate', () => {
         let testSession: Session;
         testSession = await setUpValidSession(shopify.sessionStorage);
         if (isOnline) {
-          testSession = await setUpValidSession(
-            shopify.sessionStorage,
+          testSession = await setUpValidSession(shopify.sessionStorage, {
             isOnline,
-          );
+          });
         }
 
         // WHEN
@@ -115,7 +117,7 @@ describe('authenticate', () => {
     },
   );
 
-  test('redirects to bounce page when receiving an invalid subject token response from token exchange API', async () => {
+  test('redirects to bounce page on document request when receiving an invalid subject token response from token exchange API', async () => {
     // GIVEN
     const config = testConfig();
     const shopify = shopifyApp(config);
@@ -144,10 +146,9 @@ describe('authenticate', () => {
     expect(searchParams.get('shopify-reload')).toBe(
       `${APP_URL}/?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}`,
     );
-    expect(fetchMock.mock.calls).toHaveLength(1);
   });
 
-  test('throws 401 unauthorized when receiving an invalid subject token response from token exchange API', async () => {
+  test('throws 401 unauthorized on XHR request when receiving an invalid subject token response from token exchange API', async () => {
     // GIVEN
     const config = testConfig();
     const shopify = shopifyApp(config);
@@ -167,7 +168,6 @@ describe('authenticate', () => {
 
     // THEN
     expect(response.status).toBe(401);
-    expect(fetchMock.mock.calls).toHaveLength(1);
   });
 
   test('throws 500 for any other error from token exchange API', async () => {
@@ -190,7 +190,6 @@ describe('authenticate', () => {
 
     // THEN
     expect(response.status).toBe(500);
-    expect(fetchMock.mock.calls).toHaveLength(1);
   });
 
   test('throws a 500 if afterAuth hook throws an error', async () => {

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
@@ -21,7 +21,7 @@ import {
 import {AppConfig} from '../../../config-types';
 import {getSessionTokenHeader} from '../../helpers';
 
-import {AuthorizationStrategy} from './types';
+import {AuthorizationStrategy, SessionContext} from './types';
 
 export class AuthCodeFlowStrategy<
   Resources extends ShopifyRestResources = ShopifyRestResources,
@@ -65,10 +65,11 @@ export class AuthCodeFlowStrategy<
 
   public async authenticate(
     request: Request,
-    session: Session | undefined,
-    shop: string,
+    sessionContext: SessionContext,
   ): Promise<Session | never> {
     const {api, config, logger} = this;
+
+    const {shop, session} = sessionContext;
 
     if (!session) {
       logger.debug('No session found, redirecting to OAuth', {shop});

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -7,7 +7,7 @@ import {
   ShopifyRestResources,
 } from '@shopify/shopify-api';
 import {AppConfig, AppConfigArg} from 'src/server/config-types';
-import {BasicParams, MockApiConfig} from 'src/server/types';
+import {BasicParams, ApiConfigWithFutureFlags} from 'src/server/types';
 
 import {triggerAfterAuthHook} from '../helpers';
 import {respondToInvalidSessionToken} from '../../helpers';
@@ -19,7 +19,7 @@ export class TokenExchangeStrategy<
   Resources extends ShopifyRestResources = ShopifyRestResources,
 > implements AuthorizationStrategy
 {
-  protected api: Shopify<MockApiConfig<Config['future']>>;
+  protected api: Shopify<ApiConfigWithFutureFlags<Config['future']>>;
   protected config: AppConfig;
   protected logger: Shopify['logger'];
 
@@ -41,6 +41,7 @@ export class TokenExchangeStrategy<
     if (!sessionToken) throw new InvalidJwtError();
 
     if (!session || session.isExpired()) {
+      logger.info('No valid session found');
       logger.info('Requesting offline access token');
       const {session: offlineSession} = await this.exchangeToken({
         request,

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -114,7 +114,11 @@ export class TokenExchangeStrategy<
       ) {
         throw respondToInvalidSessionToken({api, config, logger}, request);
       }
-      throw error;
+
+      throw new Response(undefined, {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
     }
   }
 }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -41,7 +41,7 @@ export class TokenExchangeStrategy<
 
     if (!sessionToken) throw new InvalidJwtError();
 
-    if (!session /* || session.isExpired() */) {
+    if (!session || session.isExpired()) {
       logger.info('Requesting offline access token');
       const {session: offlineSession} = await this.exchangeToken({
         request,

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -7,8 +7,7 @@ import {
   ShopifyRestResources,
 } from '@shopify/shopify-api';
 import {AppConfig, AppConfigArg} from 'src/server/config-types';
-import {BasicParams} from 'src/server/types';
-import {MockApiConfig} from 'src/server/shopify-app';
+import {BasicParams, MockApiConfig} from 'src/server/types';
 
 import {triggerAfterAuthHook} from '../helpers';
 import {respondToInvalidSessionToken} from '../../helpers';

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -67,11 +67,18 @@ export class TokenExchangeStrategy<
         newSession = onlineSession;
       }
 
-      await triggerAfterAuthHook<Resources>(
-        {api, config, logger},
-        newSession,
-        request,
-      );
+      try {
+        await triggerAfterAuthHook<Resources>(
+          {api, config, logger},
+          newSession,
+          request,
+        );
+      } catch (error) {
+        throw new Response(undefined, {
+          status: 500,
+          statusText: 'Internal Server Error',
+        });
+      }
 
       return newSession;
     }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -1,0 +1,113 @@
+import {
+  HttpResponseError,
+  InvalidJwtError,
+  RequestedTokenType,
+  Session,
+  Shopify,
+  ShopifyRestResources,
+} from '@shopify/shopify-api';
+import {AppConfig, AppConfigArg} from 'src/server/config-types';
+import {BasicParams} from 'src/server/types';
+import {MockApiConfig} from 'src/server/shopify-app';
+
+import {triggerAfterAuthHook} from '../helpers';
+import {respondToInvalidSessionToken} from '../../helpers';
+
+import {AuthorizationStrategy, SessionContext} from './types';
+
+export class TokenExchangeStrategy<
+  Config extends AppConfigArg,
+  Resources extends ShopifyRestResources = ShopifyRestResources,
+> implements AuthorizationStrategy
+{
+  protected api: Shopify<MockApiConfig<Config['future']>>;
+  protected config: AppConfig;
+  protected logger: Shopify['logger'];
+
+  public constructor({api, config, logger}: BasicParams<Config['future']>) {
+    this.api = api;
+    this.config = config;
+    this.logger = logger;
+  }
+
+  public async respondToOAuthRequests(_request: Request): Promise<void> {}
+
+  public async authenticate(
+    request: Request,
+    sessionContext: SessionContext,
+  ): Promise<Session> {
+    const {api, config, logger} = this;
+    const {shop, session, sessionToken} = sessionContext;
+
+    if (!sessionToken) throw new InvalidJwtError();
+
+    if (!session /* || session.isExpired() */) {
+      logger.info('Requesting offline access token');
+      const {session: offlineSession} = await this.exchangeToken({
+        request,
+        sessionToken,
+        shop,
+        requestedTokenType: RequestedTokenType.OfflineAccessToken,
+      });
+
+      await config.sessionStorage.storeSession(offlineSession);
+
+      let newSession = offlineSession;
+
+      if (config.useOnlineTokens) {
+        logger.info('Requesting online access token');
+        const {session: onlineSession} = await this.exchangeToken({
+          request,
+          sessionToken,
+          shop,
+          requestedTokenType: RequestedTokenType.OnlineAccessToken,
+        });
+
+        await config.sessionStorage.storeSession(onlineSession);
+        newSession = onlineSession;
+      }
+
+      await triggerAfterAuthHook<Resources>(
+        {api, config, logger},
+        newSession,
+        request,
+      );
+
+      return newSession;
+    }
+
+    return session!;
+  }
+
+  private async exchangeToken({
+    request,
+    shop,
+    sessionToken,
+    requestedTokenType,
+  }: {
+    request: Request;
+    shop: string;
+    sessionToken: string;
+    requestedTokenType: RequestedTokenType;
+  }): Promise<{session: Session}> {
+    const {api, config, logger} = this;
+
+    try {
+      return await api.auth.tokenExchange({
+        sessionToken,
+        shop,
+        requestedTokenType,
+      });
+    } catch (error) {
+      if (
+        error instanceof InvalidJwtError ||
+        (error instanceof HttpResponseError &&
+          error.response.code === 400 &&
+          error.response.body?.error === 'invalid_subject_token')
+      ) {
+        throw respondToInvalidSessionToken({api, config, logger}, request);
+      }
+      throw error;
+    }
+  }
+}

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/types.ts
@@ -3,14 +3,20 @@ import {JwtPayload, Session} from '@shopify/shopify-api';
 export interface SessionTokenContext {
   shop: string;
   sessionId?: string;
+  sessionToken?: string;
   payload?: JwtPayload;
+}
+
+export interface SessionContext {
+  shop: string;
+  session?: Session;
+  sessionToken?: string;
 }
 
 export interface AuthorizationStrategy {
   respondToOAuthRequests: (request: Request) => Promise<void | never>;
   authenticate: (
     request: Request,
-    session: Session | undefined,
-    shop: string,
+    sessionContext: SessionContext,
   ) => Promise<Session | never>;
 }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/types.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/types.ts
@@ -197,8 +197,3 @@ export type AuthenticateAdmin<
   Config extends AppConfigArg,
   Resources extends ShopifyRestResources = ShopifyRestResources,
 > = (request: Request) => Promise<AdminContext<Config, Resources>>;
-
-export interface SessionContext {
-  session: Session;
-  token?: JwtPayload;
-}

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/index.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/index.ts
@@ -5,3 +5,4 @@ export * from './validate-session-token';
 export * from './get-session-token-header';
 export * from './reject-bot-request';
 export * from './respond-to-options-request';
+export * from './respond-to-invalid-session-token';

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/respond-to-invalid-session-token.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/respond-to-invalid-session-token.ts
@@ -1,0 +1,21 @@
+import {BasicParams} from 'src/server/types';
+
+import {redirectToBouncePage} from '../admin/helpers/redirect-to-bounce-page';
+
+export function respondToInvalidSessionToken(
+  params: BasicParams,
+  request: Request,
+) {
+  const {api, logger, config} = params;
+
+  const isDocumentRequest = !request.headers.get('authorization');
+  if (isDocumentRequest) {
+    return redirectToBouncePage({api, logger, config}, new URL(request.url));
+  }
+
+  // TODO add header so app bridge retries with new session token
+  throw new Response(undefined, {
+    status: 401,
+    statusText: 'Unauthorized',
+  });
+}

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/respond-to-invalid-session-token.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/respond-to-invalid-session-token.ts
@@ -13,6 +13,7 @@ export function respondToInvalidSessionToken(
     return redirectToBouncePage({api, logger, config}, new URL(request.url));
   }
 
+  // eslint-disable-next-line no-warning-comments
   // TODO add header so app bridge retries with new session token
   throw new Response(undefined, {
     status: 401,

--- a/packages/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -215,10 +215,9 @@ describe('authenticating app proxy requests', () => {
   describe('Valid requests with a session return an admin API client', () => {
     expectAdminApiClient(async () => {
       const shopify = shopifyApp(testConfig());
-      const expectedSession = await setUpValidSession(
-        shopify.sessionStorage,
-        false,
-      );
+      const expectedSession = await setUpValidSession(shopify.sessionStorage, {
+        isOnline: false,
+      });
 
       const {admin, session: actualSession} =
         await shopify.authenticate.public.appProxy(await getValidRequest());
@@ -234,10 +233,9 @@ describe('authenticating app proxy requests', () => {
   describe('Valid requests with a session return a Storefront API client', () => {
     expectStorefrontApiClient(async () => {
       const shopify = shopifyApp(testConfig());
-      const expectedSession = await setUpValidSession(
-        shopify.sessionStorage,
-        false,
-      );
+      const expectedSession = await setUpValidSession(shopify.sessionStorage, {
+        isOnline: false,
+      });
 
       const {storefront, session: actualSession} =
         await shopify.authenticate.public.appProxy(await getValidRequest());

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/mock-responses.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/mock-responses.ts
@@ -32,3 +32,14 @@ export const HTTP_WEBHOOK_CREATE_ERROR_RESPONSE = {
     },
   },
 };
+
+export const HTTP_WEBHOOK_THROTTLING_ERROR_RESPONSE = {
+  errors: [
+    {
+      message: 'Throttled',
+      extensions: {
+        code: 'THROTTLED',
+      },
+    },
+  ],
+};

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
@@ -113,6 +113,8 @@ describe('Webhook registration', () => {
     });
   });
 
+  // eslint-disable-next-line no-warning-comments
+  // TODO: Remove tests once we have a better solution to parallel afterAuth calls
   it('logs throttling errors', async () => {
     // GIVEN
     const shopify = shopifyApp(

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
@@ -1,4 +1,4 @@
-import {DeliveryMethod, Session} from '@shopify/shopify-api';
+import {DeliveryMethod, GraphqlQueryError, Session} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../..';
 import {
@@ -111,5 +111,100 @@ describe('Webhook registration', () => {
     expect(results).toMatchObject({
       NOT_A_VALID_TOPIC: [expect.objectContaining({success: false})],
     });
+  });
+
+  it('logs throttling errors', async () => {
+    // GIVEN
+    const shopify = shopifyApp(
+      testConfig({
+        webhooks: {
+          NOT_A_VALID_TOPIC: {
+            deliveryMethod: DeliveryMethod.Http,
+            callbackUrl: '/webhooks',
+          },
+        },
+      }),
+    );
+    const session = new Session({
+      id: `offline_${TEST_SHOP}`,
+      shop: TEST_SHOP,
+      isOnline: false,
+      state: 'test',
+      accessToken: 'totally_real_token',
+    });
+
+    await mockExternalRequests(
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptions',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE),
+        ),
+      },
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptionCreate',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.HTTP_WEBHOOK_THROTTLING_ERROR_RESPONSE),
+        ),
+      },
+    );
+
+    // WHEN
+    const results = await shopify.registerWebhooks({session});
+
+    // THEN
+    expect(results).toBeUndefined();
+  });
+
+  it('throws other errors', async () => {
+    // GIVEN
+    const shopify = shopifyApp(
+      testConfig({
+        webhooks: {
+          NOT_A_VALID_TOPIC: {
+            deliveryMethod: DeliveryMethod.Http,
+            callbackUrl: '/webhooks',
+          },
+        },
+      }),
+    );
+    const session = new Session({
+      id: `offline_${TEST_SHOP}`,
+      shop: TEST_SHOP,
+      isOnline: false,
+      state: 'test',
+      accessToken: 'totally_real_token',
+    });
+
+    await mockExternalRequests(
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptions',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE),
+        ),
+      },
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptionCreate',
+        }),
+        response: new Response(
+          JSON.stringify({errors: [{extensions: {code: 'FAILED_REQUEST'}}]}),
+        ),
+      },
+    );
+
+    // THEN
+    expect(shopify.registerWebhooks({session})).rejects.toThrowError(
+      GraphqlQueryError,
+    );
   });
 });

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/register.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/register.ts
@@ -4,26 +4,43 @@ import type {RegisterWebhooksOptions} from './types';
 
 export function registerWebhooksFactory({api, logger}: BasicParams) {
   return async function registerWebhooks({session}: RegisterWebhooksOptions) {
-    return api.webhooks.register({session}).then((response) => {
-      Object.entries(response).forEach(([topic, topicResults]) => {
-        topicResults.forEach(({success, ...rest}) => {
-          if (success) {
-            logger.debug('Registered webhook', {
-              topic,
-              shop: session.shop,
-              operation: rest.operation,
-            });
-          } else {
-            logger.error('Failed to register webhook', {
-              topic,
-              shop: session.shop,
-              result: JSON.stringify(rest.result),
-            });
-          }
+    return api.webhooks
+      .register({session})
+      .then((response) => {
+        Object.entries(response).forEach(([topic, topicResults]) => {
+          topicResults.forEach(({success, ...rest}) => {
+            if (success) {
+              logger.debug('Registered webhook', {
+                topic,
+                shop: session.shop,
+                operation: rest.operation,
+              });
+            } else {
+              logger.error('Failed to register webhook', {
+                topic,
+                shop: session.shop,
+                result: JSON.stringify(rest.result),
+              });
+            }
+          });
         });
-      });
 
-      return response;
-    });
+        return response;
+      })
+      .catch((error) => {
+        if (
+          error.response?.errors?.find(
+            (responseError: {extensions: {code: string}}) =>
+              responseError?.extensions?.code === 'THROTTLED',
+          )
+        ) {
+          logger.error('Failed to register webhooks', {
+            shop: session.shop,
+            error: JSON.stringify(error),
+          });
+        } else {
+          throw error;
+        }
+      });
   };
 }

--- a/packages/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/shopify-app-remix/src/server/future/flags.ts
@@ -16,7 +16,7 @@ export interface FutureFlags {
   v3_authenticatePublic?: boolean;
 
   /**
-   * Enable token exchange token acquisition strategy with shopify managed install.
+   * When enabled, embedded apps will fetch access tokens via token exchange. This assumes app are using declarative scopes with Shopify managing installs.
    *
    * @default false
    */

--- a/packages/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/shopify-app-remix/src/server/future/flags.ts
@@ -14,6 +14,13 @@ export interface FutureFlags {
    * @default false
    */
   v3_authenticatePublic?: boolean;
+
+  /**
+   * TODO
+   *
+   * @default false
+   */
+  unstable_newEmbeddedAuthStrategy?: boolean;
 }
 
 export type FutureFlagOptions = FutureFlags | undefined;

--- a/packages/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/shopify-app-remix/src/server/future/flags.ts
@@ -16,7 +16,7 @@ export interface FutureFlags {
   v3_authenticatePublic?: boolean;
 
   /**
-   * TODO
+   * Enable token exchange token acquisition strategy with shopify managed install.
    *
    * @default false
    */

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -30,6 +30,7 @@ import {unauthenticatedAdminContextFactory} from './unauthenticated/admin';
 import {authenticatePublicFactory} from './authenticate/public';
 import {unauthenticatedStorefrontContextFactory} from './unauthenticated/storefront';
 import {AuthCodeFlowStrategy} from './authenticate/admin/strategies/auth-code-flow';
+import {TokenExchangeStrategy} from './authenticate/admin/strategies/token-exchange';
 
 /**
  * Creates an object your app will use to interact with Shopify.
@@ -66,9 +67,13 @@ export function shopifyApp<
 
   const params: BasicParams = {api, config, logger};
   const oauth = new AuthCodeFlowStrategy(params);
+  const tokenExchange = new TokenExchangeStrategy(params);
   const authStrategy = authStrategyFactory<Config, Resources>({
     ...params,
-    strategy: oauth,
+    strategy:
+      config.future.unstable_tokenExchange && config.isEmbeddedApp
+        ? tokenExchange
+        : oauth,
   });
 
   const shopify:

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -66,14 +66,12 @@ export function shopifyApp<
   }
 
   const params: BasicParams = {api, config, logger};
-  const oauth = new AuthCodeFlowStrategy(params);
-  const tokenExchange = new TokenExchangeStrategy(params);
   const authStrategy = authStrategyFactory<Config, Resources>({
     ...params,
     strategy:
       config.future.unstable_newEmbeddedAuthStrategy && config.isEmbeddedApp
-        ? tokenExchange
-        : oauth,
+        ? new TokenExchangeStrategy(params)
+        : new AuthCodeFlowStrategy(params),
   });
 
   const shopify:

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -71,7 +71,7 @@ export function shopifyApp<
   const authStrategy = authStrategyFactory<Config, Resources>({
     ...params,
     strategy:
-      config.future.unstable_tokenExchange && config.isEmbeddedApp
+      config.future.unstable_newEmbeddedAuthStrategy && config.isEmbeddedApp
         ? tokenExchange
         : oauth,
   });
@@ -152,7 +152,10 @@ function deriveApi(appConfig: AppConfigArg) {
     isEmbeddedApp: appConfig.isEmbeddedApp ?? true,
     apiVersion: appConfig.apiVersion ?? LATEST_API_VERSION,
     isCustomStoreApp: appConfig.distribution === AppDistribution.ShopifyAdmin,
-    future: {},
+    future: {
+      unstable_tokenExchange:
+        appConfig.future?.unstable_newEmbeddedAuthStrategy,
+    },
   });
 }
 

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -1,4 +1,5 @@
 import {
+  ConfigParams,
   RegisterReturn,
   Shopify,
   ShopifyRestResources,
@@ -13,12 +14,23 @@ import type {
 import type {AuthenticatePublic} from './authenticate/public/types';
 import type {AdminContext} from './authenticate/admin/types';
 import type {Unauthenticated} from './unauthenticated/types';
+import {FutureFlagOptions, FutureFlags} from './future/flags';
 
-export interface BasicParams {
-  api: Shopify;
+export interface BasicParams<
+  Future extends FutureFlagOptions = FutureFlagOptions,
+> {
+  api: Shopify<MockApiConfig<Future>>;
   config: AppConfig;
   logger: Shopify['logger'];
 }
+
+export type MockApiConfig<Future extends FutureFlagOptions> = ConfigParams & {
+  future?: {
+    unstable_tokenExchange?: Future extends FutureFlags
+      ? Future['unstable_newEmbeddedAuthStrategy']
+      : boolean;
+  };
+};
 
 export type JSONValue =
   | string

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -19,18 +19,19 @@ import {FutureFlagOptions, FutureFlags} from './future/flags';
 export interface BasicParams<
   Future extends FutureFlagOptions = FutureFlagOptions,
 > {
-  api: Shopify<MockApiConfig<Future>>;
+  api: Shopify<ApiConfigWithFutureFlags<Future>>;
   config: AppConfig;
   logger: Shopify['logger'];
 }
 
-export type MockApiConfig<Future extends FutureFlagOptions> = ConfigParams & {
-  future?: {
-    unstable_tokenExchange?: Future extends FutureFlags
-      ? Future['unstable_newEmbeddedAuthStrategy']
-      : boolean;
+export type ApiConfigWithFutureFlags<Future extends FutureFlagOptions> =
+  ConfigParams & {
+    future?: {
+      unstable_tokenExchange?: Future extends FutureFlags
+        ? Future['unstable_newEmbeddedAuthStrategy']
+        : boolean;
+    };
   };
-};
 
 export type JSONValue =
   | string

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -61,7 +61,7 @@ interface JSONArray extends Array<JSONValue> {}
 
 type RegisterWebhooks = (
   options: RegisterWebhooksOptions,
-) => Promise<RegisterReturn>;
+) => Promise<RegisterReturn | void>;
 
 export enum LoginErrorType {
   MissingShop = 'MISSING_SHOP',

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
@@ -17,10 +17,9 @@ describe('unauthenticated admin context', () => {
 
   expectAdminApiClient(async () => {
     const shopify = shopifyApp(testConfig());
-    const expectedSession = await setUpValidSession(
-      shopify.sessionStorage,
-      false,
-    );
+    const expectedSession = await setUpValidSession(shopify.sessionStorage, {
+      isOnline: false,
+    });
     const {admin, session: actualSession} = await shopify.unauthenticated.admin(
       TEST_SHOP,
     );

--- a/packages/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
@@ -19,10 +19,9 @@ describe('unauthenticated storefront context', () => {
 
   expectStorefrontApiClient(async () => {
     const shopify = shopifyApp(testConfig());
-    const expectedSession = await setUpValidSession(
-      shopify.sessionStorage,
-      false,
-    );
+    const expectedSession = await setUpValidSession(shopify.sessionStorage, {
+      isOnline: false,
+    });
     const {storefront, session: actualSession} =
       await shopify.unauthenticated.storefront(TEST_SHOP);
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes: https://github.com/Shopify/develop-app-access/issues/134

Our new embedded auth strategy of using managed install & token exchange relies on the library using session tokens to exchange for an access token. This PR introduces the token exchange strategy with the assumption that apps using declarative scopes and managed install (green-path).

### WHAT is this pull request doing?

- Adds a new `TokenExchangeStrategy` class to handle exchanging session tokens for access tokens.
- Strategy can only be enabled via `unstable_newEmbeddedAuthStrategy` future flag.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
