### PR TITLE
Revamp repository READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Shopify API and app tools for JavaScript
 
-This repository contains packages you can use to interact with Shopify's APIs and create apps using TypeScript / JavaScript.
+This repository contains packages you can use to interact with Shopify's APIs.
+You can use these packages to create clients for those APIs directly, or to create apps using TypeScript / JavaScript.
 
 It is organized as a [monorepo](https://monorepo.tools/), which includes multiple packages that can be used together.
 
@@ -14,7 +15,7 @@ The packages in this repository can be used to extend Shopify in different ways:
 
 ### [API clients](/packages/api-clients)
 
-These packages make it easy to interact with Shopify's APIs if you have the required access tokens.
+These packages make it easy to interact with Shopify's APIs if you have the required [access tokens](https://shopify.dev/docs/apps/auth#types-of-authentication-and-authorization-methods).
 
 | Package                                                                                 | Latest version                                                                                                                                          | Description                                                                                                                          |
 | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |

--- a/packages/api-clients/README.md
+++ b/packages/api-clients/README.md
@@ -1,0 +1,14 @@
+# API clients
+
+These packages provide clients that you can use to make requests to Shopify's APIs, if you already have the right access tokens.
+
+With them, you can quickly get set up to interact with the APIs on any JavaScript runtime that provides an implementation of the `fetch` API.
+
+## Packages
+
+| Package                                                                                | Latest version                                                                                                                                          | Description                                                                                                                          |
+| -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [`@shopify/admin-api-client`](/packages/api-clients/admin-api-client#readme)           | [![Latest badge](https://img.shields.io/npm/v/@shopify/admin-api-client/latest.svg)](https://www.npmjs.com/package/@shopify/admin-api-client)           | Client for the [GraphQL](https://shopify.dev/docs/api/admin-graphql) and [REST](https://shopify.dev/docs/api/admin-rest) Admin APIs. |
+| [`@shopify/storefront-api-client`](/packages/api-clients/storefront-api-client#readme) | [![Latest badge](https://img.shields.io/npm/v/@shopify/storefront-api-client/latest.svg)](https://www.npmjs.com/package/@shopify/storefront-api-client) | Client for the GraphQL [Storefront](https://shopify.dev/docs/api/storefront) API.                                                    |
+| [`@shopify/graphql-client`](/packages/api-clients/graphql-client#readme)               | [![Latest badge](https://img.shields.io/npm/v/@shopify/graphql-client/latest.svg)](https://www.npmjs.com/package/@shopify/graphql-client)               | Generic GraphQL API client.                                                                                                          |
+| [`@shopify/api-codegen-preset`](/packages/api-clients/api-codegen-preset#readme)       | [![Latest badge](https://img.shields.io/npm/v/@shopify/api-codegen-preset/latest.svg)](https://www.npmjs.com/package/@shopify/api-codegen-preset)       | [Codegen](https://the-guild.dev/graphql/codegen) preset for Shopify APIs. Automatically integrates with the clients above.           |

--- a/packages/apps/README.md
+++ b/packages/apps/README.md
@@ -1,0 +1,17 @@
+# Apps and middlewares
+
+These packages provide tools for creating Shopify apps, either using pure TypeScript / JavaScript, or using a specific framework, like Remix or Express.
+
+With them, you can create apps for the Shopify App Store or custom apps for merchants, get access tokens through OAuth, make requests to Shopify APIs, subscribe to webhooks, and more.
+
+## Packages
+
+| Package                                                                     | Latest version                                                                                                                                      | Description                                                                            |
+| --------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
+| [`@shopify/shopify-api`](/packages/apps/shopify-api#readme)                 | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-api/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-api)                 | Framework and runtime agnostic library for Shopify OAuth, APIs, webhooks, and more.    |
+| [`@shopify/shopify-app-remix`](/packages/apps/shopify-app-remix#readme)     | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-app-remix/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-app-remix)     | Implementation of `@shopify/shopify-api` to make it easy to create apps using Remix.   |
+| [`@shopify/shopify-app-express`](/packages/apps/shopify-app-express#readme) | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-app-express/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-app-express) | Implementation of `@shopify/shopify-api` to make it easy to create apps using Express. |
+
+### Session storage packages
+
+See the implementations of [`SessionStorage`](/packages/apps/session-storage) we provide.

--- a/packages/apps/session-storage/README.md
+++ b/packages/apps/session-storage/README.md
@@ -1,41 +1,10 @@
-# Shopify API and app tools for JavaScript
+# Session storage
 
-This repository contains packages you can use to interact with Shopify's APIs and create apps using TypeScript / JavaScript.
+When creating Shopify apps, you'll generate access tokens for the API to create new experiences for Shopify merchants, and you'll need to store those tokens to make your app as performant as possible.
 
-It is organized as a [monorepo](https://monorepo.tools/), which includes multiple packages that can be used together.
+These packages provide several database-specific implementations of the `SessionStorage` interface, to make it easier to set up apps with your preferred stack.
 
 ## Packages
-
-The packages in this repository can be used to extend Shopify in different ways:
-
-- [API clients](#api-clients)
-- [Apps and middlewares](#apps-and-middlewares)
-- [Session storage](#session-storage)
-
-### [API clients](/packages/api-clients)
-
-These packages make it easy to interact with Shopify's APIs if you have the required access tokens.
-
-| Package                                                                                 | Latest version                                                                                                                                          | Description                                                                                                                          |
-| --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [`@shopify/admin-api-client`](/packages/api-clients/admin-api-client/#readme)           | [![Latest badge](https://img.shields.io/npm/v/@shopify/admin-api-client/latest.svg)](https://www.npmjs.com/package/@shopify/admin-api-client)           | Client for the [GraphQL](https://shopify.dev/docs/api/admin-graphql) and [REST](https://shopify.dev/docs/api/admin-rest) Admin APIs. |
-| [`@shopify/storefront-api-client`](/packages/api-clients/storefront-api-client/#readme) | [![Latest badge](https://img.shields.io/npm/v/@shopify/storefront-api-client/latest.svg)](https://www.npmjs.com/package/@shopify/storefront-api-client) | Client for the GraphQL [Storefront](https://shopify.dev/docs/api/storefront) API.                                                    |
-| [`@shopify/graphql-client`](/packages/api-clients/graphql-client/#readme)               | [![Latest badge](https://img.shields.io/npm/v/@shopify/graphql-client/latest.svg)](https://www.npmjs.com/package/@shopify/graphql-client)               | Generic GraphQL API client.                                                                                                          |
-| [`@shopify/api-codegen-preset`](/packages/api-clients/api-codegen-preset/#readme)       | [![Latest badge](https://img.shields.io/npm/v/@shopify/api-codegen-preset/latest.svg)](https://www.npmjs.com/package/@shopify/api-codegen-preset)       | [Codegen](https://the-guild.dev/graphql/codegen) preset for Shopify APIs. Automatically integrates with the clients above.           |
-
-### [Apps and middlewares](/packages/apps)
-
-These packages make it easy to create Shopify apps with TS / JS using different tech stacks.
-
-| Package                                                                             | Latest version                                                                                                                                      | Description                                                                            |
-| ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`@shopify/shopify-api`](/packages/api-clients/shopify-api/#readme)                 | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-api/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-api)                 | Framework and runtime agnostic library for Shopify OAuth, APIs, webhooks, and more.    |
-| [`@shopify/shopify-app-remix`](/packages/api-clients/shopify-app-remix/#readme)     | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-app-remix/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-app-remix)     | Implementation of `@shopify/shopify-api` to make it easy to create apps using Remix.   |
-| [`@shopify/shopify-app-express`](/packages/api-clients/shopify-app-express/#readme) | [![Latest badge](https://img.shields.io/npm/v/@shopify/shopify-app-express/latest.svg)](https://www.npmjs.com/package/@shopify/shopify-app-express) | Implementation of `@shopify/shopify-api` to make it easy to create apps using Express. |
-
-### [Session storage](/packages/apps/session-storage)
-
-These packages provide database-specific implementations to manage `@shopify/shopify-api` sessions.
 
 | Package                                                                                                                           | Latest version                                                                                                                                                                            | Description                                                                           |
 | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Following the changes to update the build pipeline and merge the repos, our READMEs were no longer very practical or useful. This PR goes reworks the READMEs so that they're more useful in a repo with multiple packages.