### PR TITLE
Update `unauthenticated` session loading to throw specific `SessionNotFoundError`

### DIFF
--- a/.changeset/stupid-peas-lay.md
+++ b/.changeset/stupid-peas-lay.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": minor
+---
+
+Add SessionNotFoundError for unauthenticated requests

--- a/packages/shopify-app-remix/src/server/errors.ts
+++ b/packages/shopify-app-remix/src/server/errors.ts
@@ -1,0 +1,3 @@
+import {ShopifyError} from '@shopify/shopify-api';
+
+export class SessionNotFoundError extends ShopifyError {}

--- a/packages/shopify-app-remix/src/server/index.ts
+++ b/packages/shopify-app-remix/src/server/index.ts
@@ -17,3 +17,4 @@ export type {ShopifyApp, LoginError} from './types';
 export {LoginErrorType, AppDistribution} from './types';
 export {boundary} from './boundary';
 export {shopifyApp} from './shopify-app';
+export * from './errors';

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
@@ -1,4 +1,4 @@
-import {shopifyApp} from '../../../index';
+import {SessionNotFoundError, shopifyApp} from '../../../index';
 import {
   TEST_SHOP,
   setUpValidSession,
@@ -12,7 +12,9 @@ describe('unauthenticated admin context', () => {
     const shopify = shopifyApp(testConfig());
 
     // EXPECT
-    await expect(shopify.unauthenticated.admin(TEST_SHOP)).rejects.toThrow();
+    await expect(shopify.unauthenticated.admin(TEST_SHOP)).rejects.toThrow(
+      SessionNotFoundError,
+    );
   });
 
   expectAdminApiClient(async () => {

--- a/packages/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
@@ -1,5 +1,6 @@
-import {ShopifyError, ShopifyRestResources} from '@shopify/shopify-api';
+import {ShopifyRestResources} from '@shopify/shopify-api';
 
+import {SessionNotFoundError} from '../../errors';
 import {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients/admin';
 import {getOfflineSession} from '../helpers';
@@ -15,7 +16,7 @@ export function unauthenticatedAdminContextFactory<
     const session = await getOfflineSession(shop, params);
 
     if (!session) {
-      throw new ShopifyError(
+      throw new SessionNotFoundError(
         `Could not find a session for shop ${shop} when creating unauthenticated admin context`,
       );
     }

--- a/packages/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
+++ b/packages/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
@@ -1,5 +1,4 @@
-import {ShopifyError} from '@shopify/shopify-api';
-
+import {SessionNotFoundError} from '../../errors';
 import {BasicParams} from '../../types';
 import {storefrontClientFactory} from '../../clients/storefront';
 import {getOfflineSession} from '../helpers';
@@ -16,7 +15,7 @@ export function unauthenticatedStorefrontContextFactory(
     const session = await getOfflineSession(shop, params);
 
     if (!session) {
-      throw new ShopifyError(
+      throw new SessionNotFoundError(
         `Could not find a session for shop ${shop} when creating unauthenticated storefront context`,
       );
     }


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

It's currently awkward to catch this specific error, requiring matching on the error message string.

#### Before

```typescript
import {unauthenticated} from '~/shopify.server';

try {
  const {admin} = await unauthenticated.admin(shop);
} catch (err) {
  if (err.message.includes('Could not find a session for shop')) {
    // do something specific
  }
}
```

#### After

```typescript
import {SessionNotFoundError} from '@shopify/shopify-app-remix';
import {unauthenticated} from '~/shopify.server';

try {
  const {admin} = await unauthenticated.admin(shop);
} catch (err) {
  if (err instanceof SessionNotFoundError) {
    // do something specific
  }
}
```

### WHAT is this pull request doing?

Defines and exports a new error class extending `ShopifyError`, meaning it should be backwards compatible for anyone already doing `err instanceof ShopifyError`.

Throws `SessionNotFoundError` instead of `ShopifyError` if the session is missing.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
