### PR TITLE
Handle Webhook subscription errors after Token Exchange

### DIFF
--- a/.changeset/famous-knives-fix.md
+++ b/.changeset/famous-knives-fix.md
@@ -1,0 +1,17 @@
+---
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+'@shopify/shopify-app-session-storage-dynamodb': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-prisma': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-remix': patch
+---
+
+Bump shopify-api version from 9.0.1 to 9.0.2

--- a/.changeset/smart-windows-smash.md
+++ b/.changeset/smart-windows-smash.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Handle webhook registration throttling error

--- a/.changeset/wild-bottles-explode.md
+++ b/.changeset/wild-bottles-explode.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Use 'body' field from GraphqlQueryError when logging session validation error

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3",
     "@shopify/shopify-app-session-storage-memory": "^2.0.3",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-remix/package.json
+++ b/packages/shopify-app-remix/package.json
@@ -69,7 +69,7 @@
   "dependencies": {
     "@remix-run/server-runtime": "^2.0.0",
     "@shopify/admin-api-client": "^0.2.1",
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3",
     "@shopify/storefront-api-client": "^0.2.1",
     "isbot": "^3.7.1",

--- a/packages/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
@@ -306,7 +306,7 @@ export class AuthCodeFlowStrategy<
     } else if (error instanceof GraphqlQueryError) {
       const context: {[key: string]: string} = {shop};
       if (error.response) {
-        context.response = JSON.stringify(error.response);
+        context.response = JSON.stringify(error.body);
       }
 
       logger.error(

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/mock-responses.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/mock-responses.ts
@@ -32,3 +32,14 @@ export const HTTP_WEBHOOK_CREATE_ERROR_RESPONSE = {
     },
   },
 };
+
+export const HTTP_WEBHOOK_THROTTLING_ERROR_RESPONSE = {
+  errors: [
+    {
+      message: 'Throttled',
+      extensions: {
+        code: 'THROTTLED',
+      },
+    },
+  ],
+};

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/__tests__/register.test.ts
@@ -1,4 +1,4 @@
-import {DeliveryMethod, Session} from '@shopify/shopify-api';
+import {DeliveryMethod, GraphqlQueryError, Session} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../..';
 import {
@@ -109,5 +109,102 @@ describe('Webhook registration', () => {
     expect(results).toMatchObject({
       NOT_A_VALID_TOPIC: [expect.objectContaining({success: false})],
     });
+  });
+
+  // eslint-disable-next-line no-warning-comments
+  // TODO: Remove tests once we have a better solution to parallel afterAuth calls
+  it('logs throttling errors', async () => {
+    // GIVEN
+    const shopify = shopifyApp(
+      testConfig({
+        webhooks: {
+          NOT_A_VALID_TOPIC: {
+            deliveryMethod: DeliveryMethod.Http,
+            callbackUrl: '/webhooks',
+          },
+        },
+      }),
+    );
+    const session = new Session({
+      id: `offline_${TEST_SHOP}`,
+      shop: TEST_SHOP,
+      isOnline: false,
+      state: 'test',
+      accessToken: 'totally_real_token',
+    });
+
+    await mockExternalRequests(
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptions',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE),
+        ),
+      },
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptionCreate',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.HTTP_WEBHOOK_THROTTLING_ERROR_RESPONSE),
+        ),
+      },
+    );
+
+    // WHEN
+    const results = await shopify.registerWebhooks({session});
+
+    // THEN
+    expect(results).toBeUndefined();
+  });
+
+  it('throws other errors', async () => {
+    // GIVEN
+    const shopify = shopifyApp(
+      testConfig({
+        webhooks: {
+          NOT_A_VALID_TOPIC: {
+            deliveryMethod: DeliveryMethod.Http,
+            callbackUrl: '/webhooks',
+          },
+        },
+      }),
+    );
+    const session = new Session({
+      id: `offline_${TEST_SHOP}`,
+      shop: TEST_SHOP,
+      isOnline: false,
+      state: 'test',
+      accessToken: 'totally_real_token',
+    });
+
+    await mockExternalRequests(
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptions',
+        }),
+        response: new Response(
+          JSON.stringify(mockResponses.EMPTY_WEBHOOK_RESPONSE),
+        ),
+      },
+      {
+        request: new Request(GRAPHQL_URL, {
+          method: 'POST',
+          body: 'webhookSubscriptionCreate',
+        }),
+        response: new Response(
+          JSON.stringify({errors: [{extensions: {code: 'FAILED_REQUEST'}}]}),
+        ),
+      },
+    );
+
+    // THEN
+    expect(shopify.registerWebhooks({session})).rejects.toThrowError(
+      GraphqlQueryError,
+    );
   });
 });

