### PR TITLE
Alias default to is_default for customer addresses

### DIFF
--- a/.changeset/kind-vans-add.md
+++ b/.changeset/kind-vans-add.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Added an `is_default` field to `CustomerAddress` so it doesn't overlap with the existing `default()` method we provide in the class.

--- a/.changeset/kind-vans-add.md
+++ b/.changeset/kind-vans-add.md
@@ -3,3 +3,25 @@
 ---
 
 Added an `is_default` field to `CustomerAddress` so it doesn't overlap with the existing `default()` method we provide in the class.
+
+Before:
+
+```ts
+const address = await shopify.rest.CustomerAddress.find({ session, id: 1234 });
+// Boolean
+console.log(address.default);
+// Error - not a function
+await address.default();
+```
+
+After:
+
+```ts
+const address = await shopify.rest.CustomerAddress.find({ session, id: 1234 });
+// Boolean
+console.log(address.is_default);
+// Function
+await address.default();
+```
+
+To prevent breaking existing apps, this only happens when the `customerAddressDefaultFix` flag is enabled.

--- a/packages/apps/shopify-api/future/flags.ts
+++ b/packages/apps/shopify-api/future/flags.ts
@@ -15,6 +15,12 @@ export interface FutureFlags {
    * Enable line item billing, to make billing configuration more similar to the GraphQL API.
    */
   lineItemBilling?: boolean;
+
+  /**
+   * Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This
+   * resolves a conflict with the default() method in that class.
+   */
+  customerAddressDefaultFix?: boolean;
 }
 
 /**
@@ -52,6 +58,13 @@ export function logDisabledFutureFlags(
     logger.deprecated(
       '11.0.0',
       'v10_lineItemBilling will become enabled in v11. Use flag lineItemBilling instead',
+    );
+  }
+
+  if (!config.future?.customerAddressDefaultFix) {
+    logFlag(
+      'customerAddressDefaultFix',
+      "Enable this flag to change the CustomerAddress classes to expose a 'is_default' property instead of 'default' when fetching data.",
     );
   }
 }

--- a/packages/apps/shopify-api/lib/__tests__/test-config.ts
+++ b/packages/apps/shopify-api/lib/__tests__/test-config.ts
@@ -57,6 +57,7 @@ const TEST_FUTURE_FLAGS: Required<{
 }> = {
   v10_lineItemBilling: true,
   lineItemBilling: true,
+  customerAddressDefaultFix: true,
 } as const;
 
 const TEST_CONFIG = {

--- a/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
@@ -3,7 +3,7 @@
 ***********************************************************************************************************************/
 
 import {Base, FindAllResponse} from '../../base';
-import {ResourcePath, ResourceNames} from '../../types';
+import {ResourcePath, ResourceNames, Body} from '../../types';
 import {Session} from '../../../lib/session/session';
 import {ApiVersion} from '../../../lib/types';
 
@@ -61,6 +61,17 @@ export class CustomerAddress extends Base {
   protected static getJsonBodyName(): string
   {
     return "address";
+  }
+
+  protected setData(data: Body): void {
+    if ('default' in data) {
+      data['is_default'] = Boolean(data['default']);
+      delete data['default'];
+    } else {
+      data['is_default'] = false;
+    }
+
+    return super.setData(data);
   }
 
   public static async find(
@@ -163,6 +174,7 @@ export class CustomerAddress extends Base {
   public customer_id: number | null;
   public first_name: string | null;
   public id: number | null;
+  public is_default: boolean | null;
   public last_name: string | null;
   public name: string | null;
   public phone: string | null;

--- a/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/customer_address.ts
@@ -64,11 +64,13 @@ export class CustomerAddress extends Base {
   }
 
   protected setData(data: Body): void {
-    if ('default' in data) {
-      data['is_default'] = Boolean(data['default']);
-      delete data['default'];
-    } else {
-      data['is_default'] = false;
+    if (this.resource().config.future?.customerAddressDefaultFix) {
+      if ('default' in data) {
+        data['is_default'] = Boolean(data['default']);
+        delete data['default'];
+      } else {
+        data['is_default'] = false;
+      }
     }
 
     return super.setData(data);

--- a/packages/apps/shopify-api/rest/base.ts
+++ b/packages/apps/shopify-api/rest/base.ts
@@ -389,7 +389,7 @@ export class Base {
     });
   }
 
-  private resource(): typeof Base {
+  protected resource(): typeof Base {
     return this.constructor as unknown as typeof Base;
   }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Closes #754 

As pointed out in the issue, we currently have 2 instances of `default` in the `CustomerAddress` resource:
1. The method to set an address as default
2. The response field indicating whether an address is the default

### WHAT is this pull request doing?

Aliasing the read-only field to `is_default` so they don't overlap and cause breakages in apps.

Question: is this actually a breaking change? Are we breaking apps that expect `default` to be the boolean value in certain contexts?

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
