### PR TITLE
Make shopify-api dependency more flexible

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,6 @@
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "updateInternalDependents": "always",
-    "onlyUpdatePeerDependentsWhenOutOfRange": true
+    "updateInternalDependents": "always"
   }
 }

--- a/.changeset/mean-plums-compare.md
+++ b/.changeset/mean-plums-compare.md
@@ -1,0 +1,16 @@
+---
+"@shopify/shopify-app-session-storage-postgresql": patch
+"@shopify/shopify-app-session-storage-test-utils": patch
+"@shopify/shopify-app-session-storage-dynamodb": patch
+"@shopify/shopify-app-session-storage-drizzle": patch
+"@shopify/shopify-app-session-storage-mongodb": patch
+"@shopify/shopify-app-session-storage-memory": patch
+"@shopify/shopify-app-session-storage-prisma": patch
+"@shopify/shopify-app-session-storage-sqlite": patch
+"@shopify/shopify-app-session-storage-mysql": patch
+"@shopify/shopify-app-session-storage-redis": patch
+"@shopify/shopify-app-session-storage-kv": patch
+"@shopify/shopify-app-session-storage": patch
+---
+
+Updated @shopify/shopify-api dependency to also allow v10+ since there were no breaking changes affecting this package.

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/package.json
@@ -45,7 +45,7 @@
     "tslib": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4",
     "drizzle-orm": "^0.30.6"
   },

--- a/packages/apps/session-storage/shopify-app-session-storage-dynamodb/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-dynamodb/package.json
@@ -47,7 +47,7 @@
     "@aws-sdk/util-dynamodb": "^3.554.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-kv/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-kv/package.json
@@ -46,7 +46,7 @@
     "semver": "^7.6.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-memory/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-memory/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-mongodb/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-mongodb/package.json
@@ -45,7 +45,7 @@
     "mongodb": "^6.3.0"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/package.json
@@ -46,7 +46,7 @@
     "mysql2": "^3.9.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-postgresql/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-postgresql/package.json
@@ -47,7 +47,7 @@
     "pg-connection-string": "^2.6.2"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-prisma/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-prisma/package.json
@@ -44,7 +44,7 @@
   "dependencies": {},
   "peerDependencies": {
     "@prisma/client": "^5.10.2",
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4",
     "prisma": "^5.12.1"
   },

--- a/packages/apps/session-storage/shopify-app-session-storage-redis/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-redis/package.json
@@ -46,7 +46,7 @@
     "redis": "^4.6.12"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-sqlite/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-sqlite/package.json
@@ -46,7 +46,7 @@
     "sqlite3": "^5.1.7"
   },
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {

--- a/packages/apps/session-storage/shopify-app-session-storage-test-utils/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-test-utils/package.json
@@ -44,11 +44,11 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "devDependencies": {
-    "@shopify/shopify-api": "^9.7.2",
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0",
     "@shopify/shopify-app-session-storage": "^2.1.4"
   },
   "files": [

--- a/packages/apps/session-storage/shopify-app-session-storage/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage/package.json
@@ -43,10 +43,10 @@
   ],
   "dependencies": {},
   "peerDependencies": {
-    "@shopify/shopify-api": "^9.7.2"
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0"
   },
   "devDependencies": {
-    "@shopify/shopify-api": "^9.7.2"
+    "@shopify/shopify-api": "^9.7.2 || ^10.0.0"
   },
   "files": [
     "dist/*",


### PR DESCRIPTION
This PR fixes the dependency of the session storage packages on shopify-api to allow anything above v9.7.2, so future major versions that don't affect these packages are also included.