### PR TITLE
Require ids in `find` methods

### DIFF
--- a/.changeset/short-pillows-own.md
+++ b/.changeset/short-pillows-own.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Fixing REST resource `find()` methods to fail when missing all ids, instead of defaulting to the same behaviour as `all()`.

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/resources/base.test.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/resources/base.test.ts
@@ -4,7 +4,7 @@ import {
 } from '../../../../__tests__/test-helper';
 import {testConfig} from '../../../../__tests__/test-config';
 import {Session} from '../../../../session/session';
-import {HttpResponseError} from '../../../../error';
+import {HttpResponseError, RestResourceError} from '../../../../error';
 import {PageInfo} from '../../../types';
 import {ApiVersion, LATEST_API_VERSION} from '../../../../types';
 import {shopifyApi} from '../../../../index';
@@ -43,6 +43,14 @@ describe('Base REST resource', () => {
       path: `${prefix}/fake_resources/1.json`,
       headers,
     }).toMatchMadeHttpRequest();
+  });
+
+  it.each([NaN, null, undefined])('throws an error if id is %s', async (id) => {
+    const shopify = shopifyApi(testConfig({restResources}));
+
+    expect(async () =>
+      shopify.rest.FakeResource.find({id: id as number, session}),
+    ).rejects.toThrow(RestResourceError);
   });
 
   it('finds resource with param', async () => {

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/resources/fake-resource.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/resources/fake-resource.ts
@@ -103,6 +103,7 @@ export class FakeResource extends Base {
       session,
       urlIds: {id, other_resource_id},
       params: {param, ...otherArgs},
+      requireIds: true,
     });
     return result.data ? result.data[0] : null;
   }

