### PR TITLE
Allow not filtering by plans in billing checks

### DIFF
--- a/.changeset/perfect-countries-tickle.md
+++ b/.changeset/perfect-countries-tickle.md
@@ -2,8 +2,8 @@
 '@shopify/shopify-api': minor
 ---
 
-Added a new future flag `unstable_managedPricingSupport`, which will:
+Added a new future flag `unstable_managedPricingSupport` to support apps using [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing), which will:
 
 - Change `billing.check` to always return an object.
 - Change `billing.check` and `billing.subscription` to work without a billing config.
-- Allow finding charges for apps using [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing) by calling the billing `check` function without a `plans` filter.
+- Allow calling charges with `billing.check` without a `plans` filter. The `hasActivePayment` value will be true if any purchases are found with the given filters.

--- a/.changeset/perfect-countries-tickle.md
+++ b/.changeset/perfect-countries-tickle.md
@@ -1,6 +1,9 @@
 ---
-'@shopify/shopify-app-remix': minor
 '@shopify/shopify-api': minor
 ---
 
-Allow finding charges for apps using [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing) by calling the billing `check` function without a `plans` filter.
+Added a new future flag `unstable_managedPricingSupport`, which will:
+
+- Change `billing.check` to always return an object.
+- Change `billing.check` and `billing.subscription` to work without a billing config.
+- Allow finding charges for apps using [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing) by calling the billing `check` function without a `plans` filter.

--- a/.changeset/perfect-countries-tickle.md
+++ b/.changeset/perfect-countries-tickle.md
@@ -1,0 +1,6 @@
+---
+'@shopify/shopify-app-remix': minor
+'@shopify/shopify-api': minor
+---
+
+Allow finding charges for apps using [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing) by calling the billing `check` function without a `plans` filter.

--- a/.changeset/stale-suns-sniff.md
+++ b/.changeset/stale-suns-sniff.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Change `billing.check` and `billing.subscription` to work without a billing config, so apps can use [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing).

--- a/packages/apps/shopify-api/docs/guides/billing.md
+++ b/packages/apps/shopify-api/docs/guides/billing.md
@@ -1,13 +1,27 @@
 # Configuring App Billing
 
