### PR TITLE
Remove usages of unstable_tokenExchange

### DIFF
--- a/.changeset/thick-wombats-clap.md
+++ b/.changeset/thick-wombats-clap.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Remove references to unstable_tokenExchange

--- a/.changeset/twenty-moles-help.md
+++ b/.changeset/twenty-moles-help.md
@@ -1,0 +1,17 @@
+---
+"@shopify/shopify-app-session-storage-postgresql": minor
+"@shopify/shopify-app-session-storage-test-utils": minor
+"@shopify/shopify-app-session-storage-dynamodb": minor
+"@shopify/shopify-app-session-storage-mongodb": minor
+"@shopify/shopify-app-session-storage-memory": minor
+"@shopify/shopify-app-session-storage-prisma": minor
+"@shopify/shopify-app-session-storage-sqlite": minor
+"@shopify/shopify-app-session-storage-mysql": minor
+"@shopify/shopify-app-session-storage-redis": minor
+"@shopify/shopify-app-session-storage-kv": minor
+"@shopify/shopify-app-session-storage": minor
+"@shopify/shopify-app-express": minor
+"@shopify/shopify-app-remix": minor
+---
+
+Update shopify-api version to 9.2.0

--- a/packages/shopify-app-express/package.json
+++ b/packages/shopify-app-express/package.json
@@ -30,7 +30,7 @@
     "Storefront API"
   ],
   "dependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4",
     "@shopify/shopify-app-session-storage-memory": "^2.0.4",
     "cookie-parser": "^1.4.6",

--- a/packages/shopify-app-remix/package.json
+++ b/packages/shopify-app-remix/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "@remix-run/server-runtime": "^2.5.1",
     "@shopify/admin-api-client": "^0.2.3",
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4",
     "@shopify/storefront-api-client": "^0.2.3",
     "isbot": "^3.7.1",

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -154,10 +154,7 @@ function deriveApi(appConfig: AppConfigArg) {
     isEmbeddedApp: appConfig.isEmbeddedApp ?? true,
     apiVersion: appConfig.apiVersion ?? LATEST_API_VERSION,
     isCustomStoreApp: appConfig.distribution === AppDistribution.ShopifyAdmin,
-    future: {
-      unstable_tokenExchange:
-        appConfig.future?.unstable_newEmbeddedAuthStrategy,
-    },
+    future: {},
   });
 }
 

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -14,8 +14,8 @@ import type {
 import type {AuthenticatePublic} from './authenticate/public/types';
 import type {AuthenticateAdmin} from './authenticate/admin/types';
 import type {Unauthenticated} from './unauthenticated/types';
-import type {FutureFlagOptions, FutureFlags} from './future/flags';
 import type {AuthenticateFlow} from './authenticate/flow/types';
+import {FutureFlagOptions} from './future/flags';
 
 export interface BasicParams<
   Future extends FutureFlagOptions = FutureFlagOptions,
@@ -29,11 +29,7 @@ export interface BasicParams<
   logger: Shopify['logger'];
 }
 
-export interface ApiFutureFlags<Future extends FutureFlagOptions> {
-  unstable_tokenExchange?: Future extends FutureFlags
-    ? Future['unstable_newEmbeddedAuthStrategy']
-    : boolean;
-}
+export interface ApiFutureFlags<_Future extends FutureFlagOptions> {}
 
 export type ApiConfigWithFutureFlags<Future extends FutureFlagOptions> =
   ConfigParams<ShopifyRestResources, ApiFutureFlags<Future>>;

--- a/packages/shopify-app-remix/src/server/types.ts
+++ b/packages/shopify-app-remix/src/server/types.ts
@@ -15,7 +15,7 @@ import type {AuthenticatePublic} from './authenticate/public/types';
 import type {AuthenticateAdmin} from './authenticate/admin/types';
 import type {Unauthenticated} from './unauthenticated/types';
 import type {AuthenticateFlow} from './authenticate/flow/types';
-import {FutureFlagOptions} from './future/flags';
+import type {FutureFlagOptions} from './future/flags';
 
 export interface BasicParams<
   Future extends FutureFlagOptions = FutureFlagOptions,

--- a/packages/shopify-app-session-storage-dynamodb/package.json
+++ b/packages/shopify-app-session-storage-dynamodb/package.json
@@ -36,7 +36,7 @@
     "@aws-sdk/util-dynamodb": "^3.499.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-kv/package.json
+++ b/packages/shopify-app-session-storage-kv/package.json
@@ -35,7 +35,7 @@
     "semver": "^7.5.4"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-memory/package.json
+++ b/packages/shopify-app-session-storage-memory/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mongodb/package.json
+++ b/packages/shopify-app-session-storage-mongodb/package.json
@@ -34,7 +34,7 @@
     "mongodb": "^6.3.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-mysql/package.json
+++ b/packages/shopify-app-session-storage-mysql/package.json
@@ -35,7 +35,7 @@
     "mysql2": "^3.3.1"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-postgresql/package.json
+++ b/packages/shopify-app-session-storage-postgresql/package.json
@@ -36,7 +36,7 @@
     "pg-connection-string": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-prisma/package.json
+++ b/packages/shopify-app-session-storage-prisma/package.json
@@ -33,7 +33,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@prisma/client": "^5.8.1",
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4",
     "prisma": "^5.8.1"
   },

--- a/packages/shopify-app-session-storage-redis/package.json
+++ b/packages/shopify-app-session-storage-redis/package.json
@@ -35,7 +35,7 @@
     "redis": "^4.6.12"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-sqlite/package.json
+++ b/packages/shopify-app-session-storage-sqlite/package.json
@@ -35,7 +35,7 @@
     "sqlite3": "^5.1.7"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {

--- a/packages/shopify-app-session-storage-test-utils/package.json
+++ b/packages/shopify-app-session-storage-test-utils/package.json
@@ -35,7 +35,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0",
+    "@shopify/shopify-api": "^9.2.0",
     "@shopify/shopify-app-session-storage": "^2.0.4"
   },
   "devDependencies": {},

--- a/packages/shopify-app-session-storage/package.json
+++ b/packages/shopify-app-session-storage/package.json
@@ -32,7 +32,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.1.0"
+    "@shopify/shopify-api": "^9.2.0"
   },
   "devDependencies": {},
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2801,10 +2801,10 @@
     jest-matcher-utils "^26.6.2"
     react-reconciler "^0.28.0"
 
-"@shopify/shopify-api@^9.1.0":
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-9.1.0.tgz#7b9ca825741187221972b9ca4864e74436d5ebfa"
-  integrity sha512-9/w4bcfmwccHNedJe+tQeTVZ5WGb9eZy05wSp9LXq+V2PlcIp2gxSfudg6FGPwmSU4LgRD1d6AfWxnyRHV5M4g==
+"@shopify/shopify-api@^9.2.0":
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@shopify/shopify-api/-/shopify-api-9.2.0.tgz#8a552fc63a578fdb0b58261fefdc7b87f10065a6"
+  integrity sha512-rHAKzMO2AQLf+UkjG0x6TUNga/LcAPM3gd3ANCx/yFxKSYvyaJDeVdkgidt5GNjl7UacWkICTr9Tc4XFgmFDng==
   dependencies:
     "@shopify/admin-api-client" "^0.2.3"
     "@shopify/network" "^3.2.1"


### PR DESCRIPTION
### WHAT is this pull request doing?

With `unstable_tokenExchange` [future flag being removed](https://github.com/Shopify/shopify-api-js/pull/1196) from `shopify-api`, we need to remove references to this flag in the Remix package.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