--- a/packages/apps/shopify-api/rest/admin/2022-10/android_pay_key.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/android_pay_key.ts
@@ -41,6 +41,7 @@ export class AndroidPayKey extends Base {
   ): Promise<AndroidPayKey | null> {
     const result = await this.baseFind<AndroidPayKey>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/application_credit.ts
@@ -48,6 +48,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_order.ts
@@ -86,6 +86,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2022-10/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/application_credit.ts
@@ -48,6 +48,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/customer_saved_search.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/customer_saved_search.ts
@@ -67,6 +67,7 @@ export class CustomerSavedSearch extends Base {
   ): Promise<CustomerSavedSearch | null> {
     const result = await this.baseFind<CustomerSavedSearch>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_order.ts
@@ -87,6 +87,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-01/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/application_credit.ts
@@ -48,6 +48,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/customer_saved_search.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/customer_saved_search.ts
@@ -67,6 +67,7 @@ export class CustomerSavedSearch extends Base {
   ): Promise<CustomerSavedSearch | null> {
     const result = await this.baseFind<CustomerSavedSearch>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_order.ts
@@ -87,6 +87,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-04/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/application_credit.ts
@@ -47,6 +47,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/customer_saved_search.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/customer_saved_search.ts
@@ -67,6 +67,7 @@ export class CustomerSavedSearch extends Base {
   ): Promise<CustomerSavedSearch | null> {
     const result = await this.baseFind<CustomerSavedSearch>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_order.ts
@@ -87,6 +87,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-07/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/application_credit.ts
@@ -47,6 +47,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_order.ts
@@ -87,6 +87,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2023-10/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/application_credit.ts
@@ -47,6 +47,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_order.ts
@@ -93,6 +93,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"include_financial_summaries": include_financial_summaries, "include_order_reference_fields": include_order_reference_fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/report.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/report.ts
@@ -55,6 +55,7 @@ export class Report extends Base {
   ): Promise<Report | null> {
     const result = await this.baseFind<Report>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-01/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/apple_pay_certificate.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/apple_pay_certificate.ts
@@ -48,6 +48,7 @@ export class ApplePayCertificate extends Base {
   ): Promise<ApplePayCertificate | null> {
     const result = await this.baseFind<ApplePayCertificate>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/application_charge.ts
@@ -49,6 +49,7 @@ export class ApplicationCharge extends Base {
   ): Promise<ApplicationCharge | null> {
     const result = await this.baseFind<ApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/application_credit.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/application_credit.ts
@@ -47,6 +47,7 @@ export class ApplicationCredit extends Base {
   ): Promise<ApplicationCredit | null> {
     const result = await this.baseFind<ApplicationCredit>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/article.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/article.ts
@@ -97,6 +97,7 @@ export class Article extends Base {
   ): Promise<Article | null> {
     const result = await this.baseFind<Article>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "blog_id": blog_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/blog.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/blog.ts
@@ -62,6 +62,7 @@ export class Blog extends Base {
   ): Promise<Blog | null> {
     const result = await this.baseFind<Blog>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/carrier_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/carrier_service.ts
@@ -47,6 +47,7 @@ export class CarrierService extends Base {
   ): Promise<CarrierService | null> {
     const result = await this.baseFind<CarrierService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/checkout.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/checkout.ts
@@ -58,6 +58,7 @@ export class Checkout extends Base {
   ): Promise<Checkout | null> {
     const result = await this.baseFind<Checkout>({
       session: session,
+      requireIds: true,
       urlIds: {"token": token},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/collect.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/collect.ts
@@ -56,6 +56,7 @@ export class Collect extends Base {
   ): Promise<Collect | null> {
     const result = await this.baseFind<Collect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/collection.ts
@@ -48,6 +48,7 @@ export class Collection extends Base {
   ): Promise<Collection | null> {
     const result = await this.baseFind<Collection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/collection_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/collection_listing.ts
@@ -59,6 +59,7 @@ export class CollectionListing extends Base {
   ): Promise<CollectionListing | null> {
     const result = await this.baseFind<CollectionListing>({
       session: session,
+      requireIds: true,
       urlIds: {"collection_id": collection_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/comment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/comment.ts
@@ -93,6 +93,7 @@ export class Comment extends Base {
   ): Promise<Comment | null> {
     const result = await this.baseFind<Comment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/country.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/country.ts
@@ -60,6 +60,7 @@ export class Country extends Base {
   ): Promise<Country | null> {
     const result = await this.baseFind<Country>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/custom_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/custom_collection.ts
@@ -73,6 +73,7 @@ export class CustomCollection extends Base {
   ): Promise<CustomCollection | null> {
     const result = await this.baseFind<CustomCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/customer.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/customer.ts
@@ -97,6 +97,7 @@ export class Customer extends Base {
   ): Promise<Customer | null> {
     const result = await this.baseFind<Customer>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
@@ -72,6 +72,7 @@ export class CustomerAddress extends Base {
   ): Promise<CustomerAddress | null> {
     const result = await this.baseFind<CustomerAddress>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "customer_id": customer_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/discount_code.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/discount_code.ts
@@ -79,6 +79,7 @@ export class DiscountCode extends Base {
   ): Promise<DiscountCode | null> {
     const result = await this.baseFind<DiscountCode>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "price_rule_id": price_rule_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/dispute.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/dispute.ts
@@ -44,6 +44,7 @@ export class Dispute extends Base {
   ): Promise<Dispute | null> {
     const result = await this.baseFind<Dispute>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/dispute_evidence.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/dispute_evidence.ts
@@ -41,6 +41,7 @@ export class DisputeEvidence extends Base {
   ): Promise<DisputeEvidence | null> {
     const result = await this.baseFind<DisputeEvidence>({
       session: session,
+      requireIds: true,
       urlIds: {"dispute_id": dispute_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/draft_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/draft_order.ts
@@ -81,6 +81,7 @@ export class DraftOrder extends Base {
   ): Promise<DraftOrder | null> {
     const result = await this.baseFind<DraftOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/event.ts
@@ -60,6 +60,7 @@ export class Event extends Base {
   ): Promise<Event | null> {
     const result = await this.baseFind<Event>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/fulfillment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/fulfillment.ts
@@ -77,6 +77,7 @@ export class Fulfillment extends Base {
   ): Promise<Fulfillment | null> {
     const result = await this.baseFind<Fulfillment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_event.ts
@@ -67,6 +67,7 @@ export class FulfillmentEvent extends Base {
   ): Promise<FulfillmentEvent | null> {
     const result = await this.baseFind<FulfillmentEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id, "fulfillment_id": fulfillment_id},
       params: {"event_id": event_id},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_order.ts
@@ -93,6 +93,7 @@ export class FulfillmentOrder extends Base {
   ): Promise<FulfillmentOrder | null> {
     const result = await this.baseFind<FulfillmentOrder>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"include_financial_summaries": include_financial_summaries, "include_order_reference_fields": include_order_reference_fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_service.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/fulfillment_service.ts
@@ -48,6 +48,7 @@ export class FulfillmentService extends Base {
   ): Promise<FulfillmentService | null> {
     const result = await this.baseFind<FulfillmentService>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/gift_card.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/gift_card.ts
@@ -71,6 +71,7 @@ export class GiftCard extends Base {
   ): Promise<GiftCard | null> {
     const result = await this.baseFind<GiftCard>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/gift_card_adjustment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/gift_card_adjustment.ts
@@ -49,6 +49,7 @@ export class GiftCardAdjustment extends Base {
   ): Promise<GiftCardAdjustment | null> {
     const result = await this.baseFind<GiftCardAdjustment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "gift_card_id": gift_card_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/image.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/image.ts
@@ -62,6 +62,7 @@ export class Image extends Base {
   ): Promise<Image | null> {
     const result = await this.baseFind<Image>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "product_id": product_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/inventory_item.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/inventory_item.ts
@@ -43,6 +43,7 @@ export class InventoryItem extends Base {
   ): Promise<InventoryItem | null> {
     const result = await this.baseFind<InventoryItem>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/location.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/location.ts
@@ -51,6 +51,7 @@ export class Location extends Base {
   ): Promise<Location | null> {
     const result = await this.baseFind<Location>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/marketing_event.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/marketing_event.ts
@@ -68,6 +68,7 @@ export class MarketingEvent extends Base {
   ): Promise<MarketingEvent | null> {
     const result = await this.baseFind<MarketingEvent>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/metafield.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/metafield.ts
@@ -181,6 +181,7 @@ export class Metafield extends Base {
   ): Promise<Metafield | null> {
     const result = await this.baseFind<Metafield>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "article_id": article_id, "blog_id": blog_id, "collection_id": collection_id, "customer_id": customer_id, "draft_order_id": draft_order_id, "order_id": order_id, "page_id": page_id, "product_image_id": product_image_id, "product_id": product_id, "variant_id": variant_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/mobile_platform_application.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/mobile_platform_application.ts
@@ -47,6 +47,7 @@ export class MobilePlatformApplication extends Base {
   ): Promise<MobilePlatformApplication | null> {
     const result = await this.baseFind<MobilePlatformApplication>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/order.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/order.ts
@@ -107,6 +107,7 @@ export class Order extends Base {
   ): Promise<Order | null> {
     const result = await this.baseFind<Order>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/order_risk.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/order_risk.ts
@@ -56,6 +56,7 @@ export class OrderRisk extends Base {
   ): Promise<OrderRisk | null> {
     const result = await this.baseFind<OrderRisk>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/page.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/page.ts
@@ -78,6 +78,7 @@ export class Page extends Base {
   ): Promise<Page | null> {
     const result = await this.baseFind<Page>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/payment.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/payment.ts
@@ -56,6 +56,7 @@ export class Payment extends Base {
   ): Promise<Payment | null> {
     const result = await this.baseFind<Payment>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "checkout_id": checkout_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/payment_gateway.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/payment_gateway.ts
@@ -47,6 +47,7 @@ export class PaymentGateway extends Base {
   ): Promise<PaymentGateway | null> {
     const result = await this.baseFind<PaymentGateway>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/payout.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/payout.ts
@@ -46,6 +46,7 @@ export class Payout extends Base {
   ): Promise<Payout | null> {
     const result = await this.baseFind<Payout>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/price_rule.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/price_rule.ts
@@ -63,6 +63,7 @@ export class PriceRule extends Base {
   ): Promise<PriceRule | null> {
     const result = await this.baseFind<PriceRule>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/product.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/product.ts
@@ -88,6 +88,7 @@ export class Product extends Base {
   ): Promise<Product | null> {
     const result = await this.baseFind<Product>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/product_listing.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/product_listing.ts
@@ -69,6 +69,7 @@ export class ProductListing extends Base {
   ): Promise<ProductListing | null> {
     const result = await this.baseFind<ProductListing>({
       session: session,
+      requireIds: true,
       urlIds: {"product_id": product_id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/province.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/province.ts
@@ -54,6 +54,7 @@ export class Province extends Base {
   ): Promise<Province | null> {
     const result = await this.baseFind<Province>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "country_id": country_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/recurring_application_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/recurring_application_charge.ts
@@ -55,6 +55,7 @@ export class RecurringApplicationCharge extends Base {
   ): Promise<RecurringApplicationCharge | null> {
     const result = await this.baseFind<RecurringApplicationCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/redirect.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/redirect.ts
@@ -61,6 +61,7 @@ export class Redirect extends Base {
   ): Promise<Redirect | null> {
     const result = await this.baseFind<Redirect>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/refund.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/refund.ts
@@ -63,6 +63,7 @@ export class Refund extends Base {
   ): Promise<Refund | null> {
     const result = await this.baseFind<Refund>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/script_tag.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/script_tag.ts
@@ -63,6 +63,7 @@ export class ScriptTag extends Base {
   ): Promise<ScriptTag | null> {
     const result = await this.baseFind<ScriptTag>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/smart_collection.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/smart_collection.ts
@@ -80,6 +80,7 @@ export class SmartCollection extends Base {
   ): Promise<SmartCollection | null> {
     const result = await this.baseFind<SmartCollection>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/theme.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/theme.ts
@@ -50,6 +50,7 @@ export class Theme extends Base {
   ): Promise<Theme | null> {
     const result = await this.baseFind<Theme>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/transaction.ts
@@ -57,6 +57,7 @@ export class Transaction extends Base {
   ): Promise<Transaction | null> {
     const result = await this.baseFind<Transaction>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "order_id": order_id},
       params: {"fields": fields, "in_shop_currency": in_shop_currency},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/usage_charge.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/usage_charge.ts
@@ -51,6 +51,7 @@ export class UsageCharge extends Base {
   ): Promise<UsageCharge | null> {
     const result = await this.baseFind<UsageCharge>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id, "recurring_application_charge_id": recurring_application_charge_id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/user.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/user.ts
@@ -47,6 +47,7 @@ export class User extends Base {
   ): Promise<User | null> {
     const result = await this.baseFind<User>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/variant.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/variant.ts
@@ -64,6 +64,7 @@ export class Variant extends Base {
   ): Promise<Variant | null> {
     const result = await this.baseFind<Variant>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/admin/2024-04/webhook.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/webhook.ts
@@ -65,6 +65,7 @@ export class Webhook extends Base {
   ): Promise<Webhook | null> {
     const result = await this.baseFind<Webhook>({
       session: session,
+      requireIds: true,
       urlIds: {"id": id},
       params: {"fields": fields},
     });

--- a/packages/apps/shopify-api/rest/base.ts
+++ b/packages/apps/shopify-api/rest/base.ts
@@ -13,6 +13,7 @@ interface BaseFindArgs {
   session: Session;
   params?: ParamSet;
   urlIds: IdSet;
+  requireIds?: boolean;
 }
 
 interface BaseConstructorArgs {
@@ -77,7 +78,18 @@ export class Base {
     session,
     urlIds,
     params,
+    requireIds = false,
   }: BaseFindArgs): Promise<FindAllResponse<T>> {
+    if (requireIds) {
+      const hasIds = Object.entries(urlIds).some(([_key, value]) => value);
+
+      if (!hasIds) {
+        throw new RestResourceError(
+          'No IDs given for request, cannot find path',
+        );
+      }
+    }
+
     const response = await this.request<T>({
       http_method: 'get',
       operation: 'get',


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #756 

When all ids evaluated to falsey values in the REST resources' `find()` methods, we could end up defaulting to the non-id specific versions of a request - e.g. `/products/<id>.json` became `/products.json` because we treated these ids as optional.

However, typically in REST APIs, whenever we are GET-ing a specific item you'll need to supply its id, so it didn't make sense for `find()` to do an id-less query.

### WHAT is this pull request doing?

Making it possible to trigger an error if we're missing an id by passing in a parameter to `baseFind`, and updating all `find()` methods to pass that parameter in.

I'm considering this a bug fix because those requests were never supposed to be fired in the first place and would cause unpredictable behaviour.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change