-Some partners might wish to charge merchants for using their app.
-The Admin API provides endpoints that enable apps to trigger purchases in the Shopify platform, so that merchants can pay for apps as part of their Shopify payments.
+Some partners might wish to charge merchants for using their app. Shopify makes it possible to do that in two ways, so that merchants can pay for apps as part of their Shopify payments:
+
+- Using Shopify managed app pricing
+- Using the Admin billing API to trigger purchases in the Shopify platform.
+
+In this guide you'll learn how to use this package for both of those scenarios.
+
+## Using managed app pricing
+
+The easiest way to add billing to your app is to follow the [Shopify managed app pricing documentation](https://shopify.dev/docs/apps/launch/billing/managed-pricing). You can set up one or more plans for the app, and Shopify will host a page where merchants can select which plan they want.
+
+Since Shopify handles billing in this scenario, you don't have to add a `billing` setting to your configuration, but you can still use the [`check`](../reference/billing/check.md) method to get the plans for the current merchant.
+
+## Using the billing API
+
+If you'd prefer to have full control over billing, you can use the helpers in this package to interact with the billing API directly.
 
 See the [billing reference](../reference/billing/README.md) for details on how to call those endpoints, using this configuration.
 
 To trigger the billing behaviour, you'll need to set the `billing` value when calling `shopifyApi()`.
 
-## Configuring LineItem billing
+### Configuring LineItem billing
 
 With the future flag `v10_lineItemBilling`, the billing configuration can now specify the the `AppSubscriptionLineItems`. This will allow you to create app subscription plans with both recurring and usage based charges.
 
@@ -15,7 +29,8 @@ Subscription plans can have 1 or 2 line items. There can be a maximum of 1 of ea
 
 For configuring billing without line items see [Configuring Billing](#configuring-billing).
 
-### Configuring a Subscription Plan with a Single LineItem
+#### Configuring a Subscription Plan with a Single LineItem
+
 ```ts
 import {
   shopifyApi,
@@ -51,7 +66,8 @@ future: {
 });
 ```
 
-### Configuring a Subscription Plan with Multiple LineItems
+#### Configuring a Subscription Plan with Multiple LineItems
+
 ```ts
 import {
   shopifyApi,
@@ -93,7 +109,8 @@ future: {
 });
 ```
 
-### Configuring a one-time charge
+#### Configuring a one-time charge
+
 ```ts
 import {
   shopifyApi,
@@ -117,7 +134,7 @@ future: {
 });
 ```
 
-### Subscription Plan with LineItems
+#### Subscription Plan with LineItems
 
 | Parameter                           | Type                         | Required? | Default Value | Notes                                                                                                                                                                                  |
 | ----------------------------------- | ---------------------------- | :-------: | :-----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -125,8 +142,7 @@ future: {
 | `trialDays`                         | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                                          |
 | `replacementBehavior`               | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information.                       |
 
-
-### Recurring Charge LineItem
+#### Recurring Charge LineItem
 
 | Parameter                           | Type                         | Required? | Default Value | Notes                                                                                                                                                                                  |
 | ----------------------------------- | ---------------------------- | :-------: | :-----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -137,7 +153,7 @@ future: {
 | `discount.value.amount`             | `number`                     |    No     |       -       | The amount of the discount in the currency that the merchant is being billed in.                                                                                                       |
 | `discount.value.percentage`         | `number`                     |    No     |       -       | The percentage value of the discount.                                                                                                                                                  |
 
-### Usage Charge LineItem
+#### Usage Charge LineItem
 
 | Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                            |
 | --------------------- | ---------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -146,9 +162,7 @@ future: {
 | `currencyCode`        | `string`                     |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup>                                                                                              |
 | `usageTerms`          | `string`                     |    Yes    |       -       | These terms stipulate the pricing model for the charges that an app creates.                                                                                     |
 
-
-
-### One Time Billing Plans
+#### One Time Billing Plans
 
 | Parameter      | Type       | Required? | Default Value | Notes                                                               |
 | -------------- | ---------- | :-------: | :-----------: | ------------------------------------------------------------------- |
@@ -156,7 +170,7 @@ future: {
 | `amount`       | `number`   |    Yes    |       -       | The amount to charge                                                |
 | `currencyCode` | `string`   |    Yes    |       -       | The currency to charge, USD or merchant's shop currency<sup>1</sup> |
 
-## Configuring Billing
+### Configuring Billing
 
 Prior to the future flag `v10_lineItemBilling` and when the flag is set to false you will configure billing as follows. For example, the following configuration will allow you to charge merchants $30 every 30 days. The first three charges will be discounted by $10, so merchants would be charged $20.
 
@@ -186,7 +200,7 @@ const shopify = shopifyApi({
 });
 ```
 
-### Recurring Billing Plans
+#### Recurring Billing Plans
 
 | Parameter                           | Type                         | Required? | Default Value | Notes                                                                                                                                                                                  |
 | ----------------------------------- | ---------------------------- | :-------: | :-----------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -201,8 +215,7 @@ const shopify = shopifyApi({
 
 > **Note** `discount.value` can only include either `amount` or `percentage` but not both.
 
-### Usage Billing Plans
-
+#### Usage Billing Plans
 
 | Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                            |
 | --------------------- | ---------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -215,7 +228,7 @@ const shopify = shopifyApi({
 
 1. Prior to `ApiVersion.April23` the currency code must be `USD`.
 
-## When should the app check for payment?
+### When should the app check for payment?
 
 As mentioned above, billing requires a session to access the API, which means that the app must actually be installed before it can request payment.
 
@@ -227,7 +240,7 @@ If you're gating access to the entire app, you should check for billing:
 
 **Note**: the merchant may refuse payment when prompted or cancel subscriptions later on, but the app will already be installed at that point. We recommend using [billing webhooks](https://shopify.dev/docs/apps/billing#webhooks-for-billing) to revoke access for merchants when they cancel / decline payment.
 
-## Canceling a subscription
+### Canceling a subscription
 
 With the `cancel` method you'll be able to cancel a single subscription. First, you'll need to obtain the id for the subscription you wish to cancel. You can use the `subscriptions` method to obtain a list of current subscriptions.
 

--- a/packages/apps/shopify-api/docs/migrating-to-v12.md
+++ b/packages/apps/shopify-api/docs/migrating-to-v12.md
@@ -1,0 +1,37 @@
+# Migrating to v12
+
+This document outlines the changes you need to make to your app to migrate from v11 to v12 of this package.
+
+## Shopify managed pricing support
+
+With [Shopify managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing), apps can set up billing when publishing to the App Store, rather than using the Admin API. In order to properly support that case, the `billing.check` and `billing.subscriptions` methods have changed.
+
+Now, you can call those methods even if you don't have a billing configuration, so you can check the status of the current merchant before rendering your app. If you're using the `request` method, you'll still need a `billing` configuration with the details of the plans so subscriptions can be created.
+
+The `billing.check` method will now always return an object, but it contains the previous result as well, so you can migrate using this code:
+
+```ts
+// Before
+const result = shopify.billing.check({
+  session,
+  isTest: true,
+  plans: ['My plan 1', 'My plan 2'],
+  // This parameter no longer exists, but no changes are required if it is true
+  returnObject: false,
+});
+
+if (result === true) {
+  // App-specific code
+}
+
+// After
+const result = shopify.billing.check({
+  session,
+  isTest: true,
+  plans: ['My plan 1', 'My plan 2'],
+});
+
+if (result.hasActivePayment === true) {
+  // App-specific code
+}
+```

--- a/packages/apps/shopify-api/docs/reference/billing/check.md
+++ b/packages/apps/shopify-api/docs/reference/billing/check.md
@@ -4,6 +4,35 @@ Checks if a payment exists for any of the given plans, by querying the Shopify A
 
 > **Note**: Depending on the number of requests your app handles, you might want to cache a merchant's payment status, but you should periodically call this method to ensure you're blocking unpaid access.
 
+## Example (using Shopify managed pricing)
+
+```ts
+// You can also use a middleware to get the current plan for the user
+app.get('/billed-page', (req, res) => {
+  const sessionId = shopify.session.getCurrentId({
+    isOnline: true,
+    rawRequest: req,
+    rawResponse: res,
+  });
+
+  // use sessionId to retrieve session from app's session storage
+  // In this example, getSessionFromStorage() must be provided by app
+  const session = await getSessionFromStorage(sessionId);
+
+  const payments = await shopify.billing.check({
+    session,
+    isTest: true,
+  });
+
+  // The above will fetch all subscriptions, so you can filter by the plan you want
+  const hasPlan1 = payments.appSubscriptions.some((subscription) => {
+    return subscription.name === 'Plan 1';
+  });
+
+  // Return request here, or render a dynamic page based on the plan
+});
+```
+
 ## Example (not using return objects)
 
 ```ts
@@ -120,7 +149,7 @@ The `Session` for the current request.
 
 ### plans
 
-`string | string[]` | :exclamation: required
+`string | string[]` | :exclamation: required when not using managed pricing
 
 Which plans to look for.
 

--- a/packages/apps/shopify-api/future/flags.ts
+++ b/packages/apps/shopify-api/future/flags.ts
@@ -17,6 +17,11 @@ export interface FutureFlags {
   lineItemBilling?: boolean;
 
   /**
+   * Enable support for managed pricing, so apps can check for payments without needing a billing config.
+   */
+  unstable_managedPricingSupport?: boolean;
+
+  /**
    * Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This
    * resolves a conflict with the default() method in that class.
    */
@@ -65,6 +70,13 @@ export function logDisabledFutureFlags(
     logFlag(
       'customerAddressDefaultFix',
       "Enable this flag to change the CustomerAddress classes to expose a 'is_default' property instead of 'default' when fetching data.",
+    );
+  }
+
+  if (!config.future?.unstable_managedPricingSupport) {
+    logFlag(
+      'unstable_managedPricingSupport',
+      'Enable this flag to support managed pricing, so apps can check for payments without needing a billing config. Learn more at https://shopify.dev/docs/apps/launch/billing/managed-pricing',
     );
   }
 }

--- a/packages/apps/shopify-api/lib/__tests__/test-config.ts
+++ b/packages/apps/shopify-api/lib/__tests__/test-config.ts
@@ -58,6 +58,7 @@ const TEST_FUTURE_FLAGS: Required<{
   v10_lineItemBilling: true,
   lineItemBilling: true,
   customerAddressDefaultFix: true,
+  unstable_managedPricingSupport: true,
 } as const;
 
 const TEST_CONFIG = {

--- a/packages/apps/shopify-api/lib/billing/__tests__/check.test.ts
+++ b/packages/apps/shopify-api/lib/billing/__tests__/check.test.ts
@@ -2,7 +2,6 @@ import {queueMockResponses} from '../../__tests__/test-helper';
 import {testConfig} from '../../__tests__/test-config';
 import {Session} from '../../session/session';
 import {LATEST_API_VERSION, BillingInterval} from '../../types';
-import {BillingError} from '../../error';
 import {shopifyApi} from '../..';
 import {BillingCheckResponseObject, BillingConfig} from '../types';
 
@@ -54,18 +53,6 @@ describe('shopify.billing.check', () => {
   });
 
   describe('with no billing config', () => {
-    test('throws error if plans are given', async () => {
-      const shopify = shopifyApi(testConfig({billing: undefined}));
-
-      expect(() =>
-        shopify.billing.check({
-          session,
-          plans: Responses.ALL_PLANS,
-          isTest: true,
-        }),
-      ).rejects.toThrowError(BillingError);
-    });
-
     test('returns all purchases if no plans are given', async () => {
       const shopify = shopifyApi(testConfig({billing: undefined}));
 
@@ -78,6 +65,7 @@ describe('shopify.billing.check', () => {
         data: expect.stringContaining('activeSubscriptions'),
       }).toMatchMadeHttpRequest();
 
+      expect(response.hasActivePayment).toBe(true);
       expect(response.oneTimePurchases.length).toBe(0);
       expect(response.appSubscriptions.length).toBe(2);
     });
@@ -95,7 +83,7 @@ describe('shopify.billing.check', () => {
         isTest: true,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('oneTimePurchases'),
@@ -113,7 +101,7 @@ describe('shopify.billing.check', () => {
         isTest: false,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('oneTimePurchases'),
@@ -131,7 +119,7 @@ describe('shopify.billing.check', () => {
         isTest: false,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('oneTimePurchases'),
@@ -148,7 +136,7 @@ describe('shopify.billing.check', () => {
         plans: Responses.ALL_PLANS,
       });
 
-      expect(response).toBe(true);
+      expect(response.hasActivePayment).toBe(true);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('oneTimePurchases'),
@@ -166,7 +154,7 @@ describe('shopify.billing.check', () => {
         isTest: true,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('oneTimePurchases'),
@@ -187,7 +175,7 @@ describe('shopify.billing.check', () => {
         isTest: true,
       });
 
-      expect(response).toBe(true);
+      expect(response.hasActivePayment).toBe(true);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: {
@@ -217,7 +205,7 @@ describe('shopify.billing.check', () => {
         isTest: true,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('activeSubscriptions'),
@@ -235,7 +223,7 @@ describe('shopify.billing.check', () => {
         isTest: false,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('activeSubscriptions'),
@@ -253,7 +241,7 @@ describe('shopify.billing.check', () => {
         isTest: false,
       });
 
-      expect(response).toBe(false);
+      expect(response.hasActivePayment).toBe(false);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('activeSubscriptions'),
@@ -270,7 +258,7 @@ describe('shopify.billing.check', () => {
         plans: Responses.ALL_PLANS,
       });
 
-      expect(response).toBe(true);
+      expect(response.hasActivePayment).toBe(true);
       expect({
         ...GRAPHQL_BASE_REQUEST,
         data: expect.stringContaining('activeSubscriptions'),
@@ -309,6 +297,70 @@ describe('shopify.billing.check', () => {
         expect(Responses.ALL_PLANS.includes(subscription.name)).toBeTruthy();
         expect(subscription.id).toBeDefined();
       });
+    });
+  });
+
+  describe('with disabled future flag', () => {
+    test('check returns valid response object', async () => {
+      const shopify = shopifyApi(
+        testConfig({
+          billing: RECURRING_CONFIGS,
+          future: {unstable_managedPricingSupport: false},
+        }),
+      );
+
+      queueMockResponses(
+        [
+          Responses
+            .EXISTING_ONE_TIME_PAYMENTS_WITH_PAGINATION_AND_SUBSCRIPTION[0],
+        ],
+        [
+          Responses
+            .EXISTING_ONE_TIME_PAYMENTS_WITH_PAGINATION_AND_SUBSCRIPTION[1],
+        ],
+      );
+
+      const responseObject = (await shopify.billing.check({
+        session,
+        plans: Responses.ALL_PLANS,
+        returnObject: true,
+      })) as BillingCheckResponseObject;
+
+      expect(responseObject.hasActivePayment).toBeTruthy();
+      expect(responseObject.oneTimePurchases.length).toBe(2);
+      responseObject.oneTimePurchases.map((purchase) => {
+        expect(Responses.ALL_PLANS.includes(purchase.name)).toBeTruthy();
+        expect(purchase.status).toBe('ACTIVE');
+        expect(purchase.id).toBeDefined();
+      });
+      expect(responseObject.appSubscriptions.length).toBe(1);
+      responseObject.appSubscriptions.map((subscription) => {
+        expect(Responses.ALL_PLANS.includes(subscription.name)).toBeTruthy();
+        expect(subscription.id).toBeDefined();
+      });
+    });
+
+    test('returns boolean response when not requesting object (default)', async () => {
+      const shopify = shopifyApi(
+        testConfig({
+          billing: RECURRING_CONFIGS,
+          future: {unstable_managedPricingSupport: false},
+        }),
+      );
+
+      queueMockResponses([Responses.EXISTING_SUBSCRIPTION]);
+
+      const response = await shopify.billing.check({
+        session,
+        plans: [Responses.PLAN_2],
+        isTest: false,
+      });
+
+      expect(response).toBe(false);
+      expect({
+        ...GRAPHQL_BASE_REQUEST,
+        data: expect.stringContaining('activeSubscriptions'),
+      }).toMatchMadeHttpRequest();
     });
   });
 });

--- a/packages/apps/shopify-api/lib/billing/__tests__/check.test.ts
+++ b/packages/apps/shopify-api/lib/billing/__tests__/check.test.ts
@@ -54,7 +54,7 @@ describe('shopify.billing.check', () => {
   });
 
   describe('with no billing config', () => {
-    test('throws error', async () => {
+    test('throws error if plans are given', async () => {
       const shopify = shopifyApi(testConfig({billing: undefined}));
 
       expect(() =>
@@ -64,6 +64,22 @@ describe('shopify.billing.check', () => {
           isTest: true,
         }),
       ).rejects.toThrowError(BillingError);
+    });
+
+    test('returns all purchases if no plans are given', async () => {
+      const shopify = shopifyApi(testConfig({billing: undefined}));
+
+      queueMockResponses([Responses.MULTIPLE_SUBSCRIPTIONS]);
+
+      const response = await shopify.billing.check({session, isTest: true});
+
+      expect({
+        ...GRAPHQL_BASE_REQUEST,
+        data: expect.stringContaining('activeSubscriptions'),
+      }).toMatchMadeHttpRequest();
+
+      expect(response.oneTimePurchases.length).toBe(0);
+      expect(response.appSubscriptions.length).toBe(2);
     });
   });
 

--- a/packages/apps/shopify-api/lib/billing/__tests__/responses.ts
+++ b/packages/apps/shopify-api/lib/billing/__tests__/responses.ts
@@ -158,6 +158,21 @@ export const EXISTING_SUBSCRIPTION = JSON.stringify(
   EXISTING_SUBSCRIPTION_OBJECT,
 );
 
+export const MULTIPLE_SUBSCRIPTIONS = JSON.stringify({
+  data: {
+    currentAppInstallation: {
+      oneTimePurchases: {
+        edges: [],
+        pageInfo: {hasNextPage: false, endCursor: null},
+      },
+      activeSubscriptions: [
+        {id: 'gid://123', name: PLAN_1, test: true},
+        {id: 'gid://321', name: PLAN_2, test: true},
+      ],
+    },
+  },
+});
+
 export const PURCHASE_ONE_TIME_RESPONSE = JSON.stringify({
   data: {
     appPurchaseOneTimeCreate: {

--- a/packages/apps/shopify-api/lib/billing/__tests__/responses.ts
+++ b/packages/apps/shopify-api/lib/billing/__tests__/responses.ts
@@ -167,7 +167,7 @@ export const MULTIPLE_SUBSCRIPTIONS = JSON.stringify({
       },
       activeSubscriptions: [
         {id: 'gid://123', name: PLAN_1, test: true},
-        {id: 'gid://321', name: PLAN_2, test: true},
+        {id: 'gid://321', name: PLAN_2, test: false},
       ],
     },
   },

--- a/packages/apps/shopify-api/lib/billing/cancel.ts
+++ b/packages/apps/shopify-api/lib/billing/cancel.ts
@@ -2,7 +2,12 @@ import {ConfigInterface} from '../base-types';
 import {graphqlClientClass} from '../clients/admin';
 import {BillingError, GraphqlQueryError} from '../error';
 
-import {AppSubscription, BillingCancelParams, CancelResponse} from './types';
+import {
+  AppSubscription,
+  BillingCancel,
+  BillingCancelParams,
+  CancelResponse,
+} from './types';
 
 const CANCEL_MUTATION = `
   mutation appSubscriptionCancel($id: ID!, $prorate: Boolean) {
@@ -20,7 +25,7 @@ const CANCEL_MUTATION = `
   }
 `;
 
-export function cancel(config: ConfigInterface) {
+export function cancel(config: ConfigInterface): BillingCancel {
   return async function (
     subscriptionInfo: BillingCancelParams,
   ): Promise<AppSubscription> {

--- a/packages/apps/shopify-api/lib/billing/index.ts
+++ b/packages/apps/shopify-api/lib/billing/index.ts
@@ -1,11 +1,17 @@
 import {ConfigInterface} from '../base-types';
+import {FutureFlagOptions} from '../../future/flags';
 
 import {check} from './check';
 import {request} from './request';
 import {cancel} from './cancel';
 import {subscriptions} from './subscriptions';
+import {ShopifyBilling} from './types';
 
-export function shopifyBilling(config: ConfigInterface) {
+export {ShopifyBilling} from './types';
+
+export function shopifyBilling<Future extends FutureFlagOptions>(
+  config: ConfigInterface,
+): ShopifyBilling<Future> {
   return {
     check: check(config),
     request: request(config),
@@ -13,5 +19,3 @@ export function shopifyBilling(config: ConfigInterface) {
     subscriptions: subscriptions(config),
   };
 }
-
-export type ShopifyBilling = ReturnType<typeof shopifyBilling>;

--- a/packages/apps/shopify-api/lib/billing/request.ts
+++ b/packages/apps/shopify-api/lib/billing/request.ts
@@ -18,6 +18,7 @@ import {
   SinglePaymentResponse,
   BillingConfigSubscriptionLineItemPlan,
   RequestConfigLineItemOverrides,
+  BillingRequest,
 } from './types';
 
 interface RequestInternalParams {
@@ -47,7 +48,7 @@ export function request<
   Config extends ConfigInterface<Params>,
   Params extends ConfigParams<any, Future>,
   Future extends FutureFlagOptions,
->(config: Config) {
+>(config: Config): BillingRequest {
   return async function <Params extends BillingRequestParams>({
     session,
     plan,

--- a/packages/apps/shopify-api/lib/billing/subscriptions.ts
+++ b/packages/apps/shopify-api/lib/billing/subscriptions.ts
@@ -5,6 +5,7 @@ import {graphqlClientClass} from '../clients/admin';
 import {
   ActiveSubscriptions,
   BillingSubscriptionParams,
+  BillingSubscriptions,
   SubscriptionResponse,
 } from './types';
 
@@ -63,11 +64,11 @@ query appSubscription {
 }
 `;
 
-export function subscriptions(config: ConfigInterface) {
+export function subscriptions(config: ConfigInterface): BillingSubscriptions {
   return async function ({
     session,
   }: BillingSubscriptionParams): Promise<ActiveSubscriptions> {
-    if (!config.billing) {
+    if (!config.future?.unstable_managedPricingSupport && !config.billing) {
       throw new BillingError({
         message: 'Attempted to look for purchases without billing configs',
         errorData: [],

--- a/packages/apps/shopify-api/lib/billing/types.ts
+++ b/packages/apps/shopify-api/lib/billing/types.ts
@@ -225,7 +225,7 @@ export interface BillingCheckParams {
   /**
    * The plans to accept for this check.
    */
-  plans: string[] | string;
+  plans?: string[] | string;
   /**
    * Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.
    */
@@ -236,11 +236,7 @@ export interface BillingCheckParams {
   returnObject?: boolean;
 }
 
-export interface BillingCheckResponseObject {
-  /**
-   * Whether the user has an active payment method.
-   */
-  hasActivePayment: boolean;
+export interface BillingCheckResults {
   /**
    * The one-time purchases the shop has.
    */
@@ -251,8 +247,19 @@ export interface BillingCheckResponseObject {
   appSubscriptions: AppSubscription[];
 }
 
+export interface BillingCheckResponseObject extends BillingCheckResults {
+  /**
+   * Whether the user has an active payment method.
+   */
+  hasActivePayment: boolean;
+}
+
 export type BillingCheckResponse<Params extends BillingCheckParams> =
-  Params['returnObject'] extends true ? BillingCheckResponseObject : boolean;
+  Params['plans'] extends string[]
+    ? Params['returnObject'] extends true
+      ? BillingCheckResponseObject
+      : boolean
+    : BillingCheckResults;
 
 export type BillingRequestParams = {
   /**

--- a/packages/apps/shopify-api/lib/billing/types.ts
+++ b/packages/apps/shopify-api/lib/billing/types.ts
@@ -217,7 +217,7 @@ export interface BillingConfigSubscriptionLineItemPlan {
 export type RequestConfigLineItemOverrides =
   Partial<BillingConfigSubscriptionLineItemPlan>;
 
-export interface BillingCheckParams {
+interface BillingCheckParamsNew {
   /**
    * The session to use for this check.
    */
@@ -230,13 +230,31 @@ export interface BillingCheckParams {
    * Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.
    */
   isTest?: boolean;
+}
+
+interface BillingCheckParamsOld extends BillingCheckParamsNew {
+  /**
+   * The plans to accept for this check.
+   */
+  plans: string[] | string;
   /**
    * Whether to return the full response object.
    */
   returnObject?: boolean;
 }
 
-export interface BillingCheckResults {
+export type BillingCheckParams<
+  Future extends FutureFlagOptions = FutureFlagOptions,
+> =
+  FeatureEnabled<Future, 'unstable_managedPricingSupport'> extends true
+    ? BillingCheckParamsNew
+    : BillingCheckParamsOld;
+
+export interface BillingCheckResponseObject {
+  /**
+   * Whether the user has an active payment method.
+   */
+  hasActivePayment: boolean;
   /**
    * The one-time purchases the shop has.
    */
@@ -247,19 +265,17 @@ export interface BillingCheckResults {
   appSubscriptions: AppSubscription[];
 }
 
-export interface BillingCheckResponseObject extends BillingCheckResults {
-  /**
-   * Whether the user has an active payment method.
-   */
-  hasActivePayment: boolean;
-}
-
-export type BillingCheckResponse<Params extends BillingCheckParams> =
-  Params['plans'] extends string[]
-    ? Params['returnObject'] extends true
-      ? BillingCheckResponseObject
-      : boolean
-    : BillingCheckResults;
+export type BillingCheckResponse<
+  Params extends BillingCheckParams<Future>,
+  Future extends FutureFlagOptions = FutureFlagOptions,
+> =
+  FeatureEnabled<Future, 'unstable_managedPricingSupport'> extends true
+    ? BillingCheckResponseObject
+    : Params extends BillingCheckParamsOld
+      ? Params['returnObject'] extends true
+        ? BillingCheckResponseObject
+        : boolean
+      : never;
 
 export type BillingRequestParams = {
   /**
@@ -502,4 +518,29 @@ export interface CancelResponse {
     appSubscription: AppSubscription;
     userErrors: string[];
   };
+}
+
+export type BillingCheck<Future extends FutureFlagOptions> = <
+  Params extends BillingCheckParams<Future>,
+>(
+  params: Params,
+) => Promise<BillingCheckResponse<Params, Future>>;
+
+export type BillingRequest = <Params extends BillingRequestParams>(
+  params: Params,
+) => Promise<BillingRequestResponse<Params>>;
+
+export type BillingCancel = (
+  params: BillingCancelParams,
+) => Promise<AppSubscription>;
+
+export type BillingSubscriptions = (
+  params: BillingSubscriptionParams,
+) => Promise<ActiveSubscriptions>;
+
+export interface ShopifyBilling<Future extends FutureFlagOptions> {
+  check: BillingCheck<Future>;
+  request: BillingRequest;
+  cancel: BillingCancel;
+  subscriptions: BillingSubscriptions;
 }

--- a/packages/apps/shopify-api/lib/index.ts
+++ b/packages/apps/shopify-api/lib/index.ts
@@ -33,7 +33,7 @@ export * from './utils/types';
 export interface Shopify<
   Params extends ConfigParams = ConfigParams,
   Resources extends ShopifyRestResources = ShopifyRestResources,
-  _Future extends FutureFlagOptions = FutureFlagOptions,
+  Future extends FutureFlagOptions = FutureFlagOptions,
 > {
   config: ConfigInterface<Params>;
   clients: ShopifyClients;
@@ -41,7 +41,7 @@ export interface Shopify<
   session: ShopifySession;
   utils: ShopifyUtils;
   webhooks: ShopifyWebhooks;
-  billing: ShopifyBilling;
+  billing: ShopifyBilling<Future>;
   logger: ShopifyLogger;
   rest: Resources;
   flow: ShopifyFlow;

--- a/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -576,7 +576,7 @@
                 "filePath": "src/server/authenticate/admin/billing/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "check",
-                "value": "(options: CheckBillingOptions<Config>) => Promise<BillingCheckResponseObject>",
+                "value": "<Options extends CheckBillingOptions<Config>>(options?: Options) => Promise<BillingCheckResponseObject>",
                 "description": "Checks if the shop has an active payment for any plan defined in the `billing` config option.",
                 "examples": [
                   {
@@ -584,12 +584,22 @@
                     "description": "Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does notthrow an error if no active billing plans are present.",
                     "tabs": [
                       {
-                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n console.log(hasActivePayment)\n console.log(appSubscriptions)\n};",
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                         "title": "/app/routes/**\\/*.ts"
                       },
                       {
                         "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      lineItems: [\n        amount: 5,\n        currencyCode: 'USD',\n        interval: BillingInterval.Every30Days,\n      ],\n    },\n    [ANNUAL_PLAN]: {\n      lineItems: [\n        amount: 50,\n        currencyCode: 'USD',\n        interval: BillingInterval.Annual,\n      ],\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
                         "title": "shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Check for payments without filtering",
+                    "description": "Use billing.check to see if any payments exist for the store, regardless of whether it's a test ormatches one or more plans.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check();\n  // This will be true if any payment is found\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
+                        "title": "/app/routes/**\\/*.ts"
                       }
                     ]
                   }
@@ -656,7 +666,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Check for payments without filtering.</caption>\n   * <description>Use billing.check to see if any payments exist for the store, regardless of whether it's a test or\n   * matches one or more plans.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check();\n   *   // This will be true if any payment is found\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   */\n  check: <Options extends CheckBillingOptions<Config>>(\n    options?: Options,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "CancelBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -696,367 +706,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "importMap": {
@@ -1089,93 +738,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "plans",
                 "value": "(keyof Config[\"billing\"])[]",
-                "description": "The plans to check for. Must be one of the values defined in the `billing` config option."
+                "description": "The plans to check for. Must be one of the values defined in the `billing` config option.",
+                "isOptional": true
               }
             ],
-            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
+            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -1269,349 +836,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           },
           "EmbeddedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -1820,82 +1044,6 @@
             "value": "'_self' | '_parent' | '_top' | '_blank'",
             "description": ""
           },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
-          },
           "ScopesContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
             "importMap": {
@@ -1931,12 +1079,78 @@
               {
                 "filePath": "src/server/authenticate/admin/scope/types.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "() => Promise<ScopesInformation>",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "request",
                 "value": "(scopes: string[]) => Promise<void>",
                 "description": ""
               }
             ],
-            "value": "export interface ScopesApiContext {\n  request: (scopes: string[]) => Promise<void>;\n}"
+            "value": "export interface ScopesApiContext {\n  query: () => Promise<ScopesInformation>;\n  request: (scopes: string[]) => Promise<void>;\n}"
+          },
+          "ScopesInformation": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "ScopesInformation",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "declared",
+                "value": "DeclaredScopes",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "granted",
+                "value": "GrantedScopes",
+                "description": ""
+              }
+            ],
+            "value": "export interface ScopesInformation {\n  granted: GrantedScopes;\n  declared: DeclaredScopes;\n}"
+          },
+          "DeclaredScopes": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "DeclaredScopes",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "required",
+                "value": "string[]",
+                "description": ""
+              }
+            ],
+            "value": "export interface DeclaredScopes {\n  required: string[];\n}"
+          },
+          "GrantedScopes": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "GrantedScopes",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "optional",
+                "value": "string[]",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "required",
+                "value": "string[]",
+                "description": ""
+              }
+            ],
+            "value": "export interface GrantedScopes {\n  required: string[];\n  optional: string[];\n}"
           }
         }
       }
@@ -2220,12 +1434,25 @@
                 "tabs": [
                   {
                     "title": "/app/routes/**\\/*.ts",
-                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n console.log(hasActivePayment)\n console.log(appSubscriptions)\n};",
+                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                     "language": "typescript"
                   },
                   {
                     "title": "shopify.server.ts",
                     "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      lineItems: [\n        amount: 5,\n        currencyCode: 'USD',\n        interval: BillingInterval.Every30Days,\n      ],\n    },\n    [ANNUAL_PLAN]: {\n      lineItems: [\n        amount: 50,\n        currencyCode: 'USD',\n        interval: BillingInterval.Annual,\n      ],\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Use billing.check to see if any payments exist for the store, regardless of whether it's a test ormatches one or more plans.",
+              "codeblock": {
+                "title": "Check for payments without filtering",
+                "tabs": [
+                  {
+                    "title": "/app/routes/**\\/*.ts",
+                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check();\n  // This will be true if any payment is found\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                     "language": "typescript"
                   }
                 ]
@@ -2351,7 +1578,7 @@
                 "filePath": "src/server/authenticate/admin/billing/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "check",
-                "value": "(options: CheckBillingOptions<Config>) => Promise<BillingCheckResponseObject>",
+                "value": "<Options extends CheckBillingOptions<Config>>(options?: Options) => Promise<BillingCheckResponseObject>",
                 "description": "Checks if the shop has an active payment for any plan defined in the `billing` config option.",
                 "examples": [
                   {
@@ -2359,12 +1586,22 @@
                     "description": "Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does notthrow an error if no active billing plans are present.",
                     "tabs": [
                       {
-                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n console.log(hasActivePayment)\n console.log(appSubscriptions)\n};",
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                         "title": "/app/routes/**\\/*.ts"
                       },
                       {
                         "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      lineItems: [\n        amount: 5,\n        currencyCode: 'USD',\n        interval: BillingInterval.Every30Days,\n      ],\n    },\n    [ANNUAL_PLAN]: {\n      lineItems: [\n        amount: 50,\n        currencyCode: 'USD',\n        interval: BillingInterval.Annual,\n      ],\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
                         "title": "shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Check for payments without filtering",
+                    "description": "Use billing.check to see if any payments exist for the store, regardless of whether it's a test ormatches one or more plans.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check();\n  // This will be true if any payment is found\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
+                        "title": "/app/routes/**\\/*.ts"
                       }
                     ]
                   }
@@ -2431,7 +1668,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Check for payments without filtering.</caption>\n   * <description>Use billing.check to see if any payments exist for the store, regardless of whether it's a test or\n   * matches one or more plans.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check();\n   *   // This will be true if any payment is found\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   */\n  check: <Options extends CheckBillingOptions<Config>>(\n    options?: Options,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "CancelBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -2471,367 +1708,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "importMap": {
@@ -2864,93 +1740,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "plans",
                 "value": "(keyof Config[\"billing\"])[]",
-                "description": "The plans to check for. Must be one of the values defined in the `billing` config option."
+                "description": "The plans to check for. Must be one of the values defined in the `billing` config option.",
+                "isOptional": true
               }
             ],
-            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
+            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -3083,12 +1877,25 @@
                 "tabs": [
                   {
                     "title": "/app/routes/**\\/*.ts",
-                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n console.log(hasActivePayment)\n console.log(appSubscriptions)\n};",
+                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                     "language": "typescript"
                   },
                   {
                     "title": "shopify.server.ts",
                     "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      lineItems: [\n        amount: 5,\n        currencyCode: 'USD',\n        interval: BillingInterval.Every30Days,\n      ],\n    },\n    [ANNUAL_PLAN]: {\n      lineItems: [\n        amount: 50,\n        currencyCode: 'USD',\n        interval: BillingInterval.Annual,\n      ],\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                    "language": "typescript"
+                  }
+                ]
+              }
+            },
+            {
+              "description": "Use billing.check to see if any payments exist for the store, regardless of whether it's a test ormatches one or more plans.",
+              "codeblock": {
+                "title": "Check for payments without filtering",
+                "tabs": [
+                  {
+                    "title": "/app/routes/**\\/*.ts",
+                    "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) =&gt; {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check();\n  // This will be true if any payment is found\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                     "language": "typescript"
                   }
                 ]
@@ -3269,349 +2076,6 @@
               }
             ],
             "value": "export interface FlowContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Shopify session for the Flow request.</caption>\n   * <description>Use the session associated with this request to use REST resources.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { session, admin } = await authenticate.flow(request);\n   *\n   *   const products = await admin?.rest.resources.Product.all({ session });\n   *   // Use products\n   *\n   *   return new Response();\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * The payload from the Flow request.\n   *\n   * @example\n   * <caption>Flow payload.</caption>\n   * <description>Get the request's POST payload.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { payload } = await authenticate.flow(request);\n   *   return new Response();\n   * };\n   * ```\n   */\n  payload: any;\n\n  /**\n   * An admin context for the Flow request.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Flow admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.flow(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -3822,349 +2286,6 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "FulfillmentServicePayload",
             "value": "Record<string, any> & {\n  kind: string;\n}",
-            "description": ""
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
             "description": ""
           }
         }
@@ -4537,349 +2658,6 @@
             ],
             "value": "export interface AppProxyContextWithSession<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends Context {\n  /**\n   * The session for the shop that made the request.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * Use this to get shop or user-specific data.\n   *\n   * @example\n   * <caption>Using the session object.</caption>\n   * <description>Get the session for the shop that initiated the request to the app proxy.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppModelData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }) => {\n   *   // Get the session for the shop that initiated the request to the app proxy.\n   *   const { session } =\n   *     await authenticate.public.appProxy(request);\n   *\n   *   // Use the session data to make to queries to your database or additional requests.\n   *   return json(\n   *     await getMyAppModelData({shop: session.shop})\n   *   );\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Admin API.</caption>\n   * <description>Use the `admin` object to interact with the REST or GraphQL APIs.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     {\n   *       variables: {\n   *         input: { title: \"Product Name\" }\n   *       }\n   *     }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n\n  /**\n   * Method for interacting with the Shopify Storefront Graphql API for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Storefront API.</caption>\n   * <description>Use the `storefront` object to interact with the GraphQL API.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { storefront } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await storefront.graphql(\n   *     `#graphql\n   *     query blogIds {\n   *       blogs(first: 10) {\n   *         edges {\n   *           node {\n   *             id\n   *           }\n   *         }\n   *       }\n   *     }`\n   *   );\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
           },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
           "StorefrontContext": {
             "filePath": "src/server/clients/storefront/types.ts",
             "importMap": {
@@ -4933,8 +2711,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -4969,8 +2746,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -5009,59 +2785,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }
@@ -5328,82 +3051,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           }
         }
       }
@@ -5603,82 +3250,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           }
         }
       }
@@ -6098,349 +3669,6 @@
               }
             ],
             "value": "export interface WebhookContextWithSession<\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Webhook admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/webhooks.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -6724,8 +3952,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -6760,8 +3987,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -6800,59 +4026,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           },
           "RestClientWithResources": {
             "filePath": "src/server/clients/admin/rest.ts",
@@ -6925,494 +4098,6 @@
               }
             ],
             "value": "class RemixRestClient {\n  public session: Session;\n  private params: AdminClientOptions['params'];\n  private handleClientError: AdminClientOptions['handleClientError'];\n\n  constructor({params, session, handleClientError}: AdminClientOptions) {\n    this.params = params;\n    this.handleClientError = handleClientError;\n    this.session = session;\n  }\n\n  /**\n   * Performs a GET request on the given path.\n   */\n  public async get(params: GetRequestParams) {\n    return this.makeRequest({\n      method: 'GET' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a POST request on the given path.\n   */\n  public async post(params: PostRequestParams) {\n    return this.makeRequest({\n      method: 'POST' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a PUT request on the given path.\n   */\n  public async put(params: PutRequestParams) {\n    return this.makeRequest({\n      method: 'PUT' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a DELETE request on the given path.\n   */\n  public async delete(params: DeleteRequestParams) {\n    return this.makeRequest({\n      method: 'DELETE' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  protected async makeRequest(params: RequestParams): Promise<Response> {\n    const originalClient = new this.params.api.clients.Rest({\n      session: this.session,\n    });\n    const originalRequest = Reflect.get(originalClient, 'request');\n\n    try {\n      const apiResponse = await originalRequest.call(originalClient, params);\n\n      // We use a separate client for REST requests and REST resources because we want to override the API library\n      // client class to return a Response object instead.\n      return new Response(JSON.stringify(apiResponse.body), {\n        headers: apiResponse.headers,\n      });\n    } catch (error) {\n      if (this.handleClientError) {\n        throw await this.handleClientError({\n          error,\n          session: this.session,\n          params: this.params,\n        });\n      } else throw new Error(error);\n    }\n  }\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
-          "GetRequestParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "importMap": {
-              "AllOperations": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "Method": "../../../node_modules/@shopify/network/build/ts/index.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Headers": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "GraphqlClient": "../shopify-api/dist/ts/lib/clients/admin/graphql/client.d.ts",
-              "StorefrontClient": "../shopify-api/dist/ts/lib/clients/storefront/client.d.ts",
-              "GraphqlProxy": "../shopify-api/dist/ts/lib/clients/graphql_proxy/types.d.ts",
-              "RestClient": "../shopify-api/dist/ts/lib/clients/admin/rest/client.d.ts"
-            },
-            "name": "GetRequestParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "data",
-                "value": "Record<string, any> | string",
-                "description": "The request body.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "extraHeaders",
-                "value": "HeaderParams",
-                "description": "Additional headers to be sent with the request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "path",
-                "value": "string",
-                "description": "The path to the resource, relative to the API version root."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "SearchParams",
-                "description": "Query parameters to be sent with the request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "tries",
-                "value": "number",
-                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "type",
-                "value": "DataType",
-                "description": "The type of data expected in the response.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
-          },
-          "HeaderParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "importMap": {
-              "AllOperations": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "Method": "../../../node_modules/@shopify/network/build/ts/index.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Headers": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "GraphqlClient": "../shopify-api/dist/ts/lib/clients/admin/graphql/client.d.ts",
-              "StorefrontClient": "../shopify-api/dist/ts/lib/clients/storefront/client.d.ts",
-              "GraphqlProxy": "../shopify-api/dist/ts/lib/clients/graphql_proxy/types.d.ts",
-              "RestClient": "../shopify-api/dist/ts/lib/clients/admin/rest/client.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "HeaderParams",
-            "value": "Record<string, string | number | string[]>",
-            "description": "Headers to be sent with the request.",
-            "members": []
-          },
-          "DataType": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "importMap": {
-              "AllOperations": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "Method": "../../../node_modules/@shopify/network/build/ts/index.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Headers": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "GraphqlClient": "../shopify-api/dist/ts/lib/clients/admin/graphql/client.d.ts",
-              "StorefrontClient": "../shopify-api/dist/ts/lib/clients/storefront/client.d.ts",
-              "GraphqlProxy": "../shopify-api/dist/ts/lib/clients/graphql_proxy/types.d.ts",
-              "RestClient": "../shopify-api/dist/ts/lib/clients/admin/rest/client.d.ts"
-            },
-            "syntaxKind": "EnumDeclaration",
-            "name": "DataType",
-            "value": "export declare enum DataType {\n    JSON = \"application/json\",\n    GraphQL = \"application/graphql\",\n    URLEncoded = \"application/x-www-form-urlencoded\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "JSON",
-                "value": "application/json"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "GraphQL",
-                "value": "application/graphql"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "URLEncoded",
-                "value": "application/x-www-form-urlencoded"
-              }
-            ]
-          },
-          "PostRequestParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "importMap": {
-              "AllOperations": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "Method": "../../../node_modules/@shopify/network/build/ts/index.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Headers": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "GraphqlClient": "../shopify-api/dist/ts/lib/clients/admin/graphql/client.d.ts",
-              "StorefrontClient": "../shopify-api/dist/ts/lib/clients/storefront/client.d.ts",
-              "GraphqlProxy": "../shopify-api/dist/ts/lib/clients/graphql_proxy/types.d.ts",
-              "RestClient": "../shopify-api/dist/ts/lib/clients/admin/rest/client.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "PostRequestParams",
-            "value": "GetRequestParams & {\n    data: Record<string, any> | string;\n}",
-            "description": ""
           }
         }
       }
