### PR TITLE
Add function to sanitize exitIframe URLs

### DIFF
--- a/.changeset/smart-kiwis-tie.md
+++ b/.changeset/smart-kiwis-tie.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Throw error when attempting to exit-iframe with an invalid URL

--- a/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/exit-i-frame-path.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/__tests__/exit-i-frame-path.test.ts
@@ -1,3 +1,5 @@
+import {ShopifyError} from '@shopify/shopify-api';
+
 import {shopifyApp} from '../../..';
 import {
   APP_URL,
@@ -81,5 +83,17 @@ describe('authorize.admin exit iframe path', () => {
     // THEN
     expect(response.status).toBe(200);
     expectDocumentRequestHeaders(response);
+  });
+
+  test('refuses to redirect to invalid URLs', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const exitTo = encodeURIComponent('file:///not/allowed/path');
+    const url = `${APP_URL}/auth/exit-iframe?exitIframe=${exitTo}&shop=${TEST_SHOP}`;
+
+    // THEN
+    await expect(shopify.authenticate.admin(new Request(url))).rejects.toThrow(
+      ShopifyError,
+    );
   });
 });

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/__tests__/validate-redirect-url.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/__tests__/validate-redirect-url.test.ts
@@ -1,0 +1,84 @@
+import {ShopifyError} from '@shopify/shopify-api';
+
+import {APP_URL} from '../../../../__test-helpers';
+import {sanitizeRedirectUrl} from '../validate-redirect-url';
+
+describe('sanitizeRedirectUrlFactory', () => {
+  it('throws ShopifyError with non-string types', () => {
+    // THEN
+    expect(() => sanitizeRedirectUrl(APP_URL, 123)).toThrow(ShopifyError);
+  });
+
+  it('throws ShopifyError with file URLs', () => {
+    // THEN
+    expect(() => sanitizeRedirectUrl(APP_URL, '///path/to/a/file')).toThrow(
+      ShopifyError,
+    );
+  });
+
+  it('throws ShopifyError if URL contains whitespaces', () => {
+    // THEN
+    expect(() =>
+      sanitizeRedirectUrl(APP_URL, '/fine/url/but/it has spaces'),
+    ).toThrow(ShopifyError);
+  });
+
+  it('throws ShopifyError with invalid URLs', () => {
+    // THEN
+    expect(() => sanitizeRedirectUrl('not a domain', '/valid/path')).toThrow(
+      ShopifyError,
+    );
+  });
+
+  it('throws ShopifyError with invalid relative URLs', () => {
+    // THEN
+    expect(() => sanitizeRedirectUrl(APP_URL, '/valid//path')).toThrow(
+      ShopifyError,
+    );
+  });
+
+  it('throws ShopifyError with invalid protocol', () => {
+    // THEN
+    expect(() =>
+      sanitizeRedirectUrl(APP_URL, 'javascript:alert("nope")'),
+    ).toThrow(ShopifyError);
+  });
+
+  it('throws ShopifyError when SSL is required and an HTTP address is given', () => {
+    // THEN
+    expect(() =>
+      sanitizeRedirectUrl(APP_URL, 'http://example.com', {requireSSL: true}),
+    ).toThrow(ShopifyError);
+  });
+
+  it('returns undefined if not set to throw', () => {
+    // THEN
+    expect(
+      sanitizeRedirectUrl(APP_URL, 'http://example.com', {
+        requireSSL: true,
+        throwOnInvalid: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it('succeeds on a valid URL', () => {
+    // THEN
+    expect(
+      sanitizeRedirectUrl(APP_URL, '/my/app/path', {requireSSL: true}),
+    ).toEqual(new URL(`${APP_URL}/my/app/path`));
+  });
+
+  it('succeeds on a valid URL when not throwing', () => {
+    // THEN
+    expect(
+      sanitizeRedirectUrl(APP_URL, '/my/app/path', {throwOnInvalid: false}),
+    ).toEqual(new URL(`${APP_URL}/my/app/path`));
+  });
+
+  it('succeeds on a valid HTTP URL when not requiring SSL', () => {
+    // THEN
+    expect(
+      sanitizeRedirectUrl(APP_URL, 'http://my/app/path', {requireSSL: false}),
+    ).toEqual(new URL('http://my/app/path'));
+  });
+});

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/render-app-bridge.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/render-app-bridge.ts
@@ -2,6 +2,8 @@ import {BasicParams} from '../../../types';
 import {appBridgeUrl} from '../../helpers/app-bridge-url';
 import {addDocumentResponseHeaders} from '../../helpers/add-response-headers';
 
+import {sanitizeRedirectUrl} from './validate-redirect-url';
+
 import type {RedirectTarget} from '.';
 
 export interface RedirectToOptions {
@@ -16,7 +18,8 @@ export function renderAppBridge(
 ): never {
   let redirectToScript = '';
   if (redirectTo) {
-    const destination = new URL(redirectTo.url, config.appUrl);
+    const destination = sanitizeRedirectUrl(config.appUrl, redirectTo.url);
+
     const target = redirectTo.target ?? '_top';
 
     redirectToScript = `<script>window.open(${JSON.stringify(

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/validate-redirect-url.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/validate-redirect-url.ts
@@ -1,0 +1,67 @@
+import {ShopifyError} from '@shopify/shopify-api';
+
+interface Options {
+  requireSSL?: boolean;
+  throwOnInvalid?: boolean;
+}
+
+type SanitizedRedirectUrl<OptionsArg extends Options> =
+  OptionsArg['throwOnInvalid'] extends false ? URL | undefined : URL;
+
+const FILE_URI_MATCH = /\/\/\//;
+const INVALID_RELATIVE_URL = /[/\\][/\\]/;
+const WHITESPACE_CHARACTER = /\s/;
+const VALID_PROTOCOLS = ['https:', 'http:'];
+
+function isSafe(
+  domain: string,
+  redirectUrl: unknown,
+  requireSSL: boolean | undefined = true,
+): redirectUrl is string {
+  if (typeof redirectUrl !== 'string') {
+    return false;
+  }
+
+  if (
+    FILE_URI_MATCH.test(redirectUrl) ||
+    WHITESPACE_CHARACTER.test(redirectUrl)
+  ) {
+    return false;
+  }
+
+  let url: URL;
+
+  try {
+    url = new URL(redirectUrl, domain);
+  } catch (error) {
+    return false;
+  }
+
+  if (INVALID_RELATIVE_URL.test(url.pathname)) {
+    return false;
+  }
+
+  if (!VALID_PROTOCOLS.includes(url.protocol)) {
+    return false;
+  }
+
+  if (requireSSL && url.protocol !== 'https:') {
+    return false;
+  }
+
+  return true;
+}
+
+export function sanitizeRedirectUrl<OptionsArg extends Options>(
+  domain: string,
+  redirectUrl: unknown,
+  options: OptionsArg = {} as OptionsArg,
+): SanitizedRedirectUrl<OptionsArg> {
+  if (isSafe(domain, redirectUrl, options.requireSSL)) {
+    return new URL(redirectUrl, domain) as SanitizedRedirectUrl<OptionsArg>;
+  } else if (options.throwOnInvalid === false) {
+    return undefined as SanitizedRedirectUrl<OptionsArg>;
+  } else {
+    throw new ShopifyError('Invalid URL. Refusing to redirect');
+  }
+}


### PR DESCRIPTION
### WHY are these changes introduced?

If we pass in an invalid address when we render app bridge with a redirect URL, we're currently not detecting / failing on it, and attempting to load it instead.

### WHAT is this pull request doing?

Throw an error before we go to the destination to avoid the unnecessary request.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change