### PR TITLE
Make session storage optional for merchant custom apps

### DIFF
--- a/.changeset/mighty-hotels-pump.md
+++ b/.changeset/mighty-hotels-pump.md
@@ -1,0 +1,7 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Make session storage optional for merchant custom apps
+
+Providing a session storage to the `shopifyApp()` function is now optional for apps with a distribution of `AppDistribution.ShopifyAdmin`. Apps with this distribution create the session from the configured access tokens.

--- a/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -341,8 +341,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "AuthenticateAdmin",
             "description": "",
@@ -371,11 +373,77 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "syntaxKind": "TypeAliasDeclaration",
             "name": "AdminContext",
+            "value": "FeatureEnabled<Config['future'], 'unstable_optionalScopesApi'> extends true\n    ? EmbeddedTypedAdminContext<Config, Resources> & ScopesContext\n    : EmbeddedTypedAdminContext<Config, Resources>",
+            "description": ""
+          },
+          "FeatureEnabled": {
+            "filePath": "src/server/future/flags.ts",
+            "importMap": {
+              "ConfigParams": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Shopify": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "AppConfig": "src/server/config-types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "FeatureEnabled",
+            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
+            "description": ""
+          },
+          "FutureFlags": {
+            "filePath": "src/server/future/flags.ts",
+            "importMap": {
+              "ConfigParams": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Shopify": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "AppConfig": "src/server/config-types.ts"
+            },
+            "name": "FutureFlags",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_newEmbeddedAuthStrategy",
+                "value": "boolean",
+                "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
+                "isOptional": true,
+                "defaultValue": "false"
+              },
+              {
+                "filePath": "src/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_optionalScopesApi",
+                "value": "boolean",
+                "description": "When enabled, the `optionalScopes` API will be available.",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the `optionalScopes` API will be available.\n   *\n   * @default false\n   */\n  unstable_optionalScopesApi?: boolean;\n}"
+          },
+          "EmbeddedTypedAdminContext": {
+            "filePath": "src/server/authenticate/admin/types.ts",
+            "importMap": {
+              "JwtPayload": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
+              "AppConfigArg": "src/server/config-types.ts",
+              "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
+              "BillingContext": "src/server/authenticate/admin/billing/types.ts",
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "EmbeddedTypedAdminContext",
             "value": "Config['isEmbeddedApp'] extends false\n  ? NonEmbeddedAdminContext<Config, Resources>\n  : EmbeddedAdminContext<Config, Resources>",
             "description": ""
           },
@@ -388,8 +456,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "NonEmbeddedAdminContext",
             "description": "",
@@ -1545,8 +1615,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "EmbeddedAdminContext",
             "description": "",
@@ -1816,6 +1888,48 @@
               }
             ],
             "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
+          },
+          "ScopesContext": {
+            "filePath": "src/server/authenticate/admin/types.ts",
+            "importMap": {
+              "JwtPayload": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
+              "AppConfigArg": "src/server/config-types.ts",
+              "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
+              "BillingContext": "src/server/authenticate/admin/billing/types.ts",
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
+            },
+            "name": "ScopesContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scopes",
+                "value": "ScopesApiContext",
+                "description": "Methods to manage optional scopes for the store that made the request."
+              }
+            ],
+            "value": "interface ScopesContext {\n  /**\n   * Methods to manage optional scopes for the store that made the request.\n   */\n  scopes: ScopesApiContext;\n}"
+          },
+          "ScopesApiContext": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "ScopesApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "request",
+                "value": "(scopes: string[]) => Promise<void>",
+                "description": ""
+              }
+            ],
+            "value": "export interface ScopesApiContext {\n  request: (scopes: string[]) => Promise<void>;\n}"
           }
         }
       }
@@ -7737,7 +7851,7 @@
             },
             "syntaxKind": "TypeAliasDeclaration",
             "name": "ShopifyApp",
