### PR TITLE
Catch Prisma P2002 error

### DIFF
--- a/.changeset/famous-stingrays-burn.md
+++ b/.changeset/famous-stingrays-burn.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-session-storage-prisma": patch
+---
+
+Handle Prisma error P2002 during upsert

--- a/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
+++ b/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
@@ -84,6 +84,7 @@ describe('Prisma throws P2002 on upsert', () => {
     jest.spyOn(prisma.session, 'upsert').mockImplementation(() => {
       throw new Prisma.PrismaClientKnownRequestError('error message', {
         code: 'P2002',
+        clientVersion: '0',
       });
     });
   });
@@ -100,6 +101,29 @@ describe('Prisma throws P2002 on upsert', () => {
   it('Returns true after handling Prisma P2002 errors', async () => {
     const result = await storage.storeSession(session);
     expect(result).toBe(true);
+  });
+
+  it('Throws other errors not P2002', async () => {
+    const expectedError = new Prisma.PrismaClientKnownRequestError(
+      'error message',
+      {
+        code: 'P2003',
+        clientVersion: '0',
+      },
+    );
+    jest.clearAllMocks();
+    jest.spyOn(prisma.session, 'upsert').mockImplementation(() => {
+      throw expectedError;
+    });
+
+    try {
+      await storage.storeSession(session);
+
+      // This should never be reached
+      expect(true).toBe(false);
+    } catch (actualError) {
+      expect(actualError).toStrictEqual(expectedError);
+    }
   });
 });
 

--- a/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
+++ b/packages/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
@@ -1,8 +1,9 @@
 import fs from 'fs';
 import {execSync} from 'child_process';
 
+import {Session} from '@shopify/shopify-api';
 import {batteryOfTests} from '@shopify/shopify-app-session-storage-test-utils';
-import {PrismaClient} from '@prisma/client';
+import {Prisma, PrismaClient} from '@prisma/client';
 
 import {MissingSessionTableError, PrismaSessionStorage} from '../prisma';
 
@@ -55,6 +56,50 @@ describe('PrismaSessionStorage when with no database set up', () => {
         'The table `main.Session` does not exist in the current database.',
       );
     }
+  });
+});
+
+describe('Prisma throws P2002 on upsert', () => {
+  let prisma: PrismaClient;
+  let storage: PrismaSessionStorage<PrismaClient>;
+  let session: Session;
+
+  beforeAll(async () => {
+    // Reset the database prior to the tests
+    clearTestDatabase();
+
+    execSync('npx prisma migrate dev --name init --preview-feature');
+
+    prisma = new PrismaClient();
+    storage = new PrismaSessionStorage<PrismaClient>(prisma);
+    session = new Session({
+      id: 'session-123',
+      shop: 'shop',
+      state: 'state',
+      isOnline: false,
+      accessToken: '123',
+      scope: '',
+    });
+
+    jest.spyOn(prisma.session, 'upsert').mockImplementation(() => {
+      throw new Prisma.PrismaClientKnownRequestError('error message', {
+        code: 'P2002',
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await prisma.session.deleteMany();
+    jest.clearAllMocks();
+  });
+
+  it('handles Prisma P2002 errors', async () => {
+    await expect(storage.storeSession(session)).resolves.not.toThrow();
+  });
+
+  it('Returns true after handling Prisma P2002 errors', async () => {
+    const result = await storage.storeSession(session);
+    expect(result).toBe(true);
   });
 });
 

--- a/packages/shopify-app-session-storage-prisma/src/prisma.ts
+++ b/packages/shopify-app-session-storage-prisma/src/prisma.ts
@@ -52,14 +52,14 @@ export class PrismaSessionStorage<T extends PrismaClient>
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === UNIQUE_KEY_CONSTRAINT_ERROR_CODE
       ) {
+        console.log(
+          'Caught PrismaClientKnownRequestError P2002 - Unique Key Key Constraint, retrying upsert.',
+        );
         await this.getSessionTable().upsert({
           where: {id: session.id},
           update: data,
           create: data,
         });
-        console.log(
-          'Caught PrismaClientKnownRequestError P2002 - Unique Key Key Constraint, retrying upsert.',
-        );
         return true;
       }
       throw error;


### PR DESCRIPTION
### WHY are these changes introduced?
Fixes - https://github.com/Shopify/shopify-app-template-remix/issues/536

### WHAT is this pull request doing?
Catch and handle Prisma P2002 error but throw other errors. 

This is the[ suggested method from Prisma](https://www.prisma.io/docs/orm/reference/prisma-client-reference#unique-key-constraint-errors-on-upserts), however, in this case, we won't re-try since the data _should_ be identical. 

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)

## Tophatting:
1. Manually modified the local Remix package to call `storeSesssion` twice concurrently during token exchange
![06-18-xvmrx-vfr8r](https://github.com/Shopify/shopify-app-js/assets/102243935/6031a519-f7f0-4b08-8ac9-c201f328b9c5)

2. See that the operation fails before the fix
![error2](https://github.com/Shopify/shopify-app-js/assets/102243935/fd2d47f3-e4da-4b4d-8ce7-cc1f2fc69a6e)

3. See that the operation succeeds, and the error is caught after the fix from a local Prisma package
![caught](https://github.com/Shopify/shopify-app-js/assets/102243935/3efb32a5-4138-4006-afac-8f7735f86419)



