### PR TITLE
Fix billing when using new embedded auth strategy

### DIFF
--- a/.changeset/pretty-baboons-teach.md
+++ b/.changeset/pretty-baboons-teach.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Fix billing redirect issue when using the new embedded auth strategy

--- a/packages/shopify-app-remix/src/server/__test-helpers/expect-exit-iframe.ts
+++ b/packages/shopify-app-remix/src/server/__test-helpers/expect-exit-iframe.ts
@@ -4,6 +4,7 @@ interface ExpectExitIframeRedirectOptions {
   shop?: string;
   host?: string | null;
   destination?: string;
+  addHostToExitIframePath?: boolean;
 }
 
 export function expectExitIframeRedirect(
@@ -12,6 +13,7 @@ export function expectExitIframeRedirect(
     shop = TEST_SHOP,
     host = BASE64_HOST,
     destination = `/auth?shop=${shop}`,
+    addHostToExitIframePath = true,
   }: ExpectExitIframeRedirectOptions = {},
 ) {
   expect(response.status).toBe(302);
@@ -23,9 +25,13 @@ export function expectExitIframeRedirect(
   expect(pathname).toBe('/auth/exit-iframe');
 
   expect(searchParams.get('shop')).toBe(shop);
-  expect(searchParams.get('exitIframe')).toBe(destination);
 
+  let expectedDestination = destination;
   if (host) {
     expect(searchParams.get('host')).toBe(host);
+    if (addHostToExitIframePath) {
+      expectedDestination = destination.concat(`&host=${host}`);
+    }
   }
+  expect(searchParams.get('exitIframe')).toBe(expectedDestination);
 }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
@@ -131,9 +131,9 @@ describe('Cancel billing', () => {
     );
 
     // THEN
-    const shopSession =
+    const shopSessions =
       await config.sessionStorage.findSessionsByShop(TEST_SHOP);
-    expect(shopSession).toStrictEqual([]);
+    expect(shopSessions).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/cancel.test.ts
@@ -100,7 +100,8 @@ describe('Cancel billing', () => {
 
   it('redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
+    const config = testConfig();
+    const shopify = shopifyApp({...config, billing: BILLING_CONFIG});
     await setUpValidSession(shopify.sessionStorage);
 
     const {token} = getJwt();
@@ -130,6 +131,9 @@ describe('Cancel billing', () => {
     );
 
     // THEN
+    const shopSession =
+      await config.sessionStorage.findSessionsByShop(TEST_SHOP);
+    expect(shopSession).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/check.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/check.test.ts
@@ -125,9 +125,9 @@ describe('Billing check', () => {
     );
 
     // THEN
-    const shopSession =
+    const shopSessions =
       await config.sessionStorage.findSessionsByShop(TEST_SHOP);
-    expect(shopSession).toStrictEqual([]);
+    expect(shopSessions).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/check.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/check.test.ts
@@ -125,6 +125,9 @@ describe('Billing check', () => {
     );
 
     // THEN
+    const shopSession =
+      await config.sessionStorage.findSessionsByShop(TEST_SHOP);
+    expect(shopSession).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
@@ -167,7 +167,8 @@ describe('Billing request', () => {
 
   it('redirects to exit-iframe with authentication using app bridge when embedded and Shopify invalidated the session', async () => {
     // GIVEN
-    const shopify = shopifyApp(testConfig({billing: BILLING_CONFIG}));
+    const config = testConfig();
+    const shopify = shopifyApp({...config, billing: BILLING_CONFIG});
     await setUpValidSession(shopify.sessionStorage);
 
     await mockExternalRequest({
@@ -192,6 +193,9 @@ describe('Billing request', () => {
     );
 
     // THEN
+    const shopSession =
+      await config.sessionStorage.findSessionsByShop(TEST_SHOP);
+    expect(shopSession).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
@@ -95,6 +95,7 @@ describe('Billing request', () => {
     // THEN
     expectExitIframeRedirect(response, {
       destination: responses.CONFIRMATION_URL,
+      addHostToExitIframePath: false,
     });
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/request.test.ts
@@ -193,9 +193,9 @@ describe('Billing request', () => {
     );
 
     // THEN
-    const shopSession =
+    const shopSessions =
       await config.sessionStorage.findSessionsByShop(TEST_SHOP);
-    expect(shopSession).toStrictEqual([]);
+    expect(shopSessions).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/require.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/require.test.ts
@@ -178,6 +178,9 @@ describe('Billing require', () => {
     );
 
     // THEN
+    const shopSession =
+      await config.sessionStorage.findSessionsByShop(TEST_SHOP);
+    expect(shopSession).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/require.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/require.test.ts
@@ -178,9 +178,9 @@ describe('Billing require', () => {
     );
 
     // THEN
-    const shopSession =
+    const shopSessions =
       await config.sessionStorage.findSessionsByShop(TEST_SHOP);
-    expect(shopSession).toStrictEqual([]);
+    expect(shopSessions).toStrictEqual([]);
     expectExitIframeRedirect(response);
   });
 

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
@@ -11,7 +11,7 @@ export function cancelBillingFactory(
   session: Session,
 ) {
   return async function cancelBilling(options: CancelBillingOptions) {
-    const {api, logger} = params;
+    const {api, logger, config} = params;
 
     logger.debug('Cancelling billing', {shop: session.shop, ...options});
 
@@ -27,7 +27,9 @@ export function cancelBillingFactory(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        throw await redirectToAuthPage(params, request, session.shop);
+        const shop = session.shop;
+        config.sessionStorage.deleteSession(session.id);
+        throw await redirectToAuthPage(params, request, shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
@@ -27,9 +27,8 @@ export function cancelBillingFactory(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        const shop = session.shop;
         config.sessionStorage.deleteSession(session.id);
-        throw await redirectToAuthPage(params, request, shop);
+        throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/cancel.ts
@@ -27,7 +27,7 @@ export function cancelBillingFactory(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        config.sessionStorage.deleteSession(session.id);
+        await config.sessionStorage.deleteSession(session.id);
         throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
@@ -12,7 +12,7 @@ export function checkBillingFactory<Config extends AppConfigArg>(
   session: Session,
 ) {
   return async function checkBilling(options: CheckBillingOptions<Config>) {
-    const {api, logger} = params;
+    const {api, logger, config} = params;
 
     logger.debug('Checking billing plans', {shop: session.shop, ...options});
 
@@ -28,6 +28,7 @@ export function checkBillingFactory<Config extends AppConfigArg>(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
+        config.sessionStorage.deleteSession(session.id);
         throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
@@ -28,7 +28,7 @@ export function checkBillingFactory<Config extends AppConfigArg>(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        config.sessionStorage.deleteSession(session.id);
+        await config.sessionStorage.deleteSession(session.id);
         throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
@@ -46,7 +46,7 @@ export function requestBillingFactory<Config extends AppConfigArg>(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        config.sessionStorage.deleteSession(session.id);
+        await config.sessionStorage.deleteSession(session.id);
         throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
@@ -46,9 +46,8 @@ export function requestBillingFactory<Config extends AppConfigArg>(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        const shop = session.shop;
         config.sessionStorage.deleteSession(session.id);
-        throw await redirectToAuthPage(params, request, shop);
+        throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/request.ts
@@ -22,7 +22,7 @@ export function requestBillingFactory<Config extends AppConfigArg>(
     returnUrl,
     ...overrides
   }: RequestBillingOptions<Config>): Promise<never> {
-    const {api, logger} = params;
+    const {api, logger, config} = params;
 
     logger.info('Requesting billing', {
       shop: session.shop,
@@ -46,7 +46,9 @@ export function requestBillingFactory<Config extends AppConfigArg>(
         logger.debug('API token was invalid, redirecting to OAuth', {
           shop: session.shop,
         });
-        throw await redirectToAuthPage(params, request, session.shop);
+        const shop = session.shop;
+        config.sessionStorage.deleteSession(session.id);
+        throw await redirectToAuthPage(params, request, shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
@@ -37,7 +37,7 @@ export function requireBillingFactory<Config extends AppConfigArg>(
     } catch (error) {
       if (error instanceof HttpResponseError && error.response.code === 401) {
         logger.debug('API token was invalid, redirecting to OAuth', logContext);
-        config.sessionStorage.deleteSession(session.id);
+        await config.sessionStorage.deleteSession(session.id);
         throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
@@ -15,7 +15,7 @@ export function requireBillingFactory<Config extends AppConfigArg>(
   request: Request,
   session: Session,
 ) {
-  const {api, logger} = params;
+  const {api, logger, config} = params;
 
   return async function requireBilling(options: RequireBillingOptions<Config>) {
     const logContext = {
@@ -37,7 +37,9 @@ export function requireBillingFactory<Config extends AppConfigArg>(
     } catch (error) {
       if (error instanceof HttpResponseError && error.response.code === 401) {
         logger.debug('API token was invalid, redirecting to OAuth', logContext);
-        throw await redirectToAuthPage(params, request, session.shop);
+        const shop = session.shop;
+        config.sessionStorage.deleteSession(session.id);
+        throw await redirectToAuthPage(params, request, shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/billing/require.ts
@@ -37,9 +37,8 @@ export function requireBillingFactory<Config extends AppConfigArg>(
     } catch (error) {
       if (error instanceof HttpResponseError && error.response.code === 401) {
         logger.debug('API token was invalid, redirecting to OAuth', logContext);
-        const shop = session.shop;
         config.sessionStorage.deleteSession(session.id);
-        throw await redirectToAuthPage(params, request, shop);
+        throw await redirectToAuthPage(params, request, session.shop);
       } else {
         throw error;
       }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-with-exitiframe.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-with-exitiframe.ts
@@ -15,15 +15,14 @@ export function redirectWithExitIframe(
   const host = api.utils.sanitizeHost(queryParams.get('host')!);
 
   queryParams.set('shop', shop);
-  queryParams.set('exitIframe', `${config.auth.path}?shop=${shop}`);
+
+  let destination = `${config.auth.path}?shop=${shop}`;
 
   if (host) {
     queryParams.set('host', host);
-    queryParams.set(
-      'exitIframe',
-      `${config.auth.path}?shop=${shop}&host=${host}`,
-    );
+    destination = `${destination}&host=${host}`;
   }
+  queryParams.set('exitIframe', destination);
 
   throw redirect(`${config.auth.exitIframePath}?${queryParams.toString()}`);
 }

--- a/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-with-exitiframe.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/helpers/redirect-with-exitiframe.ts
@@ -11,6 +11,7 @@ export function redirectWithExitIframe(
   const url = new URL(request.url);
 
   const queryParams = url.searchParams;
+
   const host = api.utils.sanitizeHost(queryParams.get('host')!);
 
   queryParams.set('shop', shop);
@@ -18,6 +19,10 @@ export function redirectWithExitIframe(
 
   if (host) {
     queryParams.set('host', host);
+    queryParams.set(
+      'exitIframe',
+      `${config.auth.path}?shop=${shop}&host=${host}`,
+    );
   }
 
   throw redirect(`${config.auth.exitIframePath}?${queryParams.toString()}`);


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes: 
- https://github.com/Shopify/develop-app-access/issues/233

Steps to reproduce
1. Set up your app to [require billing](https://shopify.dev/docs/api/shopify-app-remix/v2/apis/billing#example-require)
2. Install your app on the store
3. Stop the server THEN uninstall the app 
4. Restart the server 
5. Reinstall the app. Now it redirects to the /auth/login page instead of directing you to accept billing, and are unable to reinstall

Alternatively, 
1. Set up your app to [require billing](https://shopify.dev/docs/api/shopify-app-remix/v2/apis/billing#example-require)
2. Install your app on the store
3. Invalidate online token for shop by setting the "accessToken" string in DB to be something else
4. Go into the app again
5. Now it redirects to the /auth/login page instead of directing you to accept billing

### WHAT is this pull request doing?
- Destroy the invalidated session before continuing to auth.
- Add `host` to exitIframe redirect path, it’s a part of the url param but not in the exitIframe path, causing auth to not work..

## Type of change
- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Tophatting
#### Behaviour before
https://screenshot.click/07-36-ovbv5-92abr.mp4

#### Behaviour after the fix
https://screenshot.click/13-14-u6ui0-akquk.mp4

## Checklist
- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
