### PR TITLE
🧹 Use new shopify-api util to compute admin url in login.ts

### DIFF
--- a/.changeset/dirty-starfishes-accept.md
+++ b/.changeset/dirty-starfishes-accept.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Minor refactor in login.ts to use new URL util method from shopify-api-js

--- a/packages/shopify-app-remix/src/server/authenticate/login/login.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/login/login.ts
@@ -37,8 +37,8 @@ export function loginFactory(params: BasicParams) {
 
     const authPath = `${config.appUrl}${config.auth.path}?shop=${sanitizedShop}`;
 
-    const storeName = sanitizedShop.split('.')[0];
-    const installPath = `https://admin.shopify.com/store/${storeName}/oauth/install?client_id=${config.apiKey}`;
+    const adminPath = api.utils.legacyUrlToShopAdminUrl(sanitizedShop);
+    const installPath = `https://${adminPath}/oauth/install?client_id=${config.apiKey}`;
 
     const shouldInstall =
       config.isEmbeddedApp && config.future.unstable_newEmbeddedAuthStrategy;


### PR DESCRIPTION
Closes 
- https://github.com/Shopify/develop-app-access/issues/132

### WHY are these changes introduced?
Clean up - use newly introduced url utils to compute admin URL 

### Tophat
Install with unified admin links still work: https://screenshot.click/17-56-ggai4-hem59.mp4
