### PR TITLE
Include Github Token in `publish-experimental-build.yml`

### DIFF
--- a/.github/workflows/publish-experimental-build.yml
+++ b/.github/workflows/publish-experimental-build.yml
@@ -34,3 +34,4 @@ jobs:
           createGithubReleases: false
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
### WHY are these changes introduced?

The `changesets/action` github action requires a Github Token to work.
<img width="587" alt="Screenshot 2023-12-11 at 15 17 26" src="https://github.com/Shopify/shopify-app-js/assets/446046/017b26b0-5dec-4c59-a6e1-6f96cb9df00d">

### WHAT is this pull request doing?

Adding the token to the workflow.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
