### PR TITLE
Replace query() call with request()

### DIFF
--- a/.changeset/polite-birds-unite.md
+++ b/.changeset/polite-birds-unite.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Replaced query() internal call in the GraphQL client with request()

--- a/packages/shopify-app-express/src/middlewares/has-valid-access-token.ts
+++ b/packages/shopify-app-express/src/middlewares/has-valid-access-token.ts
@@ -12,7 +12,7 @@ export async function hasValidAccessToken(
 ): Promise<boolean> {
   try {
     const client = new api.clients.Graphql({session});
-    await client.query({data: TEST_GRAPHQL_QUERY});
+    await client.request(TEST_GRAPHQL_QUERY);
     return true;
   } catch (error) {
     if (error instanceof HttpResponseError && error.response.code === 401) {


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #586 

The express package was still calling `client.query()` from the GrahpQL client in one place, which should be a call to `.request()`.

### WHAT is this pull request doing?

Fixing the call.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
