### PR TITLE
[Feature] Enable unit testing for Remix

### DIFF
--- a/packages/api-clients/admin-api-client/src/graphql/client.ts
+++ b/packages/api-clients/admin-api-client/src/graphql/client.ts
@@ -29,6 +29,7 @@ export function createAdminApiClient({
   retries = 0,
   customFetchApi,
   logger,
+  isTesting,
 }: AdminApiClientOptions): AdminApiClient {
   const currentSupportedApiVersions = getCurrentSupportedApiVersions();
 
@@ -43,7 +44,7 @@ export function createAdminApiClient({
     logger,
   };
 
-  validateServerSideUsage();
+  validateServerSideUsage(isTesting);
   validateApiVersion({
     client: CLIENT,
     currentSupportedApiVersions,

--- a/packages/api-clients/admin-api-client/src/rest/client.ts
+++ b/packages/api-clients/admin-api-client/src/rest/client.ts
@@ -47,6 +47,7 @@ export function createAdminRestApiClient({
   scheme = 'https',
   defaultRetryTime = DEFAULT_RETRY_WAIT_TIME,
   formatPaths = true,
+  isTesting,
 }: AdminRestApiClientOptions): AdminRestApiClient {
   const currentSupportedApiVersions = getCurrentSupportedApiVersions();
 
@@ -61,7 +62,7 @@ export function createAdminRestApiClient({
     logger,
   };
 
-  validateServerSideUsage();
+  validateServerSideUsage(isTesting);
   validateApiVersion({
     client: CLIENT,
     currentSupportedApiVersions,

--- a/packages/api-clients/admin-api-client/src/types.ts
+++ b/packages/api-clients/admin-api-client/src/types.ts
@@ -18,4 +18,5 @@ export type AdminApiClientOptions = Omit<
 > & {
   customFetchApi?: CustomFetchApi;
   logger?: ApiClientLogger<AdminApiClientLogContentTypes>;
+  isTesting?: boolean;
 };

--- a/packages/api-clients/admin-api-client/src/validations.ts
+++ b/packages/api-clients/admin-api-client/src/validations.ts
@@ -16,8 +16,8 @@ export function validateRequiredAccessToken(accessToken: string) {
   }
 }
 
-export function validateServerSideUsage() {
-  if (typeof window !== 'undefined') {
+export function validateServerSideUsage(isTesting = false) {
+  if (typeof window !== 'undefined' && !isTesting) {
     throw new Error(`${CLIENT}: this client should not be used in the browser`);
   }
 }

--- a/packages/apps/shopify-api/lib/base-types.ts
+++ b/packages/apps/shopify-api/lib/base-types.ts
@@ -113,6 +113,10 @@ export interface ConfigParams<
    * @private
    */
   _logDisabledFutureFlags?: boolean;
+  /**
+   * Whether the app is initialised for local testing.
+   */
+  isTesting?: boolean;
 }
 
 export type ConfigInterface<Params extends ConfigParams = ConfigParams> = Omit<
@@ -131,4 +135,5 @@ export type ConfigInterface<Params extends ConfigParams = ConfigParams> = Omit<
     timestamps: boolean;
   };
   future: FutureFlagOptions;
+  isTesting?: boolean;
 };

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -62,6 +62,7 @@ export class GraphqlClient {
       customFetchApi: abstractFetch,
       logger: clientLoggerFactory(config),
       userAgentPrefix: getUserAgent(config),
+      isTesting: config.isTesting,
     });
   }
 

--- a/packages/apps/shopify-api/lib/clients/admin/rest/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/rest/client.ts
@@ -97,6 +97,7 @@ export class RestClient {
       userAgentPrefix: getUserAgent(config),
       defaultRetryTime: this.restClass().RETRY_WAIT_TIME,
       formatPaths: this.restClass().formatPaths,
+      isTesting: config.isTesting,
     });
   }
 

--- a/packages/apps/shopify-app-remix/README.md
+++ b/packages/apps/shopify-app-remix/README.md
@@ -218,6 +218,16 @@ const shopify = shopifyApp({
 - [Using Shopify managed installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation)
 - [Configuring access scopes through the Shopify CLI](https://shopify.dev/docs/apps/tools/cli/configuration)
 
+### Unit testing
+To unit test your application, you can simply set the `isTesting` flag to true in the configuration object passed to `shopifyApp`. It can be helpful to set this value based on an environmental variable flag.
+
+```ts
+// my-app/app/shopify.server.ts
+const shopify = shopifyApp({
+  ...
+  isTesting: process.env.SHOPIFY_TESTING === "1"
+})
+
 ## Gotchas / Troubleshooting
 
 If you're experiencing unexpected behaviors when using this package, check our [app template's documentation](https://github.com/Shopify/shopify-app-template-remix#gotchas--troubleshooting) for the solution to common issues.

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -1,15 +1,8 @@
-import {
-  LATEST_API_VERSION,
-  LogSeverity,
-  ShopifyRestResources,
-} from '@shopify/shopify-api';
-import {SessionStorage} from '@shopify/shopify-app-session-storage';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
 
-import type {AppConfigArg} from '../config-types';
-import type {FutureFlagOptions, FutureFlags} from '../future/flags';
-
-import {API_KEY, API_SECRET_KEY, APP_URL} from './const';
+import {testConfig as testConfigImport} from '../test-helpers/test-config';
+import type {TestOverridesArg, TestConfig} from '../test-helpers/test-config';
+import type {FutureFlags, FutureFlagOptions} from '../future/flags';
 
 /*
  * This object mandates that all existing future flags be activated for tests. If a new flag is added, this object must
@@ -24,19 +17,10 @@ const TEST_FUTURE_FLAGS: Required<{[key in keyof FutureFlags]: true}> = {
 } as const;
 
 const TEST_CONFIG = {
-  apiKey: API_KEY,
-  apiSecretKey: API_SECRET_KEY,
-  scopes: ['testScope'] as any,
-  apiVersion: LATEST_API_VERSION,
-  appUrl: APP_URL,
   logger: {
     log: jest.fn(),
-    level: LogSeverity.Debug,
   },
-  isEmbeddedApp: true,
-  sessionStorage: new MemorySessionStorage(),
-  future: TEST_FUTURE_FLAGS,
-} as const;
+};
 
 // Reset the config object before each test
 beforeEach(() => {
@@ -45,66 +29,19 @@ beforeEach(() => {
 });
 
 export function testConfig<
-  Overrides extends TestOverridesArg<Future>,
+  Overrides extends TestOverridesArg,
   Future extends FutureFlagOptions,
 >(
   {future, ...overrides}: Overrides & {future?: Future} = {} as Overrides & {
     future?: Future;
   },
-): TestConfig<Overrides, Future> {
-  return {
-    ...TEST_CONFIG,
-    ...overrides,
-    logger: {
-      ...TEST_CONFIG.logger,
-      ...(overrides as NonNullable<Overrides>).logger,
-    },
+): TestConfig<Overrides> {
+  return testConfigImport({
     future: {
-      ...TEST_CONFIG.future,
+      ...TEST_FUTURE_FLAGS,
       ...future,
     },
-  } as any;
+    ...TEST_CONFIG,
+    ...overrides,
+  }) as any;
 }
-
-/*
- * This type combines both passed in types, by ignoring any keys from Type1 that are present (and not undefined)
- * in Type2, and then adding any keys from Type1 that are not present in Type2.
- *
- * This effectively enables us to create a type that is the const TEST_CONFIG below, plus any overrides passed in with
- * the output being a const object.
- */
-type Modify<Type1, Type2> = {
-  [key in keyof Type2 as Type2[key] extends undefined
-    ? never
-    : key]: Type2[key];
-} & {
-  [key in keyof Type1 as key extends keyof Type2 ? never : key]: Type1[key];
-};
-
-type DefaultedFutureFlags<Future> = Modify<typeof TEST_CONFIG.future, Future>;
-
-/*
- * We omit the future prop and then redefine it with a partial of that object so we can pass the fully typed object in
- * to AppConfigArg.
- */
-type TestOverrides<Future> = Partial<
-  Omit<
-    AppConfigArg<
-      ShopifyRestResources,
-      SessionStorage,
-      DefaultedFutureFlags<Future>
-    >,
-    'future'
-  > & {
-    future: Partial<DefaultedFutureFlags<Future>>;
-  }
->;
-
-type TestOverridesArg<Future> = undefined | TestOverrides<Future>;
-
-type TestConfig<Overrides extends TestOverridesArg<Future>, Future> = Modify<
-  typeof TEST_CONFIG,
-  Overrides
-> & {
-  future: Modify<typeof TEST_CONFIG.future, Future>;
-};

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -35,6 +35,7 @@ import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promis
 import {authenticateFlowFactory} from './authenticate/flow/authenticate';
 import {authenticateFulfillmentServiceFactory} from './authenticate/fulfillment-service/authenticate';
 import {FutureFlagOptions, logDisabledFutureFlags} from './future/flags';
+import {testConfig} from './test-helpers/test-config';
 
 /**
  * Creates an object your app will use to interact with Shopify.
@@ -63,6 +64,13 @@ export function shopifyApp<
   Storage extends SessionStorage,
   Future extends FutureFlagOptions = Config['future'],
 >(appConfig: Readonly<Config>): ShopifyApp<Config> {
+  if (appConfig.isTesting === true) {
+    appConfig = {
+      ...appConfig,
+      ...testConfig(),
+    };
+  }
+
   const api = deriveApi(appConfig);
   const config = deriveConfig<Storage>(appConfig, api.config);
   const logger = overrideLogger(api.logger);
@@ -192,6 +200,13 @@ function deriveConfig<Storage extends SessionStorage>(
 
   const authPathPrefix = appConfig.authPathPrefix || '/auth';
   appConfig.distribution = appConfig.distribution ?? AppDistribution.AppStore;
+
+  if (appConfig.isTesting === true) {
+    appConfig = {
+      ...appConfig,
+      ...testConfig(),
+    };
+  }
 
   return {
     ...appConfig,

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -65,10 +65,7 @@ export function shopifyApp<
   Future extends FutureFlagOptions = Config['future'],
 >(appConfig: Readonly<Config>): ShopifyApp<Config> {
   if (appConfig.isTesting === true) {
-    appConfig = {
-      ...appConfig,
-      ...testConfig(),
-    };
+    Object.assign(appConfig, testConfig());
   }
 
   const api = deriveApi(appConfig);
@@ -200,13 +197,6 @@ function deriveConfig<Storage extends SessionStorage>(
 
   const authPathPrefix = appConfig.authPathPrefix || '/auth';
   appConfig.distribution = appConfig.distribution ?? AppDistribution.AppStore;
-
-  if (appConfig.isTesting === true) {
-    appConfig = {
-      ...appConfig,
-      ...testConfig(),
-    };
-  }
 
   return {
     ...appConfig,

--- a/packages/apps/shopify-app-remix/src/server/test-helpers/test-config.ts
+++ b/packages/apps/shopify-app-remix/src/server/test-helpers/test-config.ts
@@ -1,0 +1,84 @@
+import {
+  LATEST_API_VERSION,
+  LogSeverity,
+  ShopifyRestResources,
+} from '@shopify/shopify-api';
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
+import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+
+import type {AppConfigArg} from '../config-types';
+import type {FutureFlagOptions} from '../future/flags';
+import {API_KEY, API_SECRET_KEY, APP_URL} from '../__test-helpers/const';
+
+const TEST_CONFIG = {
+  apiKey: API_KEY,
+  apiSecretKey: API_SECRET_KEY,
+  scopes: ['testScope'] as any,
+  apiVersion: LATEST_API_VERSION,
+  appUrl: APP_URL,
+  logger: {
+    level: LogSeverity.Debug,
+  },
+  isEmbeddedApp: true,
+  sessionStorage: new MemorySessionStorage(),
+};
+
+export function testConfig<
+  Overrides extends TestOverridesArg,
+  Future extends FutureFlagOptions,
+>(
+  {future, ...overrides}: Overrides & {future?: Future} = {} as Overrides & {
+    future?: Future;
+  },
+): TestConfig<Overrides> {
+  console.log(overrides);
+  return {
+    ...TEST_CONFIG,
+    ...overrides,
+    logger: {
+      ...TEST_CONFIG.logger,
+      ...(overrides as NonNullable<Overrides>).logger,
+    },
+    future: {
+      ...future,
+    },
+  } as any;
+}
+
+/*
+ * This type combines both passed in types, by ignoring any keys from Type1 that are present (and not undefined)
+ * in Type2, and then adding any keys from Type1 that are not present in Type2.
+ *
+ * This effectively enables us to create a type that is the const TEST_CONFIG below, plus any overrides passed in with
+ * the output being a const object.
+ */
+type Modify<Type1, Type2> = {
+  [key in keyof Type2 as Type2[key] extends undefined
+    ? never
+    : key]: Type2[key];
+} & {
+  [key in keyof Type1 as key extends keyof Type2 ? never : key]: Type1[key];
+};
+
+/*
+ * We omit the future prop and then redefine it with a partial of that object so we can pass the fully typed object in
+ * to AppConfigArg.
+ */
+type TestOverrides = Partial<
+  Omit<
+    AppConfigArg<ShopifyRestResources, SessionStorage, FutureFlagOptions>,
+    'future'
+  > & {
+    future: Partial<FutureFlagOptions>;
+  }
+>;
+
+export type TestOverridesArg = undefined | TestOverrides;
+
+export type TestConfig<Overrides extends TestOverridesArg> = Modify<
+  typeof TEST_CONFIG,
+  Overrides
+> & {
+  future: FutureFlagOptions;
+  logger: AppConfigArg['logger'];
+};


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Enables unit testing of Shopify apps, and together with https://github.com/Shopify/shopify-app-js/pull/1168, replaces the need for this PR https://github.com/Shopify/shopify-app-template-remix/pull/377

### WHAT is this pull request doing?

Setting `isTesting: true` in the config passed to `shopifyApp` automatically mocks config values, and disables the check that GraphQL and REST requests are sent from the server side.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
