### PR TITLE
Return a bounce response on invalid tokens

### DIFF
--- a/.changeset/famous-ducks-switch.md
+++ b/.changeset/famous-ducks-switch.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-remix": patch
+---
+
+Fixed an issue where full page reloads broke HMR on pages loaded for more than a minute

--- a/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -174,10 +174,7 @@ async function getSessionTokenContext(
   });
 
   if (config.isEmbeddedApp) {
-    const payload = await validateSessionToken(
-      {config, logger, api},
-      sessionToken,
-    );
+    const payload = await validateSessionToken(params, request, sessionToken);
     const dest = new URL(payload.dest);
     const shop = dest.hostname;
 

--- a/packages/shopify-app-remix/src/server/authenticate/helpers/validate-session-token.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/helpers/validate-session-token.ts
@@ -2,15 +2,19 @@ import {JwtPayload} from '@shopify/shopify-api';
 
 import type {BasicParams} from '../../types';
 
+import {respondToInvalidSessionToken} from './respond-to-invalid-session-token';
+
 interface ValidateSessionTokenOptions {
   checkAudience?: boolean;
 }
 
 export async function validateSessionToken(
-  {api, logger}: BasicParams,
+  params: BasicParams,
+  request: Request,
   token: string,
   {checkAudience = true}: ValidateSessionTokenOptions = {},
 ): Promise<JwtPayload> {
+  const {api, logger} = params;
   logger.debug('Validating session token');
 
   try {
@@ -24,9 +28,7 @@ export async function validateSessionToken(
     return payload;
   } catch (error) {
     logger.debug(`Failed to validate session token: ${error.message}`);
-    throw new Response(undefined, {
-      status: 401,
-      statusText: 'Unauthorized',
-    });
+
+    throw respondToInvalidSessionToken({params, request, retryRequest: true});
   }
 }

--- a/packages/shopify-app-remix/src/server/authenticate/public/checkout/authenticate.ts
+++ b/packages/shopify-app-remix/src/server/authenticate/public/checkout/authenticate.ts
@@ -36,9 +36,12 @@ export function authenticateCheckoutFactory(
     }
 
     return {
-      sessionToken: await validateSessionToken(params, sessionTokenHeader, {
-        checkAudience: false,
-      }),
+      sessionToken: await validateSessionToken(
+        params,
+        request,
+        sessionTokenHeader,
+        {checkAudience: false},
+      ),
       cors: ensureCORSHeadersFactory(params, request, corsHeaders),
     };
   };


### PR DESCRIPTION
### WHY are these changes introduced?

Closes https://github.com/Shopify/shopify-app-template-remix/issues/528
Closes https://github.com/Shopify/shopify-app-template-remix/issues/606

There are some scenarios in which Vite's HMR triggers a full page reload in the app (I believe one example is when you edit a page that is _not_ the current one).

If that happened more than 1 minute after the page loaded, the `id_token` for the request would have expired. Since Vite would replay the same request, it would then fail, in which case we simply threw a 401 response back, which causes the page load to blow up.

### WHAT is this pull request doing?

Changing that response so it returns a bounce request to get app bridge to request a new token before the reload instead of returning a 401. That way, the full page reload will use a new token and go through.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change