### PR TITLE
Update `publish-experimental-build.yml` to manually publish

### DIFF
--- a/.github/workflows/publish-experimental-build.yml
+++ b/.github/workflows/publish-experimental-build.yml
@@ -24,14 +24,10 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Version
+        run: yarn changeset version --snapshot experimental
+
       - name: Publish to NPM
-        id: changesets
-        uses: changesets/action@v1
-        with:
-          version: yarn changeset version --snapshot experimental
-          publish: yarn changeset publish --tag experimental
-          setupGitUser: false
-          createGithubReleases: false
+        run: yarn changeset publish --tag experimental
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}


### PR DESCRIPTION
### WHY are these changes introduced?

The `changesets` action only works when comparing with a single base branch specified in its config file. In our case we can just publish what's available in the `experimental` branch, so we're calling the commands individually.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Changing the workflow to use individual commands.


## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
