### PR TITLE
Fix package minification process

### DIFF
--- a/.changeset/gentle-apricots-work.md
+++ b/.changeset/gentle-apricots-work.md
@@ -1,0 +1,6 @@
+---
+"@shopify/graphql-client": patch
+"@shopify/storefront-api-client": patch
+---
+
+Fixed the minified build process to not mangle the `fetch` function, which led to requests failing in the final package.

--- a/config/rollup/rollup-utils.js
+++ b/config/rollup/rollup-utils.js
@@ -37,7 +37,14 @@ export function getPlugins({
       declaration: false,
       moduleResolution: 'Bundler',
     }),
-    ...(minify === true ? [terser({keep_fnames: new RegExp('fetch')})] : []),
+    ...(minify === true
+      ? [
+          terser({
+            keep_fnames: new RegExp('fetch'),
+            mangle: {reserved: ['fetch']},
+          }),
+        ]
+      : []),
   ];
 }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #802 

As reported, client requests behaved strangely on the minified version of the SFAPI client, because the `fetch` function was being mangled and led to it being somehow overridden in the final build.

### WHAT is this pull request doing?

Ensuring that `terser` leaves the `fetch` function alone when minifying the code, so that requests still work. We already had a rule to preserve it as a function name, but it still failed when it was passed as a parameter, probably because terser couldn't know that was a function.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change