### PR TITLE
fix: check for valid content-length before calling `request.formData()` for `HEAD` requests

### DIFF
--- a/.changeset/empty-rockets-search.md
+++ b/.changeset/empty-rockets-search.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Check for non-empty body before calling `request.formData()` in login handler

--- a/packages/shopify-app-remix/src/server/authenticate/login/__tests__/login.test.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/login/__tests__/login.test.ts
@@ -11,9 +11,12 @@ describe('login helper', () => {
   it('returns an empty errors object if GET and no shop param', async () => {
     // GIVEN
     const shopify = shopifyApp(testConfig());
+    const headers = new Headers();
+    headers.set('Content-Length', '0');
     const requestMock = {
       url: `${APP_URL}/auth/login`,
       method: 'GET',
+      headers,
     };
 
     // WHEN
@@ -27,10 +30,13 @@ describe('login helper', () => {
     // GIVEN
     const formDataMock = jest.fn();
     const shopify = shopifyApp(testConfig());
+    const headers = new Headers();
+    headers.set('Content-Length', '0');
     const requestMock = {
       url: `${APP_URL}/auth/login?shop=${TEST_SHOP}`,
       method: 'GET',
       formData: formDataMock,
+      headers,
     };
 
     // WHEN
@@ -40,13 +46,37 @@ describe('login helper', () => {
     expect(formDataMock).not.toHaveBeenCalled();
   });
 
+  it('does not access formData if method is GET with an empty body and no shop parameter (HEAD)', async () => {
+    // GIVEN
+    const formDataMock = jest.fn();
+    const shopify = shopifyApp(testConfig());
+    const headers = new Headers();
+    headers.set('Content-Length', '0');
+    const requestMock = {
+      url: `${APP_URL}/auth/login`,
+      // HEAD requests will be passed as GET requests to the loader function which calls the login function
+      method: 'GET',
+      formData: formDataMock,
+      headers,
+    };
+
+    // WHEN
+    const errors = await shopify.login(requestMock as any as Request);
+
+    // THEN
+    expect(errors).toEqual({});
+  });
+
   it('returns an error if the shop parameter is missing', async () => {
     // GIVEN
     const shopify = shopifyApp(testConfig());
+    const headers = new Headers();
+    headers.set('Content-Length', '0');
     const requestMock = {
       url: `${APP_URL}/auth/login`,
       formData: async () => ({get: () => null}),
       method: 'POST',
+      headers,
     };
 
     // WHEN
@@ -64,12 +94,15 @@ describe('login helper', () => {
     async ({urlShop, formShop, method}) => {
       // GIVEN
       const shopify = shopifyApp(testConfig());
+      const headers = new Headers();
+      headers.set('Content-Length', '0');
       const requestMock = {
         url: urlShop
           ? `${APP_URL}/auth/login?shop=${urlShop}`
           : `${APP_URL}/auth/login`,
         formData: async () => ({get: () => formShop}),
         method,
+        headers,
       };
 
       // WHEN
@@ -102,12 +135,16 @@ describe('login helper', () => {
           isEmbeddedApp: testCaseConfig.isEmbeddedApp,
         });
         const shopify = shopifyApp(config);
+        const headers = new Headers();
+        headers.set('Content-Length', method === 'POST' ? '123' : '0');
         const requestMock = {
           url: urlShop
             ? `${APP_URL}/auth/login?shop=${urlShop}`
             : `${APP_URL}/auth/login`,
-          formData: async () => ({get: () => formShop}),
+          formData:
+            method === 'POST' ? async () => ({get: () => formShop}) : undefined,
           method,
+          headers,
         };
 
         // WHEN
@@ -133,10 +170,13 @@ describe('login helper', () => {
         isEmbeddedApp: testCaseConfig.isEmbeddedApp,
       });
       const shopify = shopifyApp(config);
+      const headers = new Headers();
+      headers.set('Content-Length', '123');
       const requestMock = {
         url: `${APP_URL}/auth/login`,
         formData: async () => ({get: () => `https://${TEST_SHOP}/`}),
         method: 'POST',
+        headers,
       };
 
       // WHEN

--- a/packages/shopify-app-remix/src/server/authenticate/login/login.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/login/login.ts
@@ -8,8 +8,14 @@ export function loginFactory(params: BasicParams) {
   return async function login(request: Request): Promise<LoginError | never> {
     const url = new URL(request.url);
     const shopParam = url.searchParams.get('shop');
+    const contentLength = parseInt(
+      request.headers.get('Content-Length') ?? '0',
+      10,
+    );
 
-    if (request.method === 'GET' && !shopParam) {
+    // A HEAD request will be passed as a GET request, to avoid calling `request.formData()` on an empty body in a HEAD request
+    // we check if the `Content-Length` header is truthy so it's safe to call `request.formData()`
+    if (request.method === 'GET' && !shopParam && !contentLength) {
       return {};
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Currently the login handler will call `request.formData()` if no `?shop=xxx` param was found and it's a `GET` request. In Remix `HEAD` requests will be handled as `GET` requests, so if no `shop` param was provided in a `HEAD` request, e.g. by just visiting `/auth/login` (using the shopify remix template), it would then call the `request.formData()` function on an empty body and throw a `TypeError: Could not parse content as FormData`.


### WHAT is this pull request doing?

The PR enhances the current `if (request.method === 'GET' && !shopParam)` check to also check if the `Content-Length` header is truthy/above zero. If so, it should be safe to call `request.formData()`. It does not impact any other request types such as `POST`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
