### PR TITLE
Update AppConfig type to readonly

### DIFF
--- a/.changeset/mighty-bikes-sneeze.md
+++ b/.changeset/mighty-bikes-sneeze.md
@@ -1,0 +1,6 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Update AppConfig type to Readonly. The config should not be modified after it is created.
+

--- a/packages/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/shopify-app-remix/src/server/shopify-app.ts
@@ -61,7 +61,7 @@ export function shopifyApp<
   Resources extends ShopifyRestResources,
   Storage extends SessionStorage,
   Future extends FutureFlagOptions = Config['future'],
->(appConfig: Config): ShopifyApp<Config> {
+>(appConfig: Readonly<Config>): ShopifyApp<Config> {
   const api = deriveApi(appConfig);
   const config = deriveConfig<Storage>(appConfig, api.config);
   const logger = overrideLogger(api.logger);


### PR DESCRIPTION
### WHY are these changes introduced?
* This is type not being readonly is causing typescript error with future flags

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