--- a/packages/shopify-app-remix/src/server/authenticate/webhooks/register.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/webhooks/register.ts
@@ -4,26 +4,45 @@ import type {RegisterWebhooksOptions} from './types';
 
 export function registerWebhooksFactory({api, logger}: BasicParams) {
   return async function registerWebhooks({session}: RegisterWebhooksOptions) {
-    return api.webhooks.register({session}).then((response) => {
-      Object.entries(response).forEach(([topic, topicResults]) => {
-        topicResults.forEach(({success, ...rest}) => {
-          if (success) {
-            logger.debug('Registered webhook', {
-              topic,
-              shop: session.shop,
-              operation: rest.operation,
-            });
-          } else {
-            logger.error('Failed to register webhook', {
-              topic,
-              shop: session.shop,
-              result: JSON.stringify(rest.result),
-            });
-          }
+    return api.webhooks
+      .register({session})
+      .then((response) => {
+        Object.entries(response).forEach(([topic, topicResults]) => {
+          topicResults.forEach(({success, ...rest}) => {
+            if (success) {
+              logger.debug('Registered webhook', {
+                topic,
+                shop: session.shop,
+                operation: rest.operation,
+              });
+            } else {
+              logger.error('Failed to register webhook', {
+                topic,
+                shop: session.shop,
+                result: JSON.stringify(rest.result),
+              });
+            }
+          });
         });
-      });
 
-      return response;
-    });
+        return response;
+      })
+      .catch((error) => {
+        const graphQLErrors: {extensions: {code?: string}}[] =
+          error.body?.errors?.graphQLErrors || [];
+
+        const throttled = graphQLErrors.find(
+          ({extensions: {code}}) => code === 'THROTTLED',
+        );
+
+        if (throttled) {
+          logger.error('Failed to register webhooks', {
+            shop: session.shop,
+            error: JSON.stringify(error),
+          });
+        } else {
+          throw error;
+        }
+      });
   };
 }

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -66,7 +66,7 @@ interface JSONArray extends Array<JSONValue> {}
 
 type RegisterWebhooks = (
   options: RegisterWebhooksOptions,
-) => Promise<RegisterReturn>;
+) => Promise<RegisterReturn | void>;
 
 export enum LoginErrorType {
   MissingShop = 'MISSING_SHOP',

--- a/packages/shopify-app-session-storage-dynamodb/package.json
+++ b/packages/shopify-app-session-storage-dynamodb/package.json
@@ -37,13 +37,13 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",
     "@shopify/prettier-config": "^1.1.2",
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3",
     "@shopify/shopify-app-session-storage-test-utils": "^1.0.3",
     "eslint": "^8.55.0",

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -33,7 +33,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -35,7 +35,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -37,7 +37,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-prisma/package.json
+++ b/packages/shopify-app-session-storage-prisma/package.json
@@ -35,13 +35,13 @@
   },
   "peerDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3",
     "prisma": "^4.13.0"
   },
   "devDependencies": {
     "@prisma/client": "^4.13.0",
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3",
     "prisma": "^4.13.0",
     "@shopify/eslint-plugin": "^42.1.0",

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -36,7 +36,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -38,7 +38,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1",
+    "@shopify/shopify-api": "^9.0.2",
     "@shopify/shopify-app-session-storage": "^2.0.3"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -34,7 +34,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.0.1"
+    "@shopify/shopify-api": "^9.0.2"
   },
   "devDependencies": {
     "@shopify/eslint-plugin": "^42.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2787,6 +2787,13 @@
   dependencies:
     "@shopify/graphql-client" "^0.9.1"
 
+"@shopify/admin-api-client@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@shopify/admin-api-client/-/admin-api-client-0.2.2.tgz#c288b4af8834bc7ab6c7c1ad26e7feddfa648ec6"
+  integrity sha512-7x79Ras5gbf7U3oVBjFIPF70WUUit3kLF93IMhtTaC9OJ/b9NIeW1w4/+RSJq3FM/7MGQGUkyrrnuNI3nl3Eig==
+  dependencies:
+    "@shopify/graphql-client" "^0.9.2"
+
 "@shopify/babel-preset@^24.1.4":
   version "24.1.5"
   resolved "https://registry.yarnpkg.com/@shopify/babel-preset/-/babel-preset-24.1.5.tgz#76cfef62bb8a4d9769559f3f2505148a55d13488"
@@ -2852,6 +2859,11 @@
   version "0.9.1"
   resolved "https://registry.yarnpkg.com/@shopify/graphql-client/-/graphql-client-0.9.1.tgz#0c37a4143c0dd26837e82b8fd13e1b64fabf90dc"
   integrity sha512-yx6PIHY8u4O0ijUQccmIpjoyM1JSbe5RkrSyXSbjhsS+nla0WAJDIMw4R01mjx3dFnVIcGONhRX/QrUq97uWig==
+
+"@shopify/graphql-client@^0.9.2":
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/@shopify/graphql-client/-/graphql-client-0.9.2.tgz#2c37ba20bbc1713c78b1b241af99405cd92ab428"
+  integrity sha512-Xk7bPA3UsLXFHV6F39t5g8dTVxqPagwJoR+MLYUvCuhlWpDeZW3f/OcgShXPPben5NcnOVV38kj5GVlkvrWqiQ==
 
 "@shopify/loom-cli@^1.1.0":
   version "1.1.0"
@@ -2990,14 +3002,14 @@
     jest-matcher-utils "^26.6.2"
     react-reconciler "^0.28.0"
 
-"@shopify/shopify-api@^9.0.1":
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-9.0.1.tgz#7f236d94d902b3671c6a11f11f3561f98ddc7422"
-  integrity sha512-ToqT5zt/YA+VbFcLAoEVr6grs6v+Y9io5kuULy9Zhm5RClFEhkpRLM4U+vrrV5XjWYC6pcxs00WjpSi0onryrw==
+"@shopify/shopify-api@^9.0.2":
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-9.0.2.tgz#01a321fc6bcf3450572751e6c1f8c1e4ba8ab78a"
+  integrity sha512-ZOnzDein63JMatQAYshg2RyBXcseBUTP8stbrwG/FwDhWqNafxMC2O8AcoIGoaNc1SoRYbWpxCbwkeO/CrW7Vg==
   dependencies:
-    "@shopify/admin-api-client" "^0.2.1"
+    "@shopify/admin-api-client" "^0.2.2"
     "@shopify/network" "^3.2.1"
-    "@shopify/storefront-api-client" "^0.2.1"
+    "@shopify/storefront-api-client" "^0.2.2"
     compare-versions "^5.0.3"
     isbot "^3.6.10"
     jose "^4.9.1"
@@ -3011,6 +3023,13 @@
   integrity sha512-e0yk0rwxGd6Dr7ArBHD1MuDd74RRkW03xb2YS90PZEP3mHcMCVAng2lm733tqooA6iNaooAKsy+O0HTKH2JgUA==
   dependencies:
     "@shopify/graphql-client" "^0.9.1"
+
+"@shopify/storefront-api-client@^0.2.2":
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/@shopify/storefront-api-client/-/storefront-api-client-0.2.2.tgz#79ddddd70838617e7a1a509f2d58ce148457e293"
+  integrity sha512-sPpbXEGYbCRQ1jvwdEMtrutUTLmwtrZ30nHBLuKLIgtezFmhuvF5/FD/hgPQCxWxEukZt8518gAVgE6p+9D8ig==
+  dependencies:
+    "@shopify/graphql-client" "^0.9.2"
 
 "@shopify/typescript-configs@^5.1.0":
   version "5.1.0"


### PR DESCRIPTION
### WHY are these changes introduced?

This change re-introduces Webhook subscription error handling from 7888756951fa69af2a12a8e9a6063da9486181c1 now that the way to access GraphQL error information changed on `shopify-api` v9.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

On `afterAuth` after performing Token Exchange, if `webhooks.subscribe` throws a throttling `GraphQLError`, we catch it and log it, but don't stop server execution, since it's expected to happen on parallel requests.

We had to bump the `shopify-api` package version as well to get the error information.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- N/A I have documented new APIs/updated the documentation for modified APIs (for public APIs)