-            "value": "Config['distribution'] extends AppDistribution.ShopifyAdmin\n    ? AdminApp<Config>\n    : Config['distribution'] extends AppDistribution.SingleMerchant\n      ? SingleMerchantApp<Config>\n      : Config['distribution'] extends AppDistribution.AppStore\n        ? AppStoreApp<Config>\n        : AppStoreApp<Config>",
+            "value": "Config['distribution'] extends AppDistribution.ShopifyAdmin\n    ? AdminApp<Config>\n    : Config['distribution'] extends AppDistribution.SingleMerchant\n      ? EnforceSessionStorage<Config, SingleMerchantApp<Config>>\n      : Config['distribution'] extends AppDistribution.AppStore\n        ? EnforceSessionStorage<Config, AppStoreApp<Config>>\n        : EnforceSessionStorage<Config, AppStoreApp<Config>>",
             "description": "An object your app can use to interact with Shopify.\n\nBy default, the app's distribution is `AppStore`."
           },
           "AppDistribution": {
@@ -8102,8 +8216,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "AuthenticateAdmin",
             "description": "",
@@ -8132,11 +8248,77 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "syntaxKind": "TypeAliasDeclaration",
             "name": "AdminContext",
+            "value": "FeatureEnabled<Config['future'], 'unstable_optionalScopesApi'> extends true\n    ? EmbeddedTypedAdminContext<Config, Resources> & ScopesContext\n    : EmbeddedTypedAdminContext<Config, Resources>",
+            "description": ""
+          },
+          "FeatureEnabled": {
+            "filePath": "src/server/future/flags.ts",
+            "importMap": {
+              "ConfigParams": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Shopify": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "AppConfig": "src/server/config-types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "FeatureEnabled",
+            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
+            "description": ""
+          },
+          "FutureFlags": {
+            "filePath": "src/server/future/flags.ts",
+            "importMap": {
+              "ConfigParams": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Shopify": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "AppConfig": "src/server/config-types.ts"
+            },
+            "name": "FutureFlags",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_newEmbeddedAuthStrategy",
+                "value": "boolean",
+                "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
+                "isOptional": true,
+                "defaultValue": "false"
+              },
+              {
+                "filePath": "src/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_optionalScopesApi",
+                "value": "boolean",
+                "description": "When enabled, the `optionalScopes` API will be available.",
+                "isOptional": true,
+                "defaultValue": "false"
+              }
+            ],
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the `optionalScopes` API will be available.\n   *\n   * @default false\n   */\n  unstable_optionalScopesApi?: boolean;\n}"
+          },
+          "EmbeddedTypedAdminContext": {
+            "filePath": "src/server/authenticate/admin/types.ts",
+            "importMap": {
+              "JwtPayload": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
+              "AppConfigArg": "src/server/config-types.ts",
+              "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
+              "BillingContext": "src/server/authenticate/admin/billing/types.ts",
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "EmbeddedTypedAdminContext",
             "value": "Config['isEmbeddedApp'] extends false\n  ? NonEmbeddedAdminContext<Config, Resources>\n  : EmbeddedAdminContext<Config, Resources>",
             "description": ""
           },
@@ -8149,8 +8331,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "NonEmbeddedAdminContext",
             "description": "",
@@ -9306,8 +9490,10 @@
               "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
               "AppConfigArg": "src/server/config-types.ts",
               "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
               "BillingContext": "src/server/authenticate/admin/billing/types.ts",
-              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts"
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
             },
             "name": "EmbeddedAdminContext",
             "description": "",
@@ -9577,6 +9763,48 @@
               }
             ],
             "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
+          },
+          "ScopesContext": {
+            "filePath": "src/server/authenticate/admin/types.ts",
+            "importMap": {
+              "JwtPayload": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "EnsureCORSFunction": "src/server/authenticate/helpers/ensure-cors-headers.ts",
+              "AppConfigArg": "src/server/config-types.ts",
+              "AdminApiContext": "src/server/clients/index.ts",
+              "FeatureEnabled": "src/server/future/flags.ts",
+              "BillingContext": "src/server/authenticate/admin/billing/types.ts",
+              "RedirectFunction": "src/server/authenticate/admin/helpers/redirect.ts",
+              "ScopesApiContext": "src/server/authenticate/admin/scope/types.ts"
+            },
+            "name": "ScopesContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scopes",
+                "value": "ScopesApiContext",
+                "description": "Methods to manage optional scopes for the store that made the request."
+              }
+            ],
+            "value": "interface ScopesContext {\n  /**\n   * Methods to manage optional scopes for the store that made the request.\n   */\n  scopes: ScopesApiContext;\n}"
+          },
+          "ScopesApiContext": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "ScopesApiContext",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "request",
+                "value": "(scopes: string[]) => Promise<void>",
+                "description": ""
+              }
+            ],
+            "value": "export interface ScopesApiContext {\n  request: (scopes: string[]) => Promise<void>;\n}"
           },
           "RestResourcesType": {
             "filePath": "src/server/types.ts",
@@ -11192,6 +11420,31 @@
             ],
             "value": "export interface UnauthenticatedStorefrontContext {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use this to get shop specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.storefront(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Method for interacting with the Shopify GraphQL Storefront API for the given store.\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `storefront.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   *\n   * @example\n   * <caption>Handling GraphQL errors.</caption>\n   * <description>Catch `GraphqlQueryError` errors to see error messages from the API.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   try {\n   *     const response = await storefront.graphql(\n   *       `#graphql\n   *       query incorrectQuery {\n   *         products(first: 10) {\n   *           nodes {\n   *             not_a_field\n   *           }\n   *         }\n   *       }`,\n   *     );\n   *\n   *     return json({ data: await response.json() });\n   *   } catch (error) {\n   *     if (error instanceof GraphqlQueryError) {\n   *       // { errors: { graphQLErrors: [\n   *       //   { message: \"Field 'not_a_field' doesn't exist on type 'Product'\" }\n   *       // ] } }\n   *       return json({ errors: error.body?.errors }, { status: 500 });\n   *     }\n   *     return json({ message: \"An error occurred\" }, { status: 500 });\n   *   }\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
           },
