### PR TITLE
Avoid major bumps in peer dep updates

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,6 +9,7 @@
   "updateInternalDependencies": "patch",
   "ignore": [],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
-    "updateInternalDependents": "always"
+    "updateInternalDependents": "always",
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
   }
 }


### PR DESCRIPTION
Setting the changesets config to not bump peer dependencies that are still in range of the updated version of a package (in our case, `shopify-api`).