### PR TITLE
Idempotent promise handler

### DIFF
--- a/packages/shopify-app-remix/src/server/authenticate/helpers/__tests__/idempotent-promise-handler.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/__tests__/idempotent-promise-handler.test.ts
@@ -1,0 +1,51 @@
+import {IdempotentPromiseHandler} from '../idempotent-promise-handler';
+
+const mockFunction = jest.fn();
+async function promiseFunction() {
+  mockFunction();
+}
+
+afterEach(() => {
+  mockFunction.mockReset();
+});
+
+describe('IdempotentPromiseHandler', () => {
+  it('runs the promise function only once for the same identifier', async () => {
+    // GIVEN
+    const promiseHandler = new IdempotentPromiseHandler();
+
+    // WHEN
+    promiseHandler.handlePromise({
+      promiseFunction,
+      identifier: 'first-promise',
+    });
+
+    promiseHandler.handlePromise({
+      promiseFunction,
+      identifier: 'first-promise',
+    });
+
+    // THEN
+    expect(mockFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the promise function once for each identifier', async () => {
+    // GIVEN
+    // const promiseFunction = jest.fn();
+    const promiseHandler = new IdempotentPromiseHandler();
+
+    // WHEN
+    promiseHandler.handlePromise({
+      promiseFunction,
+      identifier: 'first-promise',
+    });
+
+    promiseHandler.handlePromise({
+      promiseFunction,
+      identifier: 'second-promise',
+    });
+
+    // THEN
+    expect(mockFunction).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/idempotent-promise-handler.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/idempotent-promise-handler.ts
@@ -1,0 +1,33 @@
+export interface IdempotentHandlePromiseParams {
+  promiseFunction: () => Promise<any>;
+  identifier: string;
+}
+
+export class IdempotentPromiseHandler {
+  protected identifiers: Set<string>;
+
+  constructor() {
+    this.identifiers = new Set<string>();
+  }
+
+  async handlePromise({
+    promiseFunction,
+    identifier,
+  }: IdempotentHandlePromiseParams): Promise<any> {
+    if (this.isPromiseRunnable(identifier)) {
+      await promiseFunction();
+    }
+
+    return Promise.resolve();
+  }
+
+  private isPromiseRunnable(identifier?: string) {
+    if (!identifier) return true;
+
+    if (!this.identifiers.has(identifier)) {
+      this.identifiers.add(identifier);
+      return true;
+    }
+    return false;
+  }
+}

--- a/packages/shopify-app-remix/src/server/config-types.ts
+++ b/packages/shopify-app-remix/src/server/config-types.ts
@@ -11,6 +11,7 @@ import {SessionStorage} from '@shopify/shopify-app-session-storage';
 import type {FutureFlagOptions, FutureFlags} from './future/flags';
 import type {AppDistribution} from './types';
 import type {AdminApiContext} from './clients';
+import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promise-handler';
 
 export interface AppConfigArg<
   Resources extends ShopifyRestResources = ShopifyRestResources,
@@ -233,6 +234,7 @@ export interface AppConfig<Storage extends SessionStorage = SessionStorage>
   useOnlineTokens: boolean;
   hooks: HooksConfig;
   future: FutureFlags;
+  idempotentPromiseHandler: IdempotentPromiseHandler;
 }
 
 export interface AuthConfig {

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -31,6 +31,7 @@ import {authenticatePublicFactory} from './authenticate/public';
 import {unauthenticatedStorefrontContextFactory} from './unauthenticated/storefront';
 import {AuthCodeFlowStrategy} from './authenticate/admin/strategies/auth-code-flow';
 import {TokenExchangeStrategy} from './authenticate/admin/strategies/token-exchange';
+import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promise-handler';
 
 /**
  * Creates an object your app will use to interact with Shopify.
@@ -173,6 +174,7 @@ function deriveConfig<Storage extends SessionStorage>(
   return {
     ...appConfig,
     ...apiConfig,
+    idempotentPromiseHandler: new IdempotentPromiseHandler(),
     canUseLoginForm: appConfig.distribution !== AppDistribution.ShopifyAdmin,
     useOnlineTokens: appConfig.useOnlineTokens ?? false,
     hooks: appConfig.hooks ?? {},


### PR DESCRIPTION
### WHY are these changes introduced?

With the [introduction of the TokenExchangeStrategy](https://github.com/Shopify/shopify-app-js/pull/509), the `afterAuth` hook is no longer guaranteed to be run by a single loader. As a result, we need to try to ensure that most cases of the `afterAuth` hook can be run once across loaders.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Introduce idempotent promise handler so that `afterAuth` hook can be run once per request.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
