### PR TITLE
fix(api-codegen-preset): strip extension from type import

### DIFF
--- a/.changeset/nice-countries-collect.md
+++ b/.changeset/nice-countries-collect.md
@@ -1,0 +1,5 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+type imports in generated codegen files will not include the extension

--- a/packages/api-clients/api-codegen-preset/src/preset.ts
+++ b/packages/api-clients/api-codegen-preset/src/preset.ts
@@ -3,16 +3,13 @@ import {preset as hydrogenPreset} from '@shopify/graphql-codegen';
 
 import {type ShopifyApiPresetConfig} from './types';
 import {apiConfigs} from './helpers/api-configs';
-import {getOutputFiles} from './helpers/get-output-files';
 
 export const preset: Types.OutputPreset<ShopifyApiPresetConfig> = {
   buildGeneratesSection: (options) => {
     const apiType = options.presetConfig.apiType;
 
     const {interfaceExtension, module, presetConfigs} = apiConfigs[apiType];
-    const declarations = options.baseOutputDir.endsWith('.d.ts');
-
-    const {typesFile} = getOutputFiles(apiType, declarations);
+    const typesFile = apiConfigs[apiType].typesFile;
 
     return hydrogenPreset.buildGeneratesSection({
       ...options,

--- a/packages/api-clients/api-codegen-preset/src/tests/preset.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/preset.test.ts
@@ -34,7 +34,7 @@ describe('Preset', () => {
 
     // Imports Admin API
     expect(generatedCode).toMatch(
-      `import type * as AdminTypes from './admin.types.d.ts';`,
+      `import type * as AdminTypes from './admin.types';`,
     );
 
     // Uses Pick<...>
@@ -59,7 +59,7 @@ describe('Preset', () => {
       .toBe(`/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable eslint-comments/no-unlimited-disable */
 /* eslint-disable */
-import type * as AdminTypes from './admin.types.d.ts';
+import type * as AdminTypes from './admin.types';
 
 export type TestQueryQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
 
@@ -100,7 +100,7 @@ declare module '@shopify/admin-api-client' {
     )!.content;
 
     expect(generatedCode).toMatch(
-      "import type * as AdminTypes from './admin.types.d.ts';",
+      "import type * as AdminTypes from './admin.types';",
     );
   });
 
@@ -116,7 +116,7 @@ declare module '@shopify/admin-api-client' {
     )!.content;
 
     expect(generatedCode).toMatch(
-      "import * as AdminTypes from './admin.types.ts';",
+      "import * as AdminTypes from './admin.types';",
     );
   });
 });


### PR DESCRIPTION
### WHY are these changes introduced?

@shopify/graphql-codegen doesn't expect a file extension when it is provided the importTypes option.  If it does it will produce:
`import type * as StorefrontTypes from './storefront.types.ts';`
when we really want
`import type * as StorefrontTypes from './storefront.types';`

### WHAT is this pull request doing?

This pull requests just leaves off the extension when passing the types file to the presetConfig

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