+          "EnforceSessionStorage": {
+            "filePath": "src/server/types.ts",
+            "importMap": {
+              "RegisterReturn": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Shopify": "../shopify-api/dist/ts/lib/index.d.ts",
+              "ShopifyRestResources": "../shopify-api/dist/ts/lib/index.d.ts",
+              "SessionStorage": "../session-storage/shopify-app-session-storage/dist/ts/index.d.ts",
+              "AppConfig": "src/server/config-types.ts",
+              "AppConfigArg": "src/server/config-types.ts",
+              "AuthenticateWebhook": "src/server/authenticate/webhooks/types.ts",
+              "RegisterWebhooksOptions": "src/server/authenticate/webhooks/types.ts",
+              "AuthenticatePublic": "src/server/authenticate/public/types.ts",
+              "AuthenticateAdmin": "src/server/authenticate/admin/types.ts",
+              "Unauthenticated": "src/server/unauthenticated/types.ts",
+              "AuthenticateFlow": "src/server/authenticate/flow/types.ts",
+              "ApiConfigWithFutureFlags": "src/server/future/flags.ts",
+              "ApiFutureFlags": "src/server/future/flags.ts",
+              "FutureFlagOptions": "src/server/future/flags.ts",
+              "AuthenticateFulfillmentService": "src/server/authenticate/fulfillment-service/types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "EnforceSessionStorage",
+            "value": "Config['distribution'] extends AppDistribution.ShopifyAdmin\n  ? Base\n  : Base & {sessionStorage: SessionStorageType<Config>}",
+            "description": ""
+          },
           "SingleMerchantApp": {
             "filePath": "src/server/types.ts",
             "importMap": {
@@ -11735,7 +11988,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "sessionStorage",
                 "value": "Storage",
-                "description": "An adaptor for storing sessions in your database of choice.\n\nShopify provides multiple session storage adaptors and you can create your own.\n\n\n\n\n",
+                "description": "An adaptor for storing sessions in your database of choice.\n\nShopify provides multiple session storage adaptors and you can create your own.\n\nOptional for apps created in the Shopify Admin.\n\n\n\n\n",
                 "isOptional": true,
                 "examples": [
                   {
@@ -11788,7 +12041,7 @@
                 ]
               }
             ],
-            "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n  Future extends FutureFlagOptions = FutureFlagOptions,\n> extends Omit<\n    ApiConfigArg<Resources, ApiFutureFlags<Future>>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n    | 'future'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage?: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * AppStore should be used for public apps that are distributed in the Shopify App Store.\n   * SingleMerchant should be used for custom apps managed in the Partner Dashboard.\n   * ShopifyAdmin should be used for apps that are managed in the merchant's Shopify Admin.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n\n  /**\n   * Features that will be introduced in future releases of this package.\n   *\n   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future\n   * releases in advance and provide feedback on the new features.\n   */\n  future?: Future;\n}"
+            "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n  Future extends FutureFlagOptions = FutureFlagOptions,\n> extends Omit<\n    ApiConfigArg<Resources, ApiFutureFlags<Future>>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n    | 'future'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * Optional for apps created in the Shopify Admin.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage?: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * AppStore should be used for public apps that are distributed in the Shopify App Store.\n   * SingleMerchant should be used for custom apps managed in the Partner Dashboard.\n   * ShopifyAdmin should be used for apps that are managed in the merchant's Shopify Admin.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n\n  /**\n   * Features that will be introduced in future releases of this package.\n   *\n   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future\n   * releases in advance and provide feedback on the new features.\n   */\n  future?: Future;\n}"
           },
           "BillingConfig": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -11827,53 +12080,6 @@
             "name": "BillingConfigItem",
             "value": "FeatureEnabled<Future, 'lineItemBilling'> extends true ? BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan : BillingConfigLegacyItem",
             "description": ""
-          },
-          "FeatureEnabled": {
-            "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
-            "importMap": {
-              "ShopifyLogger": "../shopify-api/dist/ts/lib/logger/index.d.ts",
-              "ConfigInterface": "../shopify-api/dist/ts/lib/base-types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "FeatureEnabled",
-            "value": "Future extends FutureFlags ? Future[Flag] extends true ? true : false : false",
-            "description": ""
-          },
-          "FutureFlags": {
-            "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
-            "importMap": {
-              "ShopifyLogger": "../shopify-api/dist/ts/lib/logger/index.d.ts",
-              "ConfigInterface": "../shopify-api/dist/ts/lib/base-types.d.ts"
-            },
-            "name": "FutureFlags",
-            "description": "Future flags are used to enable features that are not yet available by default.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "customerAddressDefaultFix",
-                "value": "boolean",
-                "description": "Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This resolves a conflict with the default() method in that class.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItemBilling",
-                "value": "boolean",
-                "description": "Enable line item billing, to make billing configuration more similar to the GraphQL API.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "v10_lineItemBilling",
-                "value": "boolean",
-                "description": "Enable line item billing, to make billing configuration more similar to the GraphQL API. Default enabling of this feature has been moved to v11. Use lineItemBilling instead.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface FutureFlags {\n    /**\n     * Enable line item billing, to make billing configuration more similar to the GraphQL API. Default enabling of this\n     * feature has been moved to v11. Use lineItemBilling instead.\n     */\n    v10_lineItemBilling?: boolean;\n    /**\n     * Enable line item billing, to make billing configuration more similar to the GraphQL API.\n     */\n    lineItemBilling?: boolean;\n    /**\n     * Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This\n     * resolves a conflict with the default() method in that class.\n     */\n    customerAddressDefaultFix?: boolean;\n}"
           },
           "BillingConfigOneTimePlan": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -12436,9 +12642,18 @@
                 "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
                 "isOptional": true,
                 "defaultValue": "false"
+              },
+              {
+                "filePath": "src/server/future/flags.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_optionalScopesApi",
+                "value": "boolean",
+                "description": "When enabled, the `optionalScopes` API will be available.",
+                "isOptional": true,
+                "defaultValue": "false"
               }
             ],
