### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 *       @shopify/client-libraries-app-templates
+package.json
+package-lock.json

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 *       @shopify/client-libraries-app-templates
 package.json
-package-lock.json
+yarn.lock


### PR DESCRIPTION
In order to avoid getting assigned to Dependabot PRs an imperfect but practical solution is to assign the ownership of package.json and package-lock.json to none.