### PR TITLE
Update Typescript to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "rimraf": "^5.0.0",
     "ts-jest": "^29.1.0",
     "tslib": "^2.6.2",
-    "typescript": "^4.9.5"
+    "typescript": "5.3.3"
   },
   "dependencies": {},
   "workspaces": [

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "declarationMap": true,
     "pretty": true,
-    "moduleResolution": "node16",
+    "module": "Node16",
+    "moduleResolution": "Node16",
     "target": "es5",
     "downlevelIteration": true,
     "esModuleInterop": true,
@@ -32,7 +33,6 @@
       "es2020",
       "esnext.asynciterable"
     ],
-    "typeRoots": ["./node_modules/@types"],
     "baseUrl": ".",
     "outDir": "./dist",
     "rootDir": "src"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10240,15 +10240,15 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.3.5, typescript@^4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
-
-"typescript@^4.8.3 || ^5.0.0":
+typescript@5.3.3, "typescript@^4.8.3 || ^5.0.0":
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==
+
+typescript@^4.3.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR updates the dev dependency on `typescript` to the latest version, and fixes a couple of configurations that required updates.