### PR TITLE
Add `cause` when throwing `MissingSessionTableError`

### DIFF
--- a/.changeset/shaggy-schools-hammer.md
+++ b/.changeset/shaggy-schools-hammer.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-session-storage-prisma": patch
+---
+
+Add error cause when throwing MissingSessionTableError

--- a/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
+++ b/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
@@ -33,7 +33,7 @@ describe('PrismaSessionStorage', () => {
   );
 });
 
-describe('PrismaSessionStoragewhen with no database set up', () => {
+describe('PrismaSessionStorage when with no database set up', () => {
   beforeAll(async () => {
     clearTestDatabase();
   });
@@ -49,6 +49,11 @@ describe('PrismaSessionStoragewhen with no database set up', () => {
       expect(true).toBe(false);
     } catch (error) {
       expect(error).toBeInstanceOf(MissingSessionTableError);
+
+      const {cause} = error;
+      expect(cause.message).toContain(
+        'The table `main.Session` does not exist in the current database.',
+      );
     }
   });
 });

--- a/packages/shopify-app-session-storage-prisma/src/prisma.ts
+++ b/packages/shopify-app-session-storage-prisma/src/prisma.ts
@@ -25,9 +25,10 @@ export class PrismaSessionStorage<T extends PrismaClient>
     }
     this.ready = this.getSessionTable()
       .count()
-      .catch(() => {
+      .catch((cause) => {
         throw new MissingSessionTableError(
           `Prisma ${this.tableName} table does not exist. This could happen for a few reasons, see https://github.com/Shopify/shopify-app-js/tree/main/packages/shopify-app-session-storage-prisma#troubleshooting for more information`,
+          {cause},
         );
       });
   }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,6 +31,7 @@
       "es2018",
       "es2019",
       "es2020",
+      "es2022",
       "esnext.asynciterable"
     ],
     "baseUrl": ".",


### PR DESCRIPTION
### WHY are these changes introduced?

Our app had an issue over the weekend where it could no longer see the `Session` table – the database itself was unaffected, so this seems to be a connection issue between the app and database.

We saw a lot of `Prisma session table does not exist` errors during the incident.

We believe the issue was caused by the container reaching its memory usage limit, however, it would be really useful to see the upstream cause of the `MissingSessionTableError`.

### WHAT is this pull request doing?

1. Adds the caught error as the `cause` for the thrown `MissingSessionTableError`
2. Adds `es2020` to the TypeScript `lib` options

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
