### PR TITLE
[Chore] Restore CI to latest Node 22 version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [18, 20, 22.4.1]
+        version: [18, 20, 22]
     steps:
       - uses: actions/checkout@master
       - uses: actions/setup-node@v3


### PR DESCRIPTION
### WHY are these changes introduced?

In #1233, we had to change the CI node version because there was an issue using `yarn` with 22.5.0. This seems to have been fixed in 22.5.1, so we can go back to using the latest version of 22.

### WHAT is this pull request doing?

Restoring the original CI config.