### PR TITLE
[FIX] Remix Polaris Link not allowing target _blank

### DIFF
--- a/.changeset/lovely-buses-glow.md
+++ b/.changeset/lovely-buses-glow.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': major
+---
+
+Fixes RemixPolarisLink blocking \_blank targets

--- a/packages/apps/shopify-app-remix/src/react/components/RemixPolarisLink.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/RemixPolarisLink.tsx
@@ -9,6 +9,24 @@ import type {
 export const RemixPolarisLink = React.forwardRef<
   HTMLAnchorElement,
   LinkLikeComponentProps
->((props, ref) => (
-  <Link {...props} to={props.url ?? props.to} ref={ref} />
-)) as LinkLikeComponent;
+>((props, ref) => {
+  const {url, external, ...otherProps} = props;
+
+  // Handle external links with target="_blank"
+  if (url && external) {
+    return (
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        {...otherProps}
+        ref={ref}
+      >
+        {props.children}
+      </a>
+    );
+  }
+
+  // Use Remix Link for internal routing
+  return <Link {...otherProps} to={url ?? props.to} ref={ref} />;
+}) as LinkLikeComponent;


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1153 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

By default, the AppProvider component from @shopify/shopify-app-remix overrides the standard Link component used for routing.
Polaris' Button component, when used with a url prop and set to open externally, relies on an internal UnstyledLink component.
This RemixPolarisLink component acts as an intermediary between Remix's Link and Polaris' Button to ensure external links open in a new tab.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