-            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n}"
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the `optionalScopes` API will be available.\n   *\n   * @default false\n   */\n  unstable_optionalScopesApi?: boolean;\n}"
           }
         }
       }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -156,7 +156,7 @@ export function authStrategyFactory<
 
       logger.debug('Loading session from storage', {sessionId});
       const existingSession = sessionId
-        ? await config.sessionStorage.loadSession(sessionId)
+        ? await config.sessionStorage!.loadSession(sessionId)
         : undefined;
 
       const session = await strategy.authenticate(request, {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
@@ -197,7 +197,7 @@ export class AuthCodeFlowStrategy<
         rawRequest: request,
       });
 
-      await config.sessionStorage.storeSession(session);
+      await config.sessionStorage!.storeSession(session);
 
       if (config.useOnlineTokens && !session.isOnline) {
         logger.info('Requesting online access token for offline session');
@@ -227,7 +227,7 @@ export class AuthCodeFlowStrategy<
     request: Request,
   ): Promise<Session | undefined> {
     const offlineId = await this.getOfflineSessionId(request);
-    return this.config.sessionStorage.loadSession(offlineId!);
+    return this.config.sessionStorage!.loadSession(offlineId!);
   }
 
   private async hasValidOfflineId(request: Request) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -61,7 +61,7 @@ export class TokenExchangeStrategy<Config extends AppConfigArg>
         requestedTokenType: RequestedTokenType.OfflineAccessToken,
       });
 
-      await config.sessionStorage.storeSession(offlineSession);
+      await config.sessionStorage!.storeSession(offlineSession);
 
       let newSession = offlineSession;
 
@@ -74,7 +74,7 @@ export class TokenExchangeStrategy<Config extends AppConfigArg>
           requestedTokenType: RequestedTokenType.OnlineAccessToken,
         });
 
-        await config.sessionStorage.storeSession(onlineSession);
+        await config.sessionStorage!.storeSession(onlineSession);
         newSession = onlineSession;
       }
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
@@ -48,7 +48,7 @@ export function authenticateFlowFactory<
     });
 
     const sessionId = api.session.getOfflineId(payload.shopify_domain);
