### PR TITLE
Allow encrypting access tokens in Prisma dbs

### DIFF
--- a/.changeset/empty-cobras-listen.md
+++ b/.changeset/empty-cobras-listen.md
@@ -1,0 +1,6 @@
+---
+"@shopify/shopify-app-session-storage-prisma": minor
+"@shopify/shopify-app-session-storage-test-utils": patch
+---
+
+Added the ability to encode access tokens to `PrismaSessionStorage`, to add an extra layer of security to app DBs.

--- a/packages/apps/session-storage/shopify-app-session-storage-prisma/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-prisma/package.json
@@ -44,7 +44,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@prisma/client": "^5.10.2",
-    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
+    "@shopify/shopify-api": "^10.1.0",
     "@shopify/shopify-app-session-storage": "^2.1.4",
     "prisma": "^5.12.1"
   },

--- a/packages/apps/session-storage/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-prisma/src/__tests__/prisma.test.ts
@@ -1,9 +1,11 @@
 import fs from 'fs';
 import {execSync} from 'child_process';
 
+import '@shopify/shopify-api/adapters/mock';
 import {Session} from '@shopify/shopify-api';
 import {batteryOfTests} from '@shopify/shopify-app-session-storage-test-utils';
 import {Prisma, PrismaClient} from '@prisma/client';
+import {getCryptoLib} from '@shopify/shopify-api/runtime';
 
 import {MissingSessionTableError, PrismaSessionStorage} from '../prisma';
 
@@ -32,6 +34,81 @@ describe('PrismaSessionStorage', () => {
     async () =>
       new PrismaSessionStorage<PrismaClient>(prisma, {tableName: 'mySession'}),
   );
+});
+
+describe('PrismaSessionStorage with an encryption key', () => {
+  let prisma: PrismaClient;
+  let key: CryptoKey;
+
+  beforeAll(async () => {
+    // Reset the database prior to the tests
+    clearTestDatabase();
+
+    execSync('npx prisma migrate dev --name init --preview-feature');
+
+    prisma = new PrismaClient();
+
+    const cryptoLib = getCryptoLib();
+    key = await cryptoLib.subtle.generateKey(
+      {name: 'AES-GCM', length: 256},
+      true,
+      ['encrypt', 'decrypt'],
+    );
+  });
+
+  afterAll(async () => {
+    await prisma.session.deleteMany();
+    await prisma.mySession.deleteMany();
+  });
+
+  // Using the default table name
+  batteryOfTests(
+    async () =>
+      new PrismaSessionStorage<PrismaClient>(prisma, {encryptionKey: key}),
+  );
+
+  // Using a custom table name
+  batteryOfTests(
+    async () =>
+      new PrismaSessionStorage<PrismaClient>(prisma, {
+        encryptionKey: key,
+        tableName: 'mySession',
+      }),
+  );
+
+  it('can load a non-encrypted session and encrypts it when updating', async () => {
+    // GIVEN
+    const nonEncryptedStorage = new PrismaSessionStorage<PrismaClient>(prisma);
+    const encryptedStorage = new PrismaSessionStorage<PrismaClient>(prisma, {
+      encryptionKey: key,
+    });
+    const session = new Session({
+      id: 'session-123',
+      shop: 'shop',
+      state: 'state',
+      isOnline: false,
+      accessToken: '123',
+      scope: '',
+    });
+
+    // Simulate a migration by creating a pre-existing non-encrypted session
+    await nonEncryptedStorage.storeSession(session);
+
+    // WHEN
+    const loadedSession = await encryptedStorage.loadSession(session.id);
+    expect(loadedSession).not.toBeNull();
+    expect(loadedSession?.accessToken).toBe('123');
+
+    loadedSession!.accessToken = '321';
+    await expect(
+      encryptedStorage.storeSession(loadedSession!),
+    ).resolves.toBeTruthy();
+
+    const encryptedSession = await encryptedStorage.loadSession(session.id);
+
+    // THEN
+    expect(encryptedSession?.accessToken).toBe('321');
+  });
 });
 
 describe('PrismaSessionStorage when with no database set up', () => {

--- a/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/battery-of-tests.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/battery-of-tests.ts
@@ -79,6 +79,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
 
       await expect(storage.storeSession(session)).resolves.toBeTruthy();
       const storedSession = await storage.loadSession(sessionId);
+
       expect(session.equals(storedSession)).toBeTruthy();
 
       expect(storedSession?.isActive(testScopes)).toBeTruthy();
@@ -104,6 +105,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
 
     await expect(storage.storeSession(session)).resolves.toBeTruthy();
     const storedSession = await storage.loadSession(sessionId);
+
     expect(session.equals(storedSession)).toBeTruthy();
   });
 
@@ -120,6 +122,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
 
     await expect(storage.storeSession(session)).resolves.toBeTruthy();
     const storedSession = await storage.loadSession(sessionId);
+
     expect(session.equals(storedSession)).toBeTruthy();
   });
 
@@ -171,11 +174,9 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
       expect(shop1Sessions).toBeDefined();
       if (shop1Sessions) {
         expect(shop1Sessions.length).toBe(2);
+
         expect(
-          sessionArraysEqual(shop1Sessions, [
-            sessions[0] as Session,
-            sessions[2] as Session,
-          ]),
+          sessionArraysEqual(shop1Sessions, [sessions[0], sessions[2]]),
         ).toBeTruthy();
       }
     }
@@ -246,6 +247,7 @@ export function batteryOfTests(storageFactory: () => Promise<SessionStorage>) {
 
     await expect(storage.storeSession(session)).resolves.toBeTruthy();
     const storedSession = await storage.loadSession(sessionId);
+
     expect(session.equals(storedSession)).toBeTruthy();
   });
 }


### PR DESCRIPTION
### WHY are these changes introduced?

With the ability to encrypt access tokens built into the `Session` class (#818), we should update our storage options to included that for an extra layer of security.

### WHAT is this pull request doing?

Adding a new parameter to `PrismaSessionStorage` to pass in an encryption key to be used to encrypt data. This doesn't require apps to migrate right away since we can update rows as they rotate, but we should still recommend apps load and store every session (or wipe their table).

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
