### PR TITLE
Update publish-experimental-build.yml to setup npmrc with setup-node action

### DIFF
--- a/.github/workflows/publish-experimental-build.yml
+++ b/.github/workflows/publish-experimental-build.yml
@@ -12,11 +12,15 @@ jobs:
         with:
           ref: experimental
 
+      # Setup .npmrc file to publish to npm
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
           node-version: 18.x
           cache: 'yarn'
+          registry-url: 'https://registry.npmjs.org'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: yarn --frozen-lockfile
@@ -27,10 +31,8 @@ jobs:
       - name: Version
         run: yarn changeset version --snapshot experimental
 
-      - name: Setup .npmrc with NPM token
-        run:  echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN\n" > ~/.npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-
       - name: Publish to NPM
         run: yarn changeset publish --tag experimental
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### WHY are these changes introduced?

Setting up `.npmrc` with the `setup-node` action as described here so that we don't overwrite the original `.npmrc` https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
