### PR TITLE
Add Headers to GraphQL client response

### DIFF
--- a/.changeset/unlucky-donuts-juggle.md
+++ b/.changeset/unlucky-donuts-juggle.md
@@ -1,0 +1,21 @@
+---
+'@shopify/graphql-client': minor
+'@shopify/shopify-app-remix': minor
+'@shopify/shopify-api': minor
+---
+
+Return headers in responses from GraphQL client.
+
+Headers are now returned in the response object from the GraphQL client.
+
+In apps using the `@shopify/shopify-app-remix` package the headers can be access as follows:
+```ts
+  const response = await admin.graphql(
+    ...
+
+  const responseJson = await response.json();
+  const responseHeaders = responseJson.headers
+  const xRequestID = responseHeaders? responseHeaders["X-Request-Id"] : '';
+  console.log(responseHeaders);
+  console.log(xRequestID, 'x-request-id');
+```

--- a/packages/api-clients/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/graphql-client.ts
@@ -77,13 +77,15 @@ export function generateClientLogger(logger?: Logger): Logger {
 }
 
 async function processJSONResponse<TData = any>(
-  response: any,
+  response: Response,
 ): Promise<ClientResponse<TData>> {
-  const {errors, data, extensions} = await response.json();
+  const {errors, data, extensions} = await response.json<any>();
 
   return {
     ...getKeyValueIfValid('data', data),
     ...getKeyValueIfValid('extensions', extensions),
+    headers: response.headers,
+
     ...(errors || !data
       ? {
           errors: {

--- a/packages/api-clients/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/tests/graphql-client/client-fetch-request.test.ts
@@ -391,6 +391,30 @@ describe('GraphQL Client', () => {
           expect(response).toHaveProperty('data', mockResponseData.data);
         });
 
+        it('includes headers if headers are included in the response.', async () => {
+          const headers = {
+            'content-type': 'application/json',
+            'x-request-id': '1234',
+          };
+          const mockResponseData = {
+            data: {shop: {name: 'Test shop'}},
+            headers,
+          };
+          const mockedSuccessResponse = new Response(
+            JSON.stringify(mockResponseData),
+            {
+              status: 200,
+              headers: new Headers(headers),
+            },
+          );
+
+          fetchMock.mockResolvedValue(mockedSuccessResponse);
+
+          const response = await client.request(operation, {variables});
+          console.log(response, 'RESPONSE IN TEST');
+          expect(response).toHaveProperty('headers', new Headers(headers));
+        });
+
         it('includes an API extensions object if it is included in the response', async () => {
           const extensions = {
             context: {

--- a/packages/api-clients/graphql-client/src/graphql-client/types.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/types.ts
@@ -11,7 +11,9 @@ type OperationVariables = Record<string, any>;
 
 export type DataChunk = Buffer | Uint8Array;
 
-export type Headers = Record<string, string | string[]>;
+type HeadersObject = Record<string, string | string[]>;
+
+export type {HeadersObject as Headers};
 
 export interface ResponseErrors {
   networkStatusCode?: number;
@@ -25,6 +27,7 @@ export type GQLExtensions = Record<string, any>;
 export interface FetchResponseBody<TData = any> {
   data?: TData;
   extensions?: GQLExtensions;
+  headers?: Headers;
 }
 
 export interface ClientResponse<TData = any> extends FetchResponseBody<TData> {
@@ -70,7 +73,7 @@ export type Logger<TLogContentTypes = LogContentTypes> = (
 ) => void;
 
 export interface ClientOptions {
-  headers: Headers;
+  headers: HeadersObject;
   url: string;
   customFetchApi?: CustomFetchApi;
   retries?: number;
@@ -86,7 +89,7 @@ export interface ClientConfig {
 export interface RequestOptions {
   variables?: OperationVariables;
   url?: string;
-  headers?: Headers;
+  headers?: HeadersObject;
   retries?: number;
 }
 

--- a/packages/apps/shopify-api/docs/reference/clients/Graphql.md
+++ b/packages/apps/shopify-api/docs/reference/clients/Graphql.md
@@ -91,7 +91,7 @@ const response = await client.request(
     },
   },
 );
-console.log(response.data, response.extensions);
+console.log(response.data, response.extensions, response.headers);
 ```
 
 > **Note**: If using TypeScript, you can pass in a type argument for the response body:
@@ -158,7 +158,7 @@ The maximum number of times to retry the request.
 
 ### Return
 
-`Promise<ClientResponse>`
+`Promise<GraphQLClientResponse>`
 
 Returns an object containing:
 
@@ -173,5 +173,9 @@ The [`data` component](https://shopify.dev/docs/api/admin/getting-started#graphq
 `any`
 
 The [`extensions` component](https://shopify.dev/docs/api/admin-graphql#rate_limits) of the response.
+
+#### Headers
+`Record<string, string | string[]>`
+The headers from the response.
 
 [Back to shopify.clients](./README.md)

--- a/packages/apps/shopify-api/lib/clients/admin/types.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/types.ts
@@ -1,4 +1,4 @@
-import {SearchParams} from '@shopify/admin-api-client';
+import {ClientResponse, SearchParams} from '@shopify/admin-api-client';
 
 import {ApiVersion} from '../../types';
 import {Session} from '../../session/session';
@@ -27,4 +27,9 @@ export interface RestRequestReturn<T = any> {
 export interface RestClientParams {
   session: Session;
   apiVersion?: ApiVersion;
+}
+
+export interface GraphQLClientResponse<TData = any>
+  extends Omit<ClientResponse<TData>, 'headers'> {
+  headers?: Headers;
 }

--- a/packages/apps/shopify-api/lib/clients/graphql_proxy/__tests__/graphql_proxy.test.ts
+++ b/packages/apps/shopify-api/lib/clients/graphql_proxy/__tests__/graphql_proxy.test.ts
@@ -15,6 +15,9 @@ const successResponse = {
       name: 'Shop',
     },
   },
+  headers: {
+    'Content-Type': ['application/json'],
+  },
 };
 const shopQuery = `{
   shop {

--- a/packages/apps/shopify-api/lib/webhooks/__tests__/responses.ts
+++ b/packages/apps/shopify-api/lib/webhooks/__tests__/responses.ts
@@ -132,6 +132,9 @@ export const successResponse = {
       userErrors: [],
     },
   },
+  headers: {
+    'Content-Type': ['application/json'],
+  },
 };
 
 export const eventBridgeSuccessResponse = {
@@ -139,6 +142,9 @@ export const eventBridgeSuccessResponse = {
     eventBridgeWebhookSubscriptionCreate: {
       userErrors: [],
     },
+  },
+  headers: {
+    'Content-Type': ['application/json'],
   },
 };
 
@@ -148,6 +154,9 @@ export const pubSubSuccessResponse = {
       userErrors: [],
     },
   },
+  headers: {
+    'Content-Type': ['application/json'],
+  },
 };
 
 export const successUpdateResponse = {
@@ -155,6 +164,9 @@ export const successUpdateResponse = {
     webhookSubscriptionUpdate: {
       userErrors: [],
     },
+  },
+  headers: {
+    'Content-Type': ['application/json'],
   },
 };
 
@@ -164,6 +176,9 @@ export const eventBridgeSuccessUpdateResponse = {
       userErrors: [],
     },
   },
+  headers: {
+    'Content-Type': ['application/json'],
+  },
 };
 
 export const pubSubSuccessUpdateResponse = {
@@ -172,6 +187,9 @@ export const pubSubSuccessUpdateResponse = {
       userErrors: [],
     },
   },
+  headers: {
+    'Content-Type': ['application/json'],
+  },
 };
 
 export const successDeleteResponse = {
@@ -179,6 +197,9 @@ export const successDeleteResponse = {
     webhookSubscriptionDelete: {
       userErrors: [],
     },
+  },
+  headers: {
+    'Content-Type': ['application/json'],
   },
 };
 
@@ -191,5 +212,8 @@ export const httpFailResponse = {
     webhookSubscriptionCreate: {
       userErrors: ['this is an error'],
     },
+  },
+  headers: {
+    'Content-Type': ['application/json'],
   },
 };

--- a/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -1081,7 +1081,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -1239,7 +1239,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -1348,7 +1348,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -1379,7 +1386,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -2849,7 +2856,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -3007,7 +3014,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -3341,7 +3348,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -3372,7 +3386,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -3888,7 +3902,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -3919,7 +3940,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -4594,7 +4615,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -4625,7 +4653,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -4905,7 +4933,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -4940,7 +4969,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -4984,7 +5014,7 @@
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
             "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    Unstable = \"unstable\"\n}",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
             "members": [
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -5020,6 +5050,11 @@
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
                 "name": "April24",
                 "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -6142,7 +6177,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -6173,7 +6215,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -6682,7 +6724,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -6717,7 +6760,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -6761,7 +6805,7 @@
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
             "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    Unstable = \"unstable\"\n}",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
             "members": [
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -6797,6 +6841,11 @@
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
                 "name": "April24",
                 "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -6955,7 +7004,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -6986,7 +7042,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -7547,7 +7603,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -7582,7 +7639,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -7626,7 +7684,7 @@
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
             "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    Unstable = \"unstable\"\n}",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
             "members": [
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -7662,6 +7720,11 @@
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
                 "name": "April24",
                 "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -8956,7 +9019,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -9114,7 +9177,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "isTest",
                 "value": "boolean",
-                "description": "Whether to consider test purchases.",
+                "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
                 "isOptional": true
               },
               {
@@ -9223,7 +9286,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -9254,7 +9324,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -10429,7 +10499,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -10464,7 +10535,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -10508,7 +10580,7 @@
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
             "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    Unstable = \"unstable\"\n}",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
             "members": [
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -10544,6 +10616,11 @@
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
                 "name": "April24",
                 "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -11442,7 +11519,7 @@
             },
             "syntaxKind": "TypeAliasDeclaration",
             "name": "EnforceSessionStorage",
-            "value": "Config['distribution'] extends AppDistribution.ShopifyAdmin\n  ? Base\n  : Base & {sessionStorage: SessionStorageType<Config>}",
+            "value": "Base & {\n  sessionStorage: SessionStorageType<Config>;\n}",
             "description": ""
           },
           "SingleMerchantApp": {
@@ -13006,7 +13083,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -13037,7 +13121,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -13520,7 +13604,14 @@
                 "syntaxKind": "MethodDeclaration",
                 "name": "isScopeChanged",
                 "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token has the given scopes."
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
@@ -13551,7 +13642,7 @@
                 "description": "Converts the session into an array of key-value pairs."
               }
             ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token has the given scopes.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
+            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
           },
           "OnlineAccessInfo": {
             "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
@@ -13831,7 +13922,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -13866,7 +13958,8 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -13910,7 +14003,7 @@
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
             "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    Unstable = \"unstable\"\n}",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
             "members": [
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -13946,6 +14039,11 @@
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
                 "name": "April24",
                 "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/types.d.ts",

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-admin-api-client.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-admin-api-client.ts
@@ -106,7 +106,10 @@ export function expectAdminApiClient(
 
     // THEN
     expect(response.status).toEqual(200);
-    expect(await response.json()).toEqual({data: {shop: {name: 'Test shop'}}});
+    expect(await response.json()).toEqual({
+      data: {shop: {name: 'Test shop'}},
+      headers: {'Content-Type': ['application/json']},
+    });
   });
 
   it('returns a session object as part of the context', async () => {

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-storefront-api-client.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-storefront-api-client.ts
@@ -16,7 +16,7 @@ export function expectStorefrontApiClient(
   it('Storefront client can perform GraphQL Requests', async () => {
     // GIVEN
     const {storefront, actualSession} = await factory();
-    const apiResponse = {data: {blogs: {nodes: [{id: 1}]}}};
+    const apiResponse = {data: {blogs: {nodes: [{id: 1}]}}, headers: {}};
     await mockExternalRequest({
       request: new Request(
         `https://${TEST_SHOP}/api/${LATEST_API_VERSION}/graphql.json`,

--- a/packages/apps/shopify-app-remix/src/server/clients/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/clients/types.ts
@@ -6,6 +6,7 @@ import type {
   ResponseWithType,
 } from '@shopify/admin-api-client';
 import {ApiVersion} from '@shopify/shopify-api';
+import {Headers} from '@shopify/shopify-api/runtime';
 
 export interface GraphQLQueryOptions<
   Operation extends keyof Operations,
@@ -29,10 +30,15 @@ export interface GraphQLQueryOptions<
   tries?: number;
 }
 
+export interface FetchResponse<TData = any>
+  extends Omit<FetchResponseBody<TData>, 'headers'> {
+  headers?: Headers;
+}
+
 export type GraphQLResponse<
   Operation extends keyof Operations,
   Operations extends AllOperations,
-> = ResponseWithType<FetchResponseBody<ReturnData<Operation, Operations>>>;
+> = ResponseWithType<FetchResponse<ReturnData<Operation, Operations>>>;
 
 export type GraphQLClient<Operations extends AllOperations> = <
   Operation extends keyof Operations,

--- a/packages/apps/shopify-app-remix/src/server/clients/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/clients/types.ts
@@ -6,7 +6,6 @@ import type {
   ResponseWithType,
 } from '@shopify/admin-api-client';
 import {ApiVersion} from '@shopify/shopify-api';
-import {Headers} from '@shopify/shopify-api/runtime';
 
 export interface GraphQLQueryOptions<
   Operation extends keyof Operations,
@@ -30,15 +29,10 @@ export interface GraphQLQueryOptions<
   tries?: number;
 }
 
-export interface FetchResponse<TData = any>
-  extends Omit<FetchResponseBody<TData>, 'headers'> {
-  headers?: Headers;
-}
-
 export type GraphQLResponse<
   Operation extends keyof Operations,
   Operations extends AllOperations,
-> = ResponseWithType<FetchResponse<ReturnData<Operation, Operations>>>;
+> = ResponseWithType<FetchResponseBody<ReturnData<Operation, Operations>>>;
 
 export type GraphQLClient<Operations extends AllOperations> = <
   Operation extends keyof Operations,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #637 

When we migrated to the new clients we no longer returned the headers for successful responses.
Even if a request is successful developers may need to access the headers for debugging.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
