### PR TITLE
Return 403 in non-embedded XHR requests

### DIFF
--- a/.changeset/curvy-lizards-exist.md
+++ b/.changeset/curvy-lizards-exist.md
@@ -1,0 +1,10 @@
+---
+"@shopify/shopify-app-express": patch
+---
+
+Return a 403 with X-Shopify headers on XHR requests for non-embedded apps, instead of a 302. The 302 ran into CORS errors and always failed.
+
+These requests will return the following headers:
+
+- `X-Shopify-Api-Request-Failure-Reauthorize`: `1`
+- `X-Shopify-Api-Request-Failure-Reauthorize-Url`: <URL>

--- a/packages/shopify-app-express/docs/reference/validateAuthenticatedSession.md
+++ b/packages/shopify-app-express/docs/reference/validateAuthenticatedSession.md
@@ -7,6 +7,7 @@ If the verification fails in either case, it will redirect the user to complete 
 
 - When embedded, it will verify that the request received from the front-end originates from an App Bridge `authenticatedFetch`.
 - When not embedded, it will verify that the request contains a valid session cookie set up during the OAuth process.
+  - XHR requests will return a `403 Forbidden` response with the `X-Shopify-Api-Request-Failure-Reauthorize-Url` header indicating where to redirect the user for authentication.
 
 Please visit [our documentation](https://shopify.dev/docs/apps/auth/oauth/session-tokens) to learn more about session tokens and how they work.
 

--- a/packages/shopify-app-express/src/index.ts
+++ b/packages/shopify-app-express/src/index.ts
@@ -85,7 +85,7 @@ export function shopifyApp<Params extends AppConfigParams>(
       api,
       config: validatedConfig,
     }),
-    redirectOutOfApp: redirectOutOfApp({config: validatedConfig}),
+    redirectOutOfApp: redirectOutOfApp({api, config: validatedConfig}),
   };
 }
 

--- a/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -298,5 +298,22 @@ describe('validateAuthenticatedSession', () => {
 
       expect(response.header.location).toBe(`/auth?shop=my-shop.myshopify.io`);
     });
+
+    it('returns a 403 with the authentication header in XHR requests', async () => {
+      session.expires = new Date('2020-12-31T00:00:00');
+
+      const response = await request(app)
+        .get('/test/shop?shop=my-shop.myshopify.io')
+        .set('Cookie', validCookies)
+        .set('X-Requested-With', 'XMLHttpRequest')
+        .expect(403);
+
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize'],
+      ).toBe('1');
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize-url'],
+      ).toBe(`${shopify.config.auth.path}?shop=my-shop.myshopify.io`);
+    });
   });
 });

--- a/packages/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -102,7 +102,12 @@ export function validateAuthenticatedSession({
         {shop},
       );
 
-      return redirectOutOfApp({config})({req, res, redirectUri, shop: shop!});
+      return redirectOutOfApp({api, config})({
+        req,
+        res,
+        redirectUri,
+        shop: shop!,
+      });
     };
   };
 }

--- a/packages/shopify-app-express/src/redirect-out-of-app.ts
+++ b/packages/shopify-app-express/src/redirect-out-of-app.ts
@@ -8,9 +8,10 @@ export function redirectOutOfApp({
   config,
 }: ApiAndConfigParams): RedirectOutOfAppFunction {
   return function redirectOutOfApp({req, res, redirectUri, shop}): void {
-    if (!api.config.isEmbeddedApp && isFetchRequest(req)) {
-      appBridgeHeaderRedirect(config, res, redirectUri);
-    } else if (req.headers.authorization?.match(/Bearer (.*)/)) {
+    if (
+      (!api.config.isEmbeddedApp && isFetchRequest(req)) ||
+      req.headers.authorization?.match(/Bearer (.*)/)
+    ) {
       appBridgeHeaderRedirect(config, res, redirectUri);
     } else if (req.query.embedded === '1') {
       exitIframeRedirect(config, req, res, redirectUri, shop);

--- a/packages/shopify-app-express/src/redirect-to-auth.ts
+++ b/packages/shopify-app-express/src/redirect-to-auth.ts
@@ -44,7 +44,7 @@ function clientSideRedirect(
   const redirectUriParams = new URLSearchParams({shop, host}).toString();
   const redirectUri = `${api.config.hostScheme}://${api.config.hostName}${config.auth.path}?${redirectUriParams}`;
 
-  redirectOutOfApp({config})({req, res, redirectUri, shop});
+  redirectOutOfApp({config, api})({req, res, redirectUri, shop});
 }
 
 async function serverSideRedirect(

--- a/packages/shopify-app-express/src/types.ts
+++ b/packages/shopify-app-express/src/types.ts
@@ -14,10 +14,6 @@ export interface RedirectToAuthParams extends ApiAndConfigParams {
   isOnline?: boolean;
 }
 
-export interface RedirectOutOfAppParams {
-  config: AppConfigInterface;
-}
-
 export interface RedirectOutOfAppInnerParams {
   req: Request;
   res: Response;


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #470 

As pointed out in the issue, we're returning a 302 that runs into CORS errors, making the `validateAuthenticatedSession` middleware essentially broken for non-embedded apps.

### WHAT is this pull request doing?

Returning the same 403 response headers we return for XHR requests for embedded apps. It'll be up to the app to catch and handle those requests, but it'll be a valid response, instead of a 302 that will always fail.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