@@ -7603,8 +4288,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -7639,8 +4323,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -7679,59 +4362,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }
@@ -8514,7 +5144,7 @@
                 "filePath": "src/server/authenticate/admin/billing/types.ts",
                 "syntaxKind": "PropertySignature",
                 "name": "check",
-                "value": "(options: CheckBillingOptions<Config>) => Promise<BillingCheckResponseObject>",
+                "value": "<Options extends CheckBillingOptions<Config>>(options?: Options) => Promise<BillingCheckResponseObject>",
                 "description": "Checks if the shop has an active payment for any plan defined in the `billing` config option.",
                 "examples": [
                   {
@@ -8522,12 +5152,22 @@
                     "description": "Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does notthrow an error if no active billing plans are present.",
                     "tabs": [
                       {
-                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n console.log(hasActivePayment)\n console.log(appSubscriptions)\n};",
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check({\n    plans: [MONTHLY_PLAN],\n    isTest: false,\n  });\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
                         "title": "/app/routes/**\\/*.ts"
                       },
                       {
                         "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      lineItems: [\n        amount: 5,\n        currencyCode: 'USD',\n        interval: BillingInterval.Every30Days,\n      ],\n    },\n    [ANNUAL_PLAN]: {\n      lineItems: [\n        amount: 50,\n        currencyCode: 'USD',\n        interval: BillingInterval.Annual,\n      ],\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
                         "title": "shopify.server.ts"
+                      }
+                    ]
+                  },
+                  {
+                    "title": "Check for payments without filtering",
+                    "description": "Use billing.check to see if any payments exist for the store, regardless of whether it's a test ormatches one or more plans.",
+                    "tabs": [
+                      {
+                        "code": "import { LoaderFunctionArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderFunctionArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const { hasActivePayment, appSubscriptions } = await billing.check();\n  // This will be true if any payment is found\n  console.log(hasActivePayment);\n  console.log(appSubscriptions);\n};",
+                        "title": "/app/routes/**\\/*.ts"
                       }
                     ]
                   }
@@ -8594,7 +5234,7 @@
                 ]
               }
             ],
-            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *  console.log(hasActivePayment)\n   *  console.log(appSubscriptions)\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   */\n  check: (\n    options: CheckBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+            "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately redirect to the Shopify page to request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Redirect to a plan selection page.</caption>\n   * <description>When the app has multiple plans, create a page in your App that allows the merchant to select a plan. If a merchant does not have the required plan you can redirect them to page in your app to select one.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Check what billing plans a merchant is subscribed to.</caption>\n   * <description>Use billing.check if you want to determine which plans are in use. Unlike `require`, `check` does not\n   * throw an error if no active billing plans are present. </description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: false,\n   *   });\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Check for payments without filtering.</caption>\n   * <description>Use billing.check to see if any payments exist for the store, regardless of whether it's a test or\n   * matches one or more plans.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const { hasActivePayment, appSubscriptions } = await billing.check();\n   *   // This will be true if any payment is found\n   *   console.log(hasActivePayment);\n   *   console.log(appSubscriptions);\n   * };\n   * ```\n   */\n  check: <Options extends CheckBillingOptions<Config>>(\n    options?: Options,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: 'https://admin.shopify.com/store/my-store/apps/my-app/billing-page',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       lineItems: [\n   *         amount: 5,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Every30Days,\n   *       ],\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       lineItems: [\n   *         amount: 50,\n   *         currencyCode: 'USD',\n   *         interval: BillingInterval.Annual,\n   *       ],\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
           },
           "CancelBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -8634,367 +5274,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "importMap": {
@@ -9027,93 +5306,11 @@
                 "syntaxKind": "PropertySignature",
                 "name": "plans",
                 "value": "(keyof Config[\"billing\"])[]",
-                "description": "The plans to check for. Must be one of the values defined in the `billing` config option."
+                "description": "The plans to check for. Must be one of the values defined in the `billing` config option.",
+                "isOptional": true
               }
             ],
-            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "importMap": {
-              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
-              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
-              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
-              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
-              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
-            },
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
+            "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -9207,349 +5404,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           },
           "EmbeddedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -9758,82 +5612,6 @@
             "value": "'_self' | '_parent' | '_top' | '_blank'",
             "description": ""
           },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
-          },
           "ScopesContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
             "importMap": {
@@ -9869,12 +5647,78 @@
               {
                 "filePath": "src/server/authenticate/admin/scope/types.ts",
                 "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "() => Promise<ScopesInformation>",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
                 "name": "request",
                 "value": "(scopes: string[]) => Promise<void>",
                 "description": ""
               }
             ],
-            "value": "export interface ScopesApiContext {\n  request: (scopes: string[]) => Promise<void>;\n}"
+            "value": "export interface ScopesApiContext {\n  query: () => Promise<ScopesInformation>;\n  request: (scopes: string[]) => Promise<void>;\n}"
+          },
+          "ScopesInformation": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "ScopesInformation",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "declared",
+                "value": "DeclaredScopes",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "granted",
+                "value": "GrantedScopes",
+                "description": ""
+              }
+            ],
+            "value": "export interface ScopesInformation {\n  granted: GrantedScopes;\n  declared: DeclaredScopes;\n}"
+          },
+          "DeclaredScopes": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "DeclaredScopes",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "required",
+                "value": "string[]",
+                "description": ""
+              }
+            ],
+            "value": "export interface DeclaredScopes {\n  required: string[];\n}"
+          },
+          "GrantedScopes": {
+            "filePath": "src/server/authenticate/admin/scope/types.ts",
+            "name": "GrantedScopes",
+            "description": "",
+            "members": [
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "optional",
+                "value": "string[]",
+                "description": ""
+              },
+              {
+                "filePath": "src/server/authenticate/admin/scope/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "required",
+                "value": "string[]",
+                "description": ""
+              }
+            ],
+            "value": "export interface GrantedScopes {\n  required: string[];\n  optional: string[];\n}"
           },
           "RestResourcesType": {
             "filePath": "src/server/types.ts",
@@ -9900,14 +5744,6 @@
             "name": "RestResourcesType",
             "value": "Config['restResources'] extends ShopifyRestResources\n    ? Config['restResources']\n    : ShopifyRestResources",
             "description": ""
-          },
-          "ShopifyRestResources": {
-            "filePath": "../shopify-api/dist/ts/rest/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "ShopifyRestResources",
-            "value": "Record<string, any>",
-            "description": "",
-            "members": []
           },
           "AuthenticateFlow": {
             "filePath": "src/server/authenticate/flow/types.ts",
@@ -10499,8 +6335,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -10535,8 +6370,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -10575,59 +6409,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           },
           "AuthenticateCheckout": {
             "filePath": "src/server/authenticate/public/checkout/types.ts",
@@ -11522,6 +7303,698 @@
             "value": "Base & {\n  sessionStorage: SessionStorageType<Config>;\n}",
             "description": ""
           },
+          "Base": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "importMap": {
+              "RestResourceError": "../shopify-api/lib/error.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "PageInfo": "../shopify-api/lib/clients/admin/types.ts",
+              "RestRequestReturn": "../shopify-api/lib/clients/admin/types.ts",
+              "DataType": "../shopify-api/lib/clients/types.ts",
+              "RestClient": "../shopify-api/lib/clients/admin/rest/client.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "ConfigInterface": "../shopify-api/lib/base-types.ts",
+              "Headers": "../shopify-api/runtime/http/index.ts",
+              "IdSet": "../shopify-api/rest/types.ts",
+              "Body": "../shopify-api/rest/types.ts",
+              "ResourcePath": "../shopify-api/rest/types.ts",
+              "ParamSet": "../shopify-api/rest/types.ts",
+              "ResourceNames": "../shopify-api/rest/types.ts"
+            },
+            "name": "Base",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "#session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "GetAccessor",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "save",
+                "value": "({ update }?: SaveArgs) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "saveAndUpdate",
+                "value": "() => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "delete",
+                "value": "() => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "serialize",
+                "value": "(saving?: boolean) => Body",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toJSON",
+                "value": "() => Body",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "request",
+                "value": "<T = unknown>(args: RequestArgs) => Promise<RestRequestReturn<T>>",
+                "description": ""
+              }
+            ],
+            "value": "export class Base {\n  // For instance attributes\n  [key: string]: any;\n\n  public static Client: typeof RestClient;\n  public static config: ConfigInterface;\n\n  public static apiVersion: string;\n  protected static resourceNames: ResourceNames[] = [];\n\n  protected static primaryKey = 'id';\n  protected static customPrefix: string | null = null;\n  protected static readOnlyAttributes: string[] = [];\n\n  protected static hasOne: Record<string, typeof Base> = {};\n  protected static hasMany: Record<string, typeof Base> = {};\n\n  protected static paths: ResourcePath[] = [];\n\n  public static setClassProperties({Client, config}: SetClassPropertiesArgs) {\n    this.Client = Client;\n    this.config = config;\n  }\n\n  protected static async baseFind<T extends Base = Base>({\n    session,\n    urlIds,\n    params,\n    requireIds = false,\n  }: BaseFindArgs): Promise<FindAllResponse<T>> {\n    if (requireIds) {\n      const hasIds = Object.entries(urlIds).some(([_key, value]) => value);\n\n      if (!hasIds) {\n        throw new RestResourceError(\n          'No IDs given for request, cannot find path',\n        );\n      }\n    }\n\n    const response = await this.request<T>({\n      http_method: 'get',\n      operation: 'get',\n      session,\n      urlIds,\n      params,\n    });\n\n    return {\n      data: this.createInstancesFromResponse<T>(session, response.body as Body),\n      headers: response.headers,\n      pageInfo: response.pageInfo,\n    };\n  }\n\n  protected static async request<T = unknown>({\n    session,\n    http_method,\n    operation,\n    urlIds,\n    params,\n    body,\n    entity,\n  }: RequestArgs): Promise<RestRequestReturn<T>> {\n    const client = new this.Client({\n      session,\n      apiVersion: this.apiVersion as ApiVersion,\n    });\n\n    const path = this.getPath({http_method, operation, urlIds, entity});\n\n    const cleanParams: Record<string, string | number> = {};\n    if (params) {\n      for (const key in params) {\n        if (params[key] !== null) {\n          cleanParams[key] = params[key];\n        }\n      }\n    }\n\n    switch (http_method) {\n      case 'get':\n        return client.get<T>({path, query: cleanParams});\n      case 'post':\n        return client.post<T>({\n          path,\n          query: cleanParams,\n          data: body!,\n          type: DataType.JSON,\n        });\n      case 'put':\n        return client.put<T>({\n          path,\n          query: cleanParams,\n          data: body!,\n          type: DataType.JSON,\n        });\n      case 'delete':\n        return client.delete<T>({path, query: cleanParams});\n      default:\n        throw new Error(`Unrecognized HTTP method \"${http_method}\"`);\n    }\n  }\n\n  protected static getJsonBodyName(): string {\n    return this.name.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();\n  }\n\n  protected static getPath({\n    http_method,\n    operation,\n    urlIds,\n    entity,\n  }: GetPathArgs): string {\n    let match: string | null = null;\n    let specificity = -1;\n\n    const potentialPaths: ResourcePath[] = [];\n    this.paths.forEach((path: ResourcePath) => {\n      if (\n        http_method !== path.http_method ||\n        operation !== path.operation ||\n        path.ids.length <= specificity\n      ) {\n        return;\n      }\n\n      potentialPaths.push(path);\n\n      let pathUrlIds: IdSet = {...urlIds};\n      path.ids.forEach((id) => {\n        if (!pathUrlIds[id] && entity && entity[id]) {\n          pathUrlIds[id] = entity[id];\n        }\n      });\n\n      pathUrlIds = Object.entries(pathUrlIds).reduce(\n        (acc: IdSet, [key, value]: [string, string | number | null]) => {\n          if (value) {\n            acc[key] = value;\n          }\n          return acc;\n        },\n        {},\n      );\n\n      // If we weren't given all of the path's required ids, we can't use it\n      const diff = path.ids.reduce(\n        (acc: string[], id: string) => (pathUrlIds[id] ? acc : acc.concat(id)),\n        [],\n      );\n      if (diff.length > 0) {\n        return;\n      }\n\n      specificity = path.ids.length;\n      match = path.path.replace(\n        /(<([^>]+)>)/g,\n        (_m1, _m2, id) => `${pathUrlIds[id]}`,\n      );\n    });\n\n    if (!match) {\n      const pathOptions = potentialPaths.map((path) => path.path);\n\n      throw new RestResourceError(\n        `Could not find a path for request. If you are trying to make a request to one of the following paths, ensure all relevant IDs are set. :\\n - ${pathOptions.join(\n          '\\n - ',\n        )}`,\n      );\n    }\n\n    if (this.customPrefix) {\n      return `${this.customPrefix}/${match}`;\n    } else {\n      return match;\n    }\n  }\n\n  protected static createInstancesFromResponse<T extends Base = Base>(\n    session: Session,\n    data: Body,\n  ): T[] {\n    let instances: T[] = [];\n    this.resourceNames.forEach((resourceName) => {\n      const singular = resourceName.singular;\n      const plural = resourceName.plural;\n      if (data[plural] || Array.isArray(data[singular])) {\n        instances = instances.concat(\n          (data[plural] || data[singular]).reduce(\n            (acc: T[], entry: Body) =>\n              acc.concat(this.createInstance<T>(session, entry)),\n            [],\n          ),\n        );\n      } else if (data[singular]) {\n        instances.push(this.createInstance<T>(session, data[singular]));\n      }\n    });\n\n    return instances;\n  }\n\n  protected static createInstance<T extends Base = Base>(\n    session: Session,\n    data: Body,\n    prevInstance?: T,\n  ): T {\n    const instance: T = prevInstance\n      ? prevInstance\n      : new (this as any)({session});\n\n    if (data) {\n      instance.setData(data);\n    }\n\n    return instance;\n  }\n\n  #session: Session;\n\n  get session(): Session {\n    return this.#session;\n  }\n\n  constructor({session, fromData}: BaseConstructorArgs) {\n    this.#session = session;\n\n    if (fromData) {\n      this.setData(fromData);\n    }\n  }\n\n  public async save({update = false}: SaveArgs = {}): Promise<void> {\n    const {primaryKey, resourceNames} = this.resource();\n    const method = this[primaryKey] ? 'put' : 'post';\n\n    const data = this.serialize(true);\n\n    const response = await this.resource().request({\n      http_method: method,\n      operation: method,\n      session: this.session,\n      urlIds: {},\n      body: {[this.resource().getJsonBodyName()]: data},\n      entity: this,\n    });\n\n    const flattenResourceNames: string[] = resourceNames.reduce<string[]>(\n      (acc, obj) => {\n        return acc.concat(Object.values(obj));\n      },\n      [],\n    );\n\n    const matchResourceName = Object.keys(response.body as Body).filter(\n      (key: string) => flattenResourceNames.includes(key),\n    );\n\n    const body: Body | undefined = (response.body as Body)[\n      matchResourceName[0]\n    ];\n\n    if (update && body) {\n      this.setData(body);\n    }\n  }\n\n  public async saveAndUpdate(): Promise<void> {\n    await this.save({update: true});\n  }\n\n  public async delete(): Promise<void> {\n    await this.resource().request({\n      http_method: 'delete',\n      operation: 'delete',\n      session: this.session,\n      urlIds: {},\n      entity: this,\n    });\n  }\n\n  public serialize(saving = false): Body {\n    const {hasMany, hasOne, readOnlyAttributes} = this.resource();\n\n    return Object.entries(this).reduce((acc: Body, [attribute, value]) => {\n      if (\n        ['#session'].includes(attribute) ||\n        (saving && readOnlyAttributes.includes(attribute))\n      ) {\n        return acc;\n      }\n\n      if (attribute in hasMany && value) {\n        acc[attribute] = value.reduce((attrAcc: Body, entry: Base) => {\n          return attrAcc.concat(this.serializeSubAttribute(entry, saving));\n        }, []);\n      } else if (attribute in hasOne && value) {\n        acc[attribute] = this.serializeSubAttribute(value, saving);\n      } else {\n        acc[attribute] = value;\n      }\n\n      return acc;\n    }, {});\n  }\n\n  public toJSON(): Body {\n    return this.serialize();\n  }\n\n  public request<T = unknown>(args: RequestArgs) {\n    return this.resource().request<T>(args);\n  }\n\n  protected setData(data: Body): void {\n    const {hasMany, hasOne} = this.resource();\n\n    Object.entries(data).forEach(([attribute, val]) => {\n      if (attribute in hasMany) {\n        const HasManyResource: typeof Base = hasMany[attribute];\n        this[attribute] = [];\n        val.forEach((entry: Body) => {\n          const obj = new HasManyResource({session: this.session});\n          if (entry) {\n            obj.setData(entry);\n          }\n\n          this[attribute].push(obj);\n        });\n      } else if (attribute in hasOne) {\n        const HasOneResource: typeof Base = hasOne[attribute];\n        const obj = new HasOneResource({session: this.session});\n        if (val) {\n          obj.setData(val);\n        }\n        this[attribute] = obj;\n      } else {\n        this[attribute] = val;\n      }\n    });\n  }\n\n  protected resource(): typeof Base {\n    return this.constructor as unknown as typeof Base;\n  }\n\n  private serializeSubAttribute(attribute: Base, saving: boolean): Body {\n    return attribute.serialize\n      ? attribute.serialize(saving)\n      : this.resource()\n          .createInstance(this.session, attribute)\n          .serialize(saving);\n  }\n}"
+          },
+          "Session": {
+            "filePath": "../shopify-api/lib/session/session.ts",
+            "importMap": {
+              "InvalidSession": "../shopify-api/lib/error.ts",
+              "OnlineAccessInfo": "../shopify-api/lib/auth/oauth/types.ts",
+              "AuthScopes": "../shopify-api/lib/auth/scopes/index.ts",
+              "SessionParams": "../shopify-api/lib/session/types.ts"
+            },
+            "name": "Session",
+            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "scope",
+                "value": "string",
+                "description": "The desired scopes for the access token, at the time the session was created."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isActive",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeChanged",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isExpired",
+                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
+                "description": "Whether the access token is expired."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toObject",
+                "value": "() => SessionParams",
+                "description": "Converts an object with data into a Session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(other: Session) => boolean",
+                "description": "Checks whether the given session is equal to this session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toPropertyArray",
+                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
+                "description": "Converts the session into an array of key-value pairs."
+              }
+            ],
+            "value": "export class Session {\n  public static fromPropertyArray(\n    entries: [string, string | number | boolean][],\n    returnUserData = false,\n  ): Session {\n    if (!Array.isArray(entries)) {\n      throw new InvalidSession(\n        'The parameter is not an array: a Session cannot be created from this object.',\n      );\n    }\n\n    const obj = Object.fromEntries(\n      entries\n        .filter(([_key, value]) => value !== null && value !== undefined)\n        // Sanitize keys\n        .map(([key, value]) => {\n          switch (key.toLowerCase()) {\n            case 'isonline':\n              return ['isOnline', value];\n            case 'accesstoken':\n              return ['accessToken', value];\n            case 'onlineaccessinfo':\n              return ['onlineAccessInfo', value];\n            case 'userid':\n              return ['userId', value];\n            case 'firstname':\n              return ['firstName', value];\n            case 'lastname':\n              return ['lastName', value];\n            case 'accountowner':\n              return ['accountOwner', value];\n            case 'emailverified':\n              return ['emailVerified', value];\n            default:\n              return [key.toLowerCase(), value];\n          }\n        }),\n    );\n\n    const sessionData = {} as SessionParams;\n    const onlineAccessInfo = {\n      associated_user: {},\n    } as OnlineAccessInfo;\n    Object.entries(obj).forEach(([key, value]) => {\n      switch (key) {\n        case 'isOnline':\n          if (typeof value === 'string') {\n            sessionData[key] = value.toString().toLowerCase() === 'true';\n          } else if (typeof value === 'number') {\n            sessionData[key] = Boolean(value);\n          } else {\n            sessionData[key] = value;\n          }\n          break;\n        case 'scope':\n          sessionData[key] = value.toString();\n          break;\n        case 'expires':\n          sessionData[key] = value ? new Date(Number(value)) : undefined;\n          break;\n        case 'onlineAccessInfo':\n          onlineAccessInfo.associated_user.id = Number(value);\n          break;\n        case 'userId':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.id = Number(value);\n            break;\n          }\n        case 'firstName':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.first_name = String(value);\n            break;\n          }\n        case 'lastName':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.last_name = String(value);\n            break;\n          }\n        case 'email':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.email = String(value);\n            break;\n          }\n        case 'accountOwner':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.account_owner = Boolean(value);\n            break;\n          }\n        case 'locale':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.locale = String(value);\n            break;\n          }\n        case 'collaborator':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.collaborator = Boolean(value);\n            break;\n          }\n        case 'emailVerified':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.email_verified = Boolean(value);\n            break;\n          }\n        // Return any user keys as passed in\n        default:\n          sessionData[key] = value;\n      }\n    });\n    if (sessionData.isOnline) {\n      sessionData.onlineAccessInfo = onlineAccessInfo;\n    }\n    const session = new Session(sessionData);\n    return session;\n  }\n\n  /**\n   * The unique identifier for the session.\n   */\n  readonly id: string;\n  /**\n   * The Shopify shop domain, such as `example.myshopify.com`.\n   */\n  public shop: string;\n  /**\n   * The state of the session. Used for the OAuth authentication code flow.\n   */\n  public state: string;\n  /**\n   * Whether the access token in the session is online or offline.\n   */\n  public isOnline: boolean;\n  /**\n   * The desired scopes for the access token, at the time the session was created.\n   */\n  public scope?: string;\n  /**\n   * The date the access token expires.\n   */\n  public expires?: Date;\n  /**\n   * The access token for the session.\n   */\n  public accessToken?: string;\n  /**\n   * Information on the user for the session. Only present for online sessions.\n   */\n  public onlineAccessInfo?: OnlineAccessInfo;\n\n  constructor(params: SessionParams) {\n    Object.assign(this, params);\n  }\n\n  /**\n   * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n   * scopes if scopes is equal to a truthy value.\n   */\n  public isActive(scopes: AuthScopes | string | string[] | undefined): boolean {\n    const hasAccessToken = Boolean(this.accessToken);\n    const isTokenNotExpired = !this.isExpired();\n    const isScopeChanged = this.isScopeChanged(scopes);\n    return !isScopeChanged && hasAccessToken && isTokenNotExpired;\n  }\n\n  /**\n   * Whether the access token includes the given scopes if they are provided.\n   */\n  public isScopeChanged(\n    scopes: AuthScopes | string | string[] | undefined,\n  ): boolean {\n    if (typeof scopes === 'undefined') {\n      return false;\n    }\n\n    return !this.isScopeIncluded(scopes);\n  }\n\n  /**\n   * Whether the access token includes the given scopes.\n   */\n  public isScopeIncluded(scopes: AuthScopes | string | string[]): boolean {\n    const requiredScopes =\n      scopes instanceof AuthScopes ? scopes : new AuthScopes(scopes);\n    const sessionScopes = new AuthScopes(this.scope);\n\n    return sessionScopes.has(requiredScopes);\n  }\n\n  /**\n   * Whether the access token is expired.\n   */\n  public isExpired(withinMillisecondsOfExpiry = 0): boolean {\n    return Boolean(\n      this.expires &&\n        this.expires.getTime() - withinMillisecondsOfExpiry < Date.now(),\n    );\n  }\n\n  /**\n   * Converts an object with data into a Session.\n   */\n  public toObject(): SessionParams {\n    const object: SessionParams = {\n      id: this.id,\n      shop: this.shop,\n      state: this.state,\n      isOnline: this.isOnline,\n    };\n\n    if (this.scope) {\n      object.scope = this.scope;\n    }\n    if (this.expires) {\n      object.expires = this.expires;\n    }\n    if (this.accessToken) {\n      object.accessToken = this.accessToken;\n    }\n    if (this.onlineAccessInfo) {\n      object.onlineAccessInfo = this.onlineAccessInfo;\n    }\n    return object;\n  }\n\n  /**\n   * Checks whether the given session is equal to this session.\n   */\n  public equals(other: Session | undefined): boolean {\n    if (!other) return false;\n\n    const mandatoryPropsMatch =\n      this.id === other.id &&\n      this.shop === other.shop &&\n      this.state === other.state &&\n      this.isOnline === other.isOnline;\n\n    if (!mandatoryPropsMatch) return false;\n\n    const copyA = this.toPropertyArray(true);\n    copyA.sort(([k1], [k2]) => (k1 < k2 ? -1 : 1));\n\n    const copyB = other.toPropertyArray(true);\n    copyB.sort(([k1], [k2]) => (k1 < k2 ? -1 : 1));\n\n    return JSON.stringify(copyA) === JSON.stringify(copyB);\n  }\n\n  /**\n   * Converts the session into an array of key-value pairs.\n   */\n  public toPropertyArray(\n    returnUserData = false,\n  ): [string, string | number | boolean][] {\n    return (\n      Object.entries(this)\n        .filter(\n          ([key, value]) =>\n            propertiesToSave.includes(key) &&\n            value !== undefined &&\n            value !== null,\n        )\n        // Prepare values for db storage\n        .flatMap(([key, value]): [string, string | number | boolean][] => {\n          switch (key) {\n            case 'expires':\n              return [[key, value ? value.getTime() : undefined]];\n            case 'onlineAccessInfo':\n              // eslint-disable-next-line no-negated-condition\n              if (!returnUserData) {\n                return [[key, value.associated_user.id]];\n              } else {\n                return [\n                  ['userId', value?.associated_user?.id],\n                  ['firstName', value?.associated_user?.first_name],\n                  ['lastName', value?.associated_user?.last_name],\n                  ['email', value?.associated_user?.email],\n                  ['locale', value?.associated_user?.locale],\n                  ['emailVerified', value?.associated_user?.email_verified],\n                  ['accountOwner', value?.associated_user?.account_owner],\n                  ['collaborator', value?.associated_user?.collaborator],\n                ];\n              }\n            default:\n              return [[key, value]];\n          }\n        })\n        // Filter out tuples with undefined values\n        .filter(([_key, value]) => value !== undefined)\n    );\n  }\n}"
+          },
+          "OnlineAccessInfo": {
+            "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+            "importMap": {
+              "AdapterArgs": "../shopify-api/runtime/http/types.ts"
+            },
+            "name": "OnlineAccessInfo",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user",
+                "value": "OnlineAccessUser",
+                "description": "The user associated with the access token."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user_scope",
+                "value": "string",
+                "description": "The effective set of scopes for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires_in",
+                "value": "number",
+                "description": "How long the access token is valid for, in seconds."
+              }
+            ],
+            "value": "export interface OnlineAccessInfo {\n  /**\n   * How long the access token is valid for, in seconds.\n   */\n  expires_in: number;\n  /**\n   * The effective set of scopes for the session.\n   */\n  associated_user_scope: string;\n  /**\n   * The user associated with the access token.\n   */\n  associated_user: OnlineAccessUser;\n}"
+          },
+          "OnlineAccessUser": {
+            "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+            "importMap": {
+              "AdapterArgs": "../shopify-api/runtime/http/types.ts"
+            },
+            "name": "OnlineAccessUser",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "account_owner",
+                "value": "boolean",
+                "description": "Whether the user is the account owner."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "collaborator",
+                "value": "boolean",
+                "description": "Whether the user is a collaborator."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "email",
+                "value": "string",
+                "description": "The user's email address."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "email_verified",
+                "value": "boolean",
+                "description": "Whether the user has verified their email address."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "first_name",
+                "value": "string",
+                "description": "The user's first name."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "number",
+                "description": "The user's ID."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "last_name",
+                "value": "string",
+                "description": "The user's last name."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "locale",
+                "value": "string",
+                "description": "The user's locale."
+              }
+            ],
+            "value": "export interface OnlineAccessUser {\n  /**\n   * The user's ID.\n   */\n  id: number;\n  /**\n   * The user's first name.\n   */\n  first_name: string;\n  /**\n   * The user's last name.\n   */\n  last_name: string;\n  /**\n   * The user's email address.\n   */\n  email: string;\n  /**\n   * Whether the user has verified their email address.\n   */\n  email_verified: boolean;\n  /**\n   * Whether the user is the account owner.\n   */\n  account_owner: boolean;\n  /**\n   * The user's locale.\n   */\n  locale: string;\n  /**\n   * Whether the user is a collaborator.\n   */\n  collaborator: boolean;\n}"
+          },
+          "AuthScopes": {
+            "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+            "name": "AuthScopes",
+            "description": "A class that represents a set of access token scopes.",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "has",
+                "value": "(scope: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes includes the given one."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes equals the given one."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toString",
+                "value": "() => string",
+                "description": "Returns a comma-separated string with the current set of scopes."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toArray",
+                "value": "() => any[]",
+                "description": "Returns an array with the current set of scopes."
+              }
+            ],
+            "value": "class AuthScopes {\n  public static SCOPE_DELIMITER = ',';\n\n  private compressedScopes: Set<string>;\n  private expandedScopes: Set<string>;\n\n  constructor(scopes: string | string[] | AuthScopes | undefined) {\n    let scopesArray: string[] = [];\n    if (typeof scopes === 'string') {\n      scopesArray = scopes.split(\n        new RegExp(`${AuthScopes.SCOPE_DELIMITER}\\\\s*`),\n      );\n    } else if (Array.isArray(scopes)) {\n      scopesArray = scopes;\n    } else if (scopes) {\n      scopesArray = Array.from(scopes.expandedScopes);\n    }\n\n    scopesArray = scopesArray\n      .map((scope) => scope.trim())\n      .filter((scope) => scope.length);\n\n    const impliedScopes = this.getImpliedScopes(scopesArray);\n\n    const scopeSet = new Set(scopesArray);\n    const impliedSet = new Set(impliedScopes);\n\n    this.compressedScopes = new Set(\n      [...scopeSet].filter((x) => !impliedSet.has(x)),\n    );\n    this.expandedScopes = new Set([...scopeSet, ...impliedSet]);\n  }\n\n  /**\n   * Checks whether the current set of scopes includes the given one.\n   */\n  public has(scope: string | string[] | AuthScopes | undefined) {\n    let other: AuthScopes;\n\n    if (scope instanceof AuthScopes) {\n      other = scope;\n    } else {\n      other = new AuthScopes(scope);\n    }\n\n    return (\n      other.toArray().filter((x) => !this.expandedScopes.has(x)).length === 0\n    );\n  }\n\n  /**\n   * Checks whether the current set of scopes equals the given one.\n   */\n  public equals(otherScopes: string | string[] | AuthScopes | undefined) {\n    let other: AuthScopes;\n\n    if (otherScopes instanceof AuthScopes) {\n      other = otherScopes;\n    } else {\n      other = new AuthScopes(otherScopes);\n    }\n\n    return (\n      this.compressedScopes.size === other.compressedScopes.size &&\n      this.toArray().filter((x) => !other.has(x)).length === 0\n    );\n  }\n\n  /**\n   * Returns a comma-separated string with the current set of scopes.\n   */\n  public toString() {\n    return this.toArray().join(AuthScopes.SCOPE_DELIMITER);\n  }\n\n  /**\n   * Returns an array with the current set of scopes.\n   */\n  public toArray() {\n    return [...this.compressedScopes];\n  }\n\n  private getImpliedScopes(scopesArray: string[]): string[] {\n    return scopesArray.reduce((array: string[], current: string) => {\n      const matches = current.match(/^(unauthenticated_)?write_(.*)$/);\n      if (matches) {\n        array.push(`${matches[1] ? matches[1] : ''}read_${matches[2]}`);\n      }\n\n      return array;\n    }, []);\n  }\n}"
+          },
+          "SessionParams": {
+            "filePath": "../shopify-api/lib/session/types.ts",
+            "importMap": {
+              "AdapterArgs": "../shopify-api/runtime/http/index.ts",
+              "OnlineAccessInfo": "../shopify-api/lib/auth/oauth/types.ts",
+              "OnlineAccessUser": "../shopify-api/lib/auth/oauth/types.ts"
+            },
+            "name": "SessionParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "name": "[key: string]",
+                "value": "any"
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scope",
+                "value": "string",
+                "description": "The scopes for the access token.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              }
+            ],
+            "value": "export interface SessionParams {\n  /**\n   * The unique identifier for the session.\n   */\n  readonly id: string;\n  /**\n   * The Shopify shop domain.\n   */\n  shop: string;\n  /**\n   * The state of the session. Used for the OAuth authentication code flow.\n   */\n  state: string;\n  /**\n   * Whether the access token in the session is online or offline.\n   */\n  isOnline: boolean;\n  /**\n   * The scopes for the access token.\n   */\n  scope?: string;\n  /**\n   * The date the access token expires.\n   */\n  expires?: Date;\n  /**\n   * The access token for the session.\n   */\n  accessToken?: string;\n  /**\n   * Information on the user for the session. Only present for online sessions.\n   */\n  onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n  /**\n   * Additional properties of the session allowing for extension\n   */\n  [key: string]: any;\n}"
+          },
+          "StoredOnlineAccessInfo": {
+            "filePath": "../shopify-api/lib/session/types.ts",
+            "importMap": {
+              "AdapterArgs": "../shopify-api/runtime/http/index.ts",
+              "OnlineAccessInfo": "../shopify-api/lib/auth/oauth/types.ts",
+              "OnlineAccessUser": "../shopify-api/lib/auth/oauth/types.ts"
+            },
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StoredOnlineAccessInfo",
+            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n  associated_user: Partial<OnlineAccessUser>;\n}",
+            "description": ""
+          },
+          "SaveArgs": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "importMap": {
+              "RestResourceError": "../shopify-api/lib/error.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "PageInfo": "../shopify-api/lib/clients/admin/types.ts",
+              "RestRequestReturn": "../shopify-api/lib/clients/admin/types.ts",
+              "DataType": "../shopify-api/lib/clients/types.ts",
+              "RestClient": "../shopify-api/lib/clients/admin/rest/client.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "ConfigInterface": "../shopify-api/lib/base-types.ts",
+              "Headers": "../shopify-api/runtime/http/index.ts",
+              "IdSet": "../shopify-api/rest/types.ts",
+              "Body": "../shopify-api/rest/types.ts",
+              "ResourcePath": "../shopify-api/rest/types.ts",
+              "ParamSet": "../shopify-api/rest/types.ts",
+              "ResourceNames": "../shopify-api/rest/types.ts"
+            },
+            "name": "SaveArgs",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "update",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "interface SaveArgs {\n  update?: boolean;\n}"
+          },
+          "Body": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Body",
+            "value": "Record<string, any>",
+            "description": "",
+            "members": []
+          },
+          "RequestArgs": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "importMap": {
+              "RestResourceError": "../shopify-api/lib/error.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "PageInfo": "../shopify-api/lib/clients/admin/types.ts",
+              "RestRequestReturn": "../shopify-api/lib/clients/admin/types.ts",
+              "DataType": "../shopify-api/lib/clients/types.ts",
+              "RestClient": "../shopify-api/lib/clients/admin/rest/client.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "ConfigInterface": "../shopify-api/lib/base-types.ts",
+              "Headers": "../shopify-api/runtime/http/index.ts",
+              "IdSet": "../shopify-api/rest/types.ts",
+              "Body": "../shopify-api/rest/types.ts",
+              "ResourcePath": "../shopify-api/rest/types.ts",
+              "ParamSet": "../shopify-api/rest/types.ts",
+              "ResourceNames": "../shopify-api/rest/types.ts"
+            },
+            "name": "RequestArgs",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "body",
+                "value": "Body | null",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "entity",
+                "value": "Base | null",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "http_method",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "operation",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "params",
+                "value": "ParamSet",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "requireIds",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "urlIds",
+                "value": "IdSet",
+                "description": ""
+              }
+            ],
+            "value": "interface RequestArgs extends BaseFindArgs {\n  http_method: string;\n  operation: string;\n  body?: Body | null;\n  entity?: Base | null;\n}"
+          },
+          "ParamSet": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ParamSet",
+            "value": "Record<string, any>",
+            "description": "",
+            "members": []
+          },
+          "IdSet": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "IdSet",
+            "value": "Record<string, string | number | null>",
+            "description": "",
+            "members": []
+          },
+          "RestRequestReturn": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "importMap": {
+              "ClientResponse": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
+            },
+            "name": "RestRequestReturn",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "body",
+                "value": "T",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "Headers",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "pageInfo",
+                "value": "PageInfo",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface RestRequestReturn<T = any> {\n  body: T;\n  headers: Headers;\n  pageInfo?: PageInfo;\n}"
+          },
+          "PageInfo": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "importMap": {
+              "ClientResponse": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
+            },
+            "name": "PageInfo",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "fields",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "limit",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "nextPage",
+                "value": "PageInfoParams",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "nextPageUrl",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "previousPageUrl",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "prevPage",
+                "value": "PageInfoParams",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface PageInfo {\n  limit: string;\n  fields?: string[];\n  previousPageUrl?: string;\n  nextPageUrl?: string;\n  prevPage?: PageInfoParams;\n  nextPage?: PageInfoParams;\n}"
+          },
+          "PageInfoParams": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "importMap": {
+              "ClientResponse": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "SearchParams": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
+              "ApiVersion": "../shopify-api/lib/types.ts",
+              "Session": "../shopify-api/lib/session/session.ts",
+              "Headers": "../shopify-api/runtime/index.ts"
+            },
+            "name": "PageInfoParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "path",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "SearchParams",
+                "description": ""
+              }
+            ],
+            "value": "export interface PageInfoParams {\n  path: string;\n  query: SearchParams;\n}"
+          },
           "SingleMerchantApp": {
             "filePath": "src/server/types.ts",
             "importMap": {
@@ -12120,6 +8593,59 @@
             ],
             "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n  Future extends FutureFlagOptions = FutureFlagOptions,\n> extends Omit<\n    ApiConfigArg<Resources, ApiFutureFlags<Future>>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n    | 'future'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * Optional for apps created in the Shopify Admin.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage?: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * AppStore should be used for public apps that are distributed in the Shopify App Store.\n   * SingleMerchant should be used for custom apps managed in the Partner Dashboard.\n   * ShopifyAdmin should be used for apps that are managed in the merchant's Shopify Admin.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n\n  /**\n   * Features that will be introduced in future releases of this package.\n   *\n   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future\n   * releases in advance and provide feedback on the new features.\n   */\n  future?: Future;\n}"
           },
+          "ApiVersion": {
+            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "April23",
+                "value": "2023-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July23",
+                "value": "2023-07"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "October23",
+                "value": "2023-10"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "January24",
+                "value": "2024-01"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "April24",
+                "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          },
           "BillingConfig": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
             "importMap": {
@@ -12195,6 +8721,34 @@
               }
             ],
             "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `OneTime`.\n     */\n    interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
           },
           "BillingConfigSubscriptionLineItemPlan": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -12314,6 +8868,70 @@
             ],
             "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    /**\n     * The number of intervals to apply the discount for.\n     */\n    durationLimitInIntervals?: number;\n    /**\n     * The discount to apply.\n     */\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
           },
+          "BillingConfigSubscriptionPlanDiscountAmount": {
+            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+            "importMap": {
+              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
+              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
+              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
+              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
+              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
+              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
+            },
+            "name": "BillingConfigSubscriptionPlanDiscountAmount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "never",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountPercentage": {
+            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+            "importMap": {
+              "BillingInterval": "../shopify-api/dist/ts/lib/types.d.ts",
+              "BillingReplacementBehavior": "../shopify-api/dist/ts/lib/types.d.ts",
+              "RecurringBillingIntervals": "../shopify-api/dist/ts/lib/types.d.ts",
+              "Session": "../shopify-api/dist/ts/lib/session/session.d.ts",
+              "FeatureEnabled": "../shopify-api/dist/ts/future/flags.d.ts",
+              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
+              "FutureFlags": "../shopify-api/dist/ts/future/flags.d.ts"
+            },
+            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "never",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "number",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
+          },
           "BillingConfigUsageLineItem": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
             "importMap": {
@@ -12333,7 +8951,7 @@
                 "syntaxKind": "PropertySignature",
                 "name": "amount",
                 "value": "number",
-                "description": "The amount to charge for this line item."
+                "description": "The capped amount or the maximum amount to be charged in the interval."
               },
               {
                 "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -12357,7 +8975,7 @@
                 "description": "Usage terms for this line item."
               }
             ],
-            "value": "export interface BillingConfigUsageLineItem extends BillingConfigLineItem {\n    /**\n     * The usage interval for this line item.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * Usage terms for this line item.\n     */\n    terms: string;\n}"
+            "value": "export interface BillingConfigUsageLineItem extends BillingConfigLineItem {\n    /**\n     * The usage interval for this line item.\n     *\n     * Must be set to `Usage`.\n     */\n    interval: BillingInterval.Usage;\n    /**\n     * The capped amount or the maximum amount to be charged in the interval.\n     */\n    amount: number;\n    /**\n     * Usage terms for this line item.\n     */\n    terms: string;\n}"
           },
           "BillingReplacementBehavior": {
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -12607,40 +9225,6 @@
               }
             ],
             "value": "export interface AfterAuthOptions<\n  R extends ShopifyRestResources = ShopifyRestResources,\n> {\n  session: Session;\n  admin: AdminApiContext<R>;\n}"
-          },
-          "LogFunction": {
-            "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts",
-            "importMap": {
-              "FutureFlagOptions": "../shopify-api/dist/ts/future/flags.d.ts",
-              "ShopifyRestResources": "../shopify-api/dist/ts/rest/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "BillingConfig": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/types.d.ts",
-              "LogSeverity": "../shopify-api/dist/ts/lib/types.d.ts"
-            },
-            "name": "LogFunction",
-            "description": "A function used by the library to log events related to Shopify.",
-            "params": [
-              {
-                "name": "severity",
-                "description": "",
-                "value": "LogSeverity",
-                "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts"
-              },
-              {
-                "name": "msg",
-                "description": "",
-                "value": "string",
-                "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts",
-              "description": "",
-              "name": "void",
-              "value": "void"
-            },
-            "value": "export type LogFunction = (severity: LogSeverity, msg: string) => void;"
           },
           "LogSeverity": {
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
@@ -13004,349 +9588,6 @@
               }
             ],
             "value": "export interface UnauthenticatedAdminContext<\n  Resources extends ShopifyRestResources,\n> {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use to get shop-specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.admin(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the given store.\n   *\n   * @example\n   * <caption>Performing a GET request to the REST API.</caption>\n   * <description>Use `admin.rest.get` to make custom requests to make a request to to the `customer/count` endpoint</description>\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *  const { admin, session } = await unauthenticated.admin(request);\n   *\n   *  const response = await admin.rest.get(\n   *    {\n   *      path: \"/customers/count.json\"\n   *    }\n   *  );\n   *  const customers = await response.json();\n   *\n   *  return json({ customers });\n   * };\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *  restResources,\n   *  // ...etc\n   * });\n   *\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `admin.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *  const { admin } = await unauthenticated.admin(request);\n   *\n   *  const response = await admin.graphql(\n   *    `#graphql\n   *    mutation populateProduct($input: ProductInput!) {\n   *      productCreate(input: $input) {\n   *        product {\n   *          id\n   *        }\n   *      }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *  const productData = await response.json();\n   *  return json({ data: productData.data });\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *  restResources,\n   *  // ...etc\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -13526,349 +9767,6 @@
             ],
             "value": "export interface UnauthenticatedStorefrontContext {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use this to get shop specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.storefront(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Method for interacting with the Shopify GraphQL Storefront API for the given store.\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `storefront.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   *\n   * @example\n   * <caption>Handling GraphQL errors.</caption>\n   * <description>Catch `GraphqlQueryError` errors to see error messages from the API.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   try {\n   *     const response = await storefront.graphql(\n   *       `#graphql\n   *       query incorrectQuery {\n   *         products(first: 10) {\n   *           nodes {\n   *             not_a_field\n   *           }\n   *         }\n   *       }`,\n   *     );\n   *\n   *     return json({ data: await response.json() });\n   *   } catch (error) {\n   *     if (error instanceof GraphqlQueryError) {\n   *       // { errors: { graphQLErrors: [\n   *       //   { message: \"Field 'not_a_field' doesn't exist on type 'Product'\" }\n   *       // ] } }\n   *       return json({ errors: error.body?.errors }, { status: 500 });\n   *     }\n   *     return json({ message: \"An error occurred\" }, { status: 500 });\n   *   }\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
           },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "importMap": {
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "AuthScopes": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-              "SessionParams": "../shopify-api/dist/ts/lib/session/types.d.ts"
-            },
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/types.d.ts"
-            },
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "() => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "importMap": {
-              "AdapterArgs": "../shopify-api/dist/ts/runtime/http/index.d.ts",
-              "OnlineAccessInfo": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-              "OnlineAccessUser": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts"
-            },
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
           "StorefrontContext": {
             "filePath": "src/server/clients/storefront/types.ts",
             "importMap": {
@@ -13922,8 +9820,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLClient",
             "description": "",
@@ -13958,8 +9855,7 @@
               "FetchResponseBody": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ApiClientRequestOptions": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
               "ResponseWithType": "../../api-clients/admin-api-client/dist/ts/index.d.ts",
-              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts",
-              "Headers": "../shopify-api/runtime/index.ts"
+              "ApiVersion": "../shopify-api/dist/ts/lib/index.d.ts"
             },
             "name": "GraphQLQueryOptions",
             "description": "",
@@ -13998,59 +9894,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/mock-responses.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/__tests__/mock-responses.ts
@@ -35,6 +35,21 @@ export const EXISTING_SUBSCRIPTION = JSON.stringify({
   },
 });
 
+export const MULTIPLE_SUBSCRIPTIONS = JSON.stringify({
+  data: {
+    currentAppInstallation: {
+      oneTimePurchases: {
+        edges: [],
+        pageInfo: {hasNextPage: false, endCursor: null},
+      },
+      activeSubscriptions: [
+        {id: 'gid://123', name: PLAN_1, test: true},
+        {id: 'gid://321', name: PLAN_2, test: true},
+      ],
+    },
+  },
+});
+
 export const PURCHASE_SUBSCRIPTION_RESPONSE = JSON.stringify({
   data: {
     appSubscriptionCreate: {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/check.ts
@@ -12,7 +12,9 @@ export function checkBillingFactory<Config extends AppConfigArg>(
   request: Request,
   session: Session,
 ) {
-  return async function checkBilling(options: CheckBillingOptions<Config>) {
+  return async function checkBilling(
+    options: CheckBillingOptions<Config> = {},
+  ) {
     const {api, logger} = params;
 
     logger.debug('Checking billing plans', {shop: session.shop, ...options});

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
@@ -1,10 +1,8 @@
 import {
   AppSubscription,
   BillingCheckParams,
-  BillingCheckResponse,
   BillingCheckResponseObject,
   BillingRequestParams,
-  Session,
 } from '@shopify/shopify-api';
 
 import type {AppConfigArg} from '../../../config-types';
@@ -223,17 +221,7 @@ export interface BillingContext<Config extends AppConfigArg> {
    */
   check: <Options extends CheckBillingOptions<Config>>(
     options?: Options,
-  ) => Promise<
-    BillingCheckResponse<
-      Options & {
-        session: Session;
-        returnObject: true;
-        plans?: Options['plans'] extends (keyof Config['billing'])[]
-          ? string[]
-          : undefined;
-      }
-    >
-  >;
+  ) => Promise<BillingCheckResponseObject>;
 
   /**
    * Requests payment for the plan.

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
@@ -1,8 +1,10 @@
 import {
   AppSubscription,
   BillingCheckParams,
+  BillingCheckResponse,
   BillingCheckResponseObject,
   BillingRequestParams,
+  Session,
 } from '@shopify/shopify-api';
 
 import type {AppConfigArg} from '../../../config-types';
@@ -24,7 +26,7 @@ export interface CheckBillingOptions<Config extends AppConfigArg>
   /**
    * The plans to check for. Must be one of the values defined in the `billing` config option.
    */
-  plans: (keyof Config['billing'])[];
+  plans?: (keyof Config['billing'])[];
 }
 
 export interface RequestBillingOptions<Config extends AppConfigArg>
@@ -219,9 +221,19 @@ export interface BillingContext<Config extends AppConfigArg> {
    * ```
    *
    */
-  check: (
-    options: CheckBillingOptions<Config>,
-  ) => Promise<BillingCheckResponseObject>;
+  check: <Options extends CheckBillingOptions<Config>>(
+    options?: Options,
+  ) => Promise<
+    BillingCheckResponse<
+      Options & {
+        session: Session;
+        returnObject: true;
+        plans?: Options['plans'] extends (keyof Config['billing'])[]
+          ? string[]
+          : undefined;
+      }
+    >
+  >;
 
   /**
    * Requests payment for the plan.

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/billing/types.ts
@@ -184,8 +184,8 @@ export interface BillingContext<Config extends AppConfigArg> {
    *     plans: [MONTHLY_PLAN],
    *     isTest: false,
    *   });
-   *  console.log(hasActivePayment)
-   *  console.log(appSubscriptions)
+   *   console.log(hasActivePayment);
+   *   console.log(appSubscriptions);
    * };
    * ```
    * ```ts
@@ -218,6 +218,23 @@ export interface BillingContext<Config extends AppConfigArg> {
    * export const authenticate = shopify.authenticate;
    * ```
    *
+   * @example
+   * <caption>Check for payments without filtering.</caption>
+   * <description>Use billing.check to see if any payments exist for the store, regardless of whether it's a test or
+   * matches one or more plans.</description>
+   * ```ts
+   * // /app/routes/**\/*.ts
+   * import { LoaderFunctionArgs } from "@remix-run/node";
+   * import { authenticate, MONTHLY_PLAN } from "../shopify.server";
+   *
+   * export const loader = async ({ request }: LoaderFunctionArgs) => {
+   *   const { billing } = await authenticate.admin(request);
+   *   const { hasActivePayment, appSubscriptions } = await billing.check();
+   *   // This will be true if any payment is found
+   *   console.log(hasActivePayment);
+   *   console.log(appSubscriptions);
+   * };
+   * ```
    */
   check: <Options extends CheckBillingOptions<Config>>(
     options?: Options,

--- a/packages/apps/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/apps/shopify-app-remix/src/server/future/flags.ts
@@ -32,6 +32,7 @@ export interface FutureFlags {
 export interface ApiFutureFlags<_Future extends FutureFlagOptions> {
   // We're currently hardcoding this flag to true in our settings, so we should propagate it here
   lineItemBilling: true;
+  unstable_managedPricingSupport: true;
 }
 
 export type ApiConfigWithFutureFlags<Future extends FutureFlagOptions> =

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -172,6 +172,7 @@ export function deriveApi(appConfig: AppConfigArg): BasicParams['api'] {
     billing: appConfig.billing as ApiConfig['billing'],
     future: {
       lineItemBilling: true,
+      unstable_managedPricingSupport: true,
     },
     _logDisabledFutureFlags: false,
   });


### PR DESCRIPTION
### WHY are these changes introduced?

Shopify has introduced [managed pricing](https://shopify.dev/docs/apps/launch/billing/managed-pricing) for apps, so they don't need to set up the billing plans in their configs any more. They can configure billing directly when publishing the app, and use the billing API to look for subscriptions.

However, the current code in these packages forced apps to pass in a set of plans to filter by when querying the API, and those plans needed to match the configuration object.

### WHAT is this pull request doing?

Since no config object is needed when using managed billing, we should make it possible to call `check` without a config.

## Type of change

- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
