### PR TITLE
Add links to migration guides from CHANGELOGs

### DIFF
--- a/.changeset/dry-needles-sin.md
+++ b/.changeset/dry-needles-sin.md
@@ -2,4 +2,6 @@
 '@shopify/shopify-app-remix': major
 ---
 
-Remove v3_authenticate_public future flag and enable functionality be default
+Remove v3_authenticate_public future flag and enable functionality be default.
+
+See more details in the [migration guide](./docs/MIGRATION_V3.md).

--- a/.changeset/rich-panthers-refuse.md
+++ b/.changeset/rich-panthers-refuse.md
@@ -7,7 +7,7 @@
 
 With this change when using online access tokens, the user information is stored as part of the session. Previously only the user ID was stored. This will enable changing of page content or limiting of page visibility by user, as well as unlock logging users actions. This is a breaking change, as the Prisma schema has been updated to include the user information.
 
-For more information review the [migration guide](../packages/apps/session-storage/shopify-app-session-storage-prisma/MIGRATION_V5.md).
+For more information review the [migration guide](./MIGRATION_V5.md).
 
 
 <details>

--- a/.changeset/tame-boats-dance.md
+++ b/.changeset/tame-boats-dance.md
@@ -2,4 +2,6 @@
 '@shopify/shopify-app-remix': major
 ---
 
-Remove v3_webhookAdminContext future flag and enable functionality
+Remove v3_webhookAdminContext future flag and enable functionality.
+
+See more details in the [migration guide](./docs/MIGRATION_V3.md).

--- a/.changeset/wise-bobcats-add.md
+++ b/.changeset/wise-bobcats-add.md
@@ -16,3 +16,5 @@ import '@shopify/shopify-app-remix/server/adapters/node';
 - import {shopifyApp} from '@shopify/shopify-app-remix';
 import {AppProvider} from '@shopify/shopify-app-remix/react';
 ```
+
+See more details in the [migration guide](./docs/MIGRATION_V3.md).

--- a/packages/apps/shopify-app-remix/docs/MIGRATION_V3.md
+++ b/packages/apps/shopify-app-remix/docs/MIGRATION_V3.md
@@ -1,8 +1,15 @@
 # Migrating to Version 3.0.0
 
+## Table of contents
+
+- [Replace `authenticate.public()` with `authenticate.public.checkout()`](#replace-authenticatepublic-with-authenticatepubliccheckout)
+- [Align the `admin` context object for webhooks](#align-the-admin-context-object-for-webhooks)
+- [Root import path deprecation](#root-import-path-deprecation)
+- [Use the AppProvider component](#use-the-appprovider-component)
+
 ## Replace `authenticate.public()` with `authenticate.public.checkout()`
 
-The `v3_authenticatePublic` future flag has been enabled, and removed.
+The `v3_authenticatePublic` future flag has been enabled, and removed. If you've already enabled that flag, you only need to remove it from your configuration.
 
 The `authenticate.public` export used to be a function that was meant to authenticate [checkout extension](https://shopify.dev/docs/api/checkout-extensions) requests.
 
@@ -35,7 +42,7 @@ export async function loader({request}: LoaderFunctionArgs) {
 
 ## Align the `admin` context object for webhooks
 
-The `v3_webhookAdminContext` future flag has been removed and the feature has been enabled.
+The `v3_webhookAdminContext` future flag has been removed and the feature has been enabled. If you've already enabled that flag, you only need to remove it from your configuration.
 
 The `admin` context returned by `authenticate.webhook` didn't match the object returned by e.g. `authenticate.admin`, which could lead to confusion.
 


### PR DESCRIPTION
This PR makes some tweaks to the CHANGELOGs and migration guides to make them easier to follow.