### PR TITLE
Use the actual error string from body

### DIFF
--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/__tests__/token-exchange/authenticate.test.ts
@@ -123,7 +123,7 @@ describe('authenticate', () => {
     const shopify = shopifyApp(config);
 
     const {token} = getJwt();
-    await mockInvalidTokenExchangeRequest('invalid_subject_token');
+    await mockInvalidTokenExchangeRequest('invalid_subject_token_type');
 
     // WHEN
     const response = await getThrownResponse(
@@ -154,7 +154,7 @@ describe('authenticate', () => {
     const shopify = shopifyApp(config);
 
     const {token} = getJwt();
-    await mockInvalidTokenExchangeRequest('invalid_subject_token');
+    await mockInvalidTokenExchangeRequest('invalid_subject_token_type');
 
     // WHEN
     const response = await getThrownResponse(

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -126,7 +126,7 @@ export class TokenExchangeStrategy<Config extends AppConfigArg>
         error instanceof InvalidJwtError ||
         (error instanceof HttpResponseError &&
           error.response.code === 400 &&
-          error.response.body?.error === 'invalid_subject_token')
+          error.response.body?.error === 'invalid_subject_token_type')
       ) {
         throw respondToInvalidSessionToken({
           params: {api, config, logger},


### PR DESCRIPTION

### WHY are these changes introduced?
The error returned in the body is actually `invalid_subject_token_type`

![09-45-hfl11-s6yov](https://github.com/Shopify/shopify-app-js/assets/102243935/c865a370-1ba7-4291-b5bf-18de44eddd2b)