-    const session = await config.sessionStorage.loadSession(sessionId);
+    const session = await config.sessionStorage!.loadSession(sessionId);
 
     if (!session) {
       logger.info('Flow request could not find session', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
@@ -1,7 +1,7 @@
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
 
-import {shopifyApp} from '../../..';
+import {AppDistribution, shopifyApp} from '../../..';
 import {
   expectAdminApiClient,
   getHmac,
@@ -14,116 +14,126 @@ import {
 const FULFILLMENT_URL =
   'https://example.myapp.io/authenticate/fulfillment_order_notification';
 
-describe('authenticating fulfillment service notification requests', () => {
-  it('throws a 405 response if the request method is not POST', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
+const TEST_CONFIGS = {
+  distribution: AppDistribution.ShopifyAdmin,
+  adminApiAccessToken: 'shpat_accesstoken',
+  sessionStorage: undefined,
+};
 
-    // WHEN
-    const response = await getThrownResponse(
-      shopify.authenticate.fulfillmentService,
-      new Request(FULFILLMENT_URL, {method: 'GET'}),
-    );
+[true, false].forEach((isMerchantCustomApp) => {
+  const isCustomApp = isMerchantCustomApp ? 'Merchant Custom App' : 'Public';
+  describe(`authenticating fulfillment service notification requests for ${isCustomApp}`, () => {
+    it('throws a 405 response if the request method is not POST', async () => {
+      // GIVEN
+      const config = isMerchantCustomApp ? TEST_CONFIGS : {};
+      const shopify = shopifyApp(testConfig(config));
 
-    // THEN
-    expect(response.status).toBe(405);
-    expect(response.statusText).toBe('Method not allowed');
-  });
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.fulfillmentService,
+        new Request(FULFILLMENT_URL, {method: 'GET'}),
+      );
 
-  it('throws a 400 response if the is missing the HMAC signature', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
+      // THEN
+      expect(response.status).toBe(405);
+      expect(response.statusText).toBe('Method not allowed');
+    });
 
-    // WHEN
-    const response = await getThrownResponse(
-      shopify.authenticate.fulfillmentService,
-      new Request(FULFILLMENT_URL, {method: 'POST'}),
-    );
+    it('throws a 400 response if the is missing the HMAC signature', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
 
-    // THEN
-    expect(response.status).toBe(400);
-    expect(response.statusText).toBe('Bad Request');
-  });
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.fulfillmentService,
+        new Request(FULFILLMENT_URL, {method: 'POST'}),
+      );
 
-  it('throws a 400 response if the request has an invalid HMAC signature', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
+      // THEN
+      expect(response.status).toBe(400);
+      expect(response.statusText).toBe('Bad Request');
+    });
 
-    // WHEN
-    const response = await getThrownResponse(
-      shopify.authenticate.fulfillmentService,
-      new Request(FULFILLMENT_URL, {
-        method: 'POST',
-        headers: {
-          'X-Shopify-Hmac-Sha256': 'not-the-right-signature',
-        },
-      }),
-    );
+    it('throws a 400 response if the request has an invalid HMAC signature', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
 
-    // THEN
-    expect(response.status).toBe(400);
-    expect(response.statusText).toBe('Bad Request');
-  });
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.fulfillmentService,
+        new Request(FULFILLMENT_URL, {
+          method: 'POST',
+          headers: {
+            'X-Shopify-Hmac-Sha256': 'not-the-right-signature',
+          },
+        }),
+      );
 
-  it('throws a 400 response if there is no session for the shop', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
-    const body = {kind: 'FULFILLMENT_REQUEST'};
+      // THEN
+      expect(response.status).toBe(400);
+      expect(response.statusText).toBe('Bad Request');
+    });
 
-    // WHEN
-    const response = await getThrownResponse(
-      shopify.authenticate.fulfillmentService,
-      new Request(FULFILLMENT_URL, {
-        body: JSON.stringify(body),
-        method: 'POST',
-        headers: {
-          'X-Shopify-Hmac-Sha256': getHmac(JSON.stringify(body)),
-          'X-Shopify-Shop-Domain': 'not-a-real-shop.myshopify.com',
-        },
-      }),
-    );
+    it('throws a 400 response if there is no session for the shop', async () => {
+      // GIVEN
+      const shopify = shopifyApp(testConfig());
+      const body = {kind: 'FULFILLMENT_REQUEST'};
 
-    // THEN
-    expect(response.status).toBe(400);
-    expect(response.statusText).toBe('Bad Request');
-  });
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.fulfillmentService,
+        new Request(FULFILLMENT_URL, {
+          body: JSON.stringify(body),
+          method: 'POST',
+          headers: {
+            'X-Shopify-Hmac-Sha256': getHmac(JSON.stringify(body)),
+            'X-Shopify-Shop-Domain': 'not-a-real-shop.myshopify.com',
+          },
+        }),
+      );
 
-  it('valid requests with a session succeed', async () => {
-    // GIVEN
-    const sessionStorage = new MemorySessionStorage();
-    const shopify = shopifyApp(testConfig({sessionStorage}));
+      // THEN
+      expect(response.status).toBe(400);
+      expect(response.statusText).toBe('Bad Request');
+    });
 
-    const {
-      request,
-      body,
-      session: expectedSession,
-    } = await getValidRequest(sessionStorage);
-
-    // WHEN
-    const {session, payload} =
-      await shopify.authenticate.fulfillmentService(request);
-
-    // THEN
-    expect(session).toEqual(expectedSession);
-    expect(payload.kind).toBe(body.kind);
-  });
-
-  describe('valid requests include an API client object', () => {
-    expectAdminApiClient(async () => {
+    it('valid requests with a session succeed', async () => {
+      // GIVEN
       const sessionStorage = new MemorySessionStorage();
       const shopify = shopifyApp(testConfig({sessionStorage}));
 
-      const {request, session: expectedSession} =
-        await getValidRequest(sessionStorage);
+      const {
+        request,
+        body,
+        session: expectedSession,
+      } = await getValidRequest(sessionStorage);
 
-      const {admin, session: actualSession} =
+      // WHEN
+      const {session, payload} =
         await shopify.authenticate.fulfillmentService(request);
 
-      if (!admin) {
-        throw new Error('No admin client');
-      }
+      // THEN
+      expect(session).toEqual(expectedSession);
+      expect(payload.kind).toBe(body.kind);
+    });
 
-      return {admin, expectedSession, actualSession};
+    describe('valid requests include an API client object', () => {
+      expectAdminApiClient(async () => {
+        const sessionStorage = new MemorySessionStorage();
+        const shopify = shopifyApp(testConfig({sessionStorage}));
+
+        const {request, session: expectedSession} =
+          await getValidRequest(sessionStorage);
+
+        const {admin, session: actualSession} =
+          await shopify.authenticate.fulfillmentService(request);
+
+        if (!admin) {
+          throw new Error('No admin client');
+        }
+
+        return {admin, expectedSession, actualSession};
+      });
     });
   });
 });

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
@@ -14,7 +14,7 @@ import {
 const FULFILLMENT_URL =
   'https://example.myapp.io/authenticate/fulfillment_order_notification';
 
-const TEST_CONFIGS = {
+const MERCHANT_CUSTOM_APP_CONFIG = {
   distribution: AppDistribution.ShopifyAdmin,
   adminApiAccessToken: 'shpat_accesstoken',
   sessionStorage: undefined,
@@ -25,7 +25,7 @@ const TEST_CONFIGS = {
   describe(`authenticating fulfillment service notification requests for ${isCustomApp}`, () => {
     it('throws a 405 response if the request method is not POST', async () => {
       // GIVEN
-      const config = isMerchantCustomApp ? TEST_CONFIGS : {};
+      const config = isMerchantCustomApp ? MERCHANT_CUSTOM_APP_CONFIG : {};
       const shopify = shopifyApp(testConfig(config));
 
       // WHEN

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
@@ -2,7 +2,7 @@ import {ShopifyRestResources, ShopifyHeader} from '@shopify/shopify-api';
 
 import {adminClientFactory} from '../../clients/admin';
 import {BasicParams} from '../../types';
-import {loadSession} from '../helpers';
+import {createOrLoadOfflineSession} from '../helpers';
 
 import type {
   AuthenticateFulfillmentService,
@@ -57,7 +57,7 @@ export function authenticateFulfillmentServiceFactory<
       },
     );
 
-    const session = await loadSession(shop, params);
+    const session = await createOrLoadOfflineSession(shop, params);
 
     if (!session) {
       logger.info('Fulfillment service request could not find session', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
@@ -2,6 +2,7 @@ import {ShopifyRestResources, ShopifyHeader} from '@shopify/shopify-api';
 
 import {adminClientFactory} from '../../clients/admin';
 import {BasicParams} from '../../types';
+import {loadSession} from '../helpers';
 
 import type {
   AuthenticateFulfillmentService,
@@ -11,7 +12,7 @@ import type {
 export function authenticateFulfillmentServiceFactory<
   Resources extends ShopifyRestResources = ShopifyRestResources,
 >(params: BasicParams): AuthenticateFulfillmentService<Resources> {
-  const {api, config, logger} = params;
+  const {api, logger} = params;
 
   return async function authenticate(
     request: Request,
@@ -56,8 +57,7 @@ export function authenticateFulfillmentServiceFactory<
       },
     );
 
-    const sessionId = api.session.getOfflineId(shop);
-    const session = await config.sessionStorage.loadSession(sessionId);
+    const session = await loadSession(shop, params);
 
     if (!session) {
       logger.info('Fulfillment service request could not find session', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/create-or-load-offline-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/create-or-load-offline-session.ts
@@ -1,6 +1,6 @@
 import {AppDistribution, BasicParams} from '../../types';
 
-export async function loadSession(
+export async function createOrLoadOfflineSession(
   shop: string,
   {api, config, logger}: BasicParams,
 ) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
@@ -7,3 +7,4 @@ export * from './invalidate-access-token';
 export * from './reject-bot-request';
 export * from './respond-to-options-request';
 export * from './respond-to-invalid-session-token';
+export * from './load-session';

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
@@ -7,4 +7,4 @@ export * from './invalidate-access-token';
 export * from './reject-bot-request';
 export * from './respond-to-options-request';
 export * from './respond-to-invalid-session-token';
-export * from './load-session';
+export * from './create-or-load-offline-session';

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/invalidate-access-token.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/invalidate-access-token.ts
@@ -11,5 +11,5 @@ export async function invalidateAccessToken(
   logger.debug(`Invalidating access token for session - ${session.id}`);
 
   session.accessToken = undefined;
-  await config.sessionStorage.storeSession(session);
+  await config.sessionStorage!.storeSession(session);
 }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/load-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/load-session.ts
@@ -1,0 +1,17 @@
+import {AppDistribution, BasicParams} from '../../types';
+
+export async function loadSession(
+  shop: string,
+  {api, config, logger}: BasicParams,
+) {
+  if (config.distribution === AppDistribution.ShopifyAdmin) {
+    logger.debug('Creating custom app session from configured access token');
+    return api.session.customAppSession(shop);
+  } else {
+    logger.debug('Loading offline session from session storage');
+    const offlineSessionId = api.session.getOfflineId(shop);
+    const session = await config.sessionStorage!.loadSession(offlineSessionId);
+
+    return session;
+  }
+}

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -32,7 +32,7 @@ export function authenticateAppProxyFactory<
 
     const shop = url.searchParams.get('shop')!;
     const sessionId = api.session.getOfflineId(shop);
-    const session = await config.sessionStorage.loadSession(sessionId);
+    const session = await config.sessionStorage!.loadSession(sessionId);
 
     if (!session) {
       logger.debug('Could not find offline session, returning empty context', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
@@ -6,6 +6,7 @@ import {
 import type {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients';
 import {handleClientErrorFactory} from '../admin/helpers';
+import {loadSession} from '../helpers';
 
 import type {
   AuthenticateWebhook,
@@ -17,7 +18,7 @@ export function authenticateWebhookFactory<
   Resources extends ShopifyRestResources,
   Topics extends string,
 >(params: BasicParams): AuthenticateWebhook<Resources, Topics> {
-  const {api, config, logger} = params;
+  const {api, logger} = params;
 
   return async function authenticate(
     request: Request,
@@ -52,9 +53,7 @@ export function authenticateWebhookFactory<
         throw new Response(undefined, {status: 400, statusText: 'Bad Request'});
       }
     }
-
-    const sessionId = api.session.getOfflineId(check.domain);
-    const session = await config.sessionStorage.loadSession(sessionId);
+    const session = await loadSession(check.domain, params);
     const webhookContext: WebhookContextWithoutSession<Topics> = {
       apiVersion: check.apiVersion,
       shop: check.domain,

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
@@ -6,7 +6,7 @@ import {
 import type {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients';
 import {handleClientErrorFactory} from '../admin/helpers';
-import {loadSession} from '../helpers';
+import {createOrLoadOfflineSession} from '../helpers';
 
 import type {
   AuthenticateWebhook,
@@ -53,7 +53,7 @@ export function authenticateWebhookFactory<
         throw new Response(undefined, {status: 400, statusText: 'Bad Request'});
       }
     }
-    const session = await loadSession(check.domain, params);
+    const session = await createOrLoadOfflineSession(check.domain, params);
     const webhookContext: WebhookContextWithoutSession<Topics> = {
       apiVersion: check.apiVersion,
       shop: check.domain,

--- a/packages/apps/shopify-app-remix/src/server/config-types.ts
+++ b/packages/apps/shopify-app-remix/src/server/config-types.ts
@@ -60,7 +60,7 @@ export interface AppConfigArg<
    * export default shopify;
    * ```
    */
-  sessionStorage: Storage;
+  sessionStorage?: Storage;
 
   /**
    * Whether your app use online or offline tokens.
@@ -238,7 +238,7 @@ export interface AppConfig<Storage extends SessionStorage = SessionStorage>
   canUseLoginForm: boolean;
   appUrl: string;
   auth: AuthConfig;
-  sessionStorage: Storage;
+  sessionStorage?: Storage;
   useOnlineTokens: boolean;
   hooks: HooksConfig;
   future: FutureFlags;

--- a/packages/apps/shopify-app-remix/src/server/config-types.ts
+++ b/packages/apps/shopify-app-remix/src/server/config-types.ts
@@ -42,6 +42,8 @@ export interface AppConfigArg<
    *
    * Shopify provides multiple session storage adaptors and you can create your own.
    *
+   * Optional for apps created in the Shopify Admin.
+   *
    * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}
    *
    * @example

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -181,7 +181,10 @@ function deriveConfig<Storage extends SessionStorage>(
   appConfig: AppConfigArg,
   apiConfig: ApiConfig,
 ): AppConfig<Storage> {
-  if (!appConfig.sessionStorage) {
+  if (
+    !appConfig.sessionStorage &&
+    appConfig.distribution !== AppDistribution.ShopifyAdmin
+  ) {
     throw new ShopifyError(
       'Please provide a valid session storage. Refer to https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options for options.',
     );

--- a/packages/apps/shopify-app-remix/src/server/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/types.ts
@@ -276,7 +276,7 @@ export interface ShopifyAppBase<Config extends AppConfigArg> {
    * // shopify.sessionStorage is an instance of PrismaSessionStorage
    * ```
    */
-  sessionStorage: SessionStorageType<Config>;
+  sessionStorage?: SessionStorageType<Config>;
 
   /**
    * Adds the required Content Security Policy headers for Shopify apps to the given Headers object.
@@ -495,6 +495,13 @@ export type SingleMerchantApp<Config extends AppConfigArg> =
 export type AppStoreApp<Config extends AppConfigArg> = ShopifyAppBase<Config> &
   ShopifyAppLogin;
 
+type EnforceSessionStorage<
+  Config extends AppConfigArg,
+  Base,
+> = Config['distribution'] extends AppDistribution.ShopifyAdmin
+  ? Base
+  : Base & {sessionStorage: SessionStorageType<Config>};
+
 /**
  * An object your app can use to interact with Shopify.
  *
@@ -504,7 +511,7 @@ export type ShopifyApp<Config extends AppConfigArg> =
   Config['distribution'] extends AppDistribution.ShopifyAdmin
     ? AdminApp<Config>
     : Config['distribution'] extends AppDistribution.SingleMerchant
-      ? SingleMerchantApp<Config>
+      ? EnforceSessionStorage<Config, SingleMerchantApp<Config>>
       : Config['distribution'] extends AppDistribution.AppStore
-        ? AppStoreApp<Config>
-        : AppStoreApp<Config>;
+        ? EnforceSessionStorage<Config, AppStoreApp<Config>>
+        : EnforceSessionStorage<Config, AppStoreApp<Config>>;

--- a/packages/apps/shopify-app-remix/src/server/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/types.ts
@@ -495,12 +495,9 @@ export type SingleMerchantApp<Config extends AppConfigArg> =
 export type AppStoreApp<Config extends AppConfigArg> = ShopifyAppBase<Config> &
   ShopifyAppLogin;
 
-type EnforceSessionStorage<
-  Config extends AppConfigArg,
-  Base,
-> = Config['distribution'] extends AppDistribution.ShopifyAdmin
-  ? Base
-  : Base & {sessionStorage: SessionStorageType<Config>};
+type EnforceSessionStorage<Config extends AppConfigArg, Base> = Base & {
+  sessionStorage: SessionStorageType<Config>;
+};
 
 /**
  * An object your app can use to interact with Shopify.

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
@@ -1,9 +1,14 @@
-import {SessionNotFoundError, shopifyApp} from '../../../index';
+import {
+  AppDistribution,
+  SessionNotFoundError,
+  shopifyApp,
+} from '../../../index';
 import {
   TEST_SHOP,
   setUpValidSession,
   testConfig,
   expectAdminApiClient,
+  setupValidCustomAppSession,
 } from '../../../__test-helpers';
 
 describe('unauthenticated admin context', () => {
@@ -22,6 +27,23 @@ describe('unauthenticated admin context', () => {
     const expectedSession = await setUpValidSession(shopify.sessionStorage, {
       isOnline: false,
     });
+    const {admin, session: actualSession} =
+      await shopify.unauthenticated.admin(TEST_SHOP);
+
+    return {admin, expectedSession, actualSession};
+  });
+});
+
+describe('unauthenticated admin context for merchant custom apps', () => {
+  expectAdminApiClient(async () => {
+    const shopify = shopifyApp(
+      testConfig({
+        distribution: AppDistribution.ShopifyAdmin,
+        adminApiAccessToken: 'admin-access-token',
+        sessionStorage: undefined,
+      }),
+    );
+    const expectedSession = setupValidCustomAppSession(TEST_SHOP);
     const {admin, session: actualSession} =
       await shopify.unauthenticated.admin(TEST_SHOP);
 

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
@@ -1,13 +1,13 @@
 import {Session} from '@shopify/shopify-api';
 
-import {loadSession} from '../../authenticate/helpers/load-session';
+import {createOrLoadOfflineSession} from '../../authenticate/helpers/create-or-load-offline-session';
 import {BasicParams} from '../../types';
 
 export async function getOfflineSession(
   shop: string,
   params: BasicParams,
 ): Promise<Session | undefined> {
-  const session = await loadSession(shop, params);
+  const session = await createOrLoadOfflineSession(shop, params);
 
   return session;
 }

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/helpers/get-offline-session.ts
@@ -1,13 +1,13 @@
 import {Session} from '@shopify/shopify-api';
 
+import {loadSession} from '../../authenticate/helpers/load-session';
 import {BasicParams} from '../../types';
 
 export async function getOfflineSession(
   shop: string,
-  {api, config}: BasicParams,
+  params: BasicParams,
 ): Promise<Session | undefined> {
-  const offlineSessionId = api.session.getOfflineId(shop);
-  const session = await config.sessionStorage.loadSession(offlineSessionId);
+  const session = await loadSession(shop, params);
 
   return session;
 }

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
@@ -1,9 +1,10 @@
-import {shopifyApp} from '../../../index';
+import {AppDistribution, shopifyApp} from '../../../index';
 import {
   TEST_SHOP,
   setUpValidSession,
   testConfig,
   expectStorefrontApiClient,
+  setupValidCustomAppSession,
 } from '../../../__test-helpers';
 
 describe('unauthenticated storefront context', () => {
@@ -22,6 +23,23 @@ describe('unauthenticated storefront context', () => {
     const expectedSession = await setUpValidSession(shopify.sessionStorage, {
       isOnline: false,
     });
+    const {storefront, session: actualSession} =
+      await shopify.unauthenticated.storefront(TEST_SHOP);
+
+    return {storefront, expectedSession, actualSession};
+  });
+});
+
+describe('unauthenticated storefront context for merchant custom apps', () => {
+  expectStorefrontApiClient(async () => {
+    const shopify = shopifyApp(
+      testConfig({
+        distribution: AppDistribution.ShopifyAdmin,
+        adminApiAccessToken: 'admin-access-token',
+        privateAppStorefrontAccessToken: 'storefront-access',
+      }),
+    );
+    const expectedSession = setupValidCustomAppSession(TEST_SHOP);
     const {storefront, session: actualSession} =
       await shopify.unauthenticated.storefront(TEST_SHOP);
 


### PR DESCRIPTION
(cherry picked from commit 9bf0e069a4e1b4c33359934aa0f451345756cb36)

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Continuation of [Improvements for custom Remix apps](https://github.com/Shopify/first-party-library-planning/issues/586)

Related [PR](https://github.com/Shopify/shopify-app-js/pull/1085)

### How was this tested
I tested that using this branch you are able to remove session storage, and authenticate a webhook request correctly for a merchant custom app.

### WHAT is this pull request doing?
* For merchant custom apps when we need a session we build it out of the configured access tokens provided in the `shopifyApp` config.

* This PR adds a helper function to either load the session from storage or in the case of merchant custom apps to create it from the configured tokens.


## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ x I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
