### PR TITLE
Add optional `poolConfig` to Postgres session options

### DIFF
--- a/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgres-connection.ts
@@ -5,12 +5,21 @@ export class PostgresConnection implements RdbmsConnection {
   sessionStorageIdentifier: string;
   private ready: Promise<void>;
   private pool: pg.Pool;
+  /**
+   * Additional user-provided configuration for the PostgreSQL pool.
+   */
+  private poolConfig: pg.PoolConfig | undefined;
   private dbUrl: URL;
 
-  constructor(dbUrl: string, sessionStorageIdentifier: string) {
+  constructor(
+    dbUrl: string,
+    sessionStorageIdentifier: string,
+    poolConfig: pg.PoolConfig | undefined,
+  ) {
     this.dbUrl = new URL(dbUrl);
     this.ready = this.init();
     this.sessionStorageIdentifier = sessionStorageIdentifier;
+    this.poolConfig = poolConfig;
   }
 
   async query(query: string, params: any[] = []): Promise<any[]> {
@@ -84,6 +93,7 @@ export class PostgresConnection implements RdbmsConnection {
 
   private async init(): Promise<void> {
     this.pool = new pg.Pool({
+      ...this.poolConfig,
       host: this.dbUrl.hostname,
       user: decodeURIComponent(this.dbUrl.username),
       password: decodeURIComponent(this.dbUrl.password),

--- a/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
+++ b/packages/shopify-app-session-storage-postgresql/src/postgresql.ts
@@ -3,6 +3,7 @@ import {
   SessionStorage,
   RdbmsSessionStorageOptions,
 } from '@shopify/shopify-app-session-storage';
+import {type PoolConfig} from 'pg';
 
 import {migrationList} from './migrations';
 import {PostgresConnection} from './postgres-connection';
@@ -11,6 +12,13 @@ import {PostgresSessionStorageMigrator} from './postgres-migrator';
 export interface PostgreSQLSessionStorageOptions
   extends RdbmsSessionStorageOptions {
   port: number;
+
+  /**
+   * Optional additional configuration for the PostgreSQL pool.
+   *
+   * For example, use this to provide additional SSL connection options.
+   */
+  poolConfig?: PoolConfig;
 }
 const defaultPostgreSQLSessionStorageOptions: PostgreSQLSessionStorageOptions =
   {
@@ -145,7 +153,11 @@ export class PostgreSQLSessionStorage implements SessionStorage {
   }
 
   private async init(dbUrl: string) {
-    this.client = new PostgresConnection(dbUrl, this.options.sessionTableName);
+    this.client = new PostgresConnection(
+      dbUrl,
+      this.options.sessionTableName,
+      this.options.poolConfig,
+    );
     await this.connectClient();
     await this.createTable();
   }


### PR DESCRIPTION
### WHY are these changes introduced?
When using PostgreSQL for sessions, it's not possible to use a host that requires a specific SSL certificate.

For example, DigitalOcean managed databases come with a CA certificate needed for authentication.

The reason you can't use these hosts is because the PostgreSQLSessionStorage constructor has no way to provide SSL options.

### WHAT is this pull request doing?
I added an optional `pg.PoolConfig` option.

## Type of change
- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
