### PR TITLE
Add scopes api middleware and react client component

### DIFF
--- a/packages/apps/shopify-app-remix/src/react/clients/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/clients/index.ts
@@ -1,0 +1,1 @@
+export * from './optionalScopes';

--- a/packages/apps/shopify-app-remix/src/react/clients/optionalScopes.ts
+++ b/packages/apps/shopify-app-remix/src/react/clients/optionalScopes.ts
@@ -1,0 +1,28 @@
+import {ScopesInformation} from '../../server/authenticate/admin/scope/types';
+// eslint-disable-next-line @shopify/strict-component-boundaries
+import {useAppContext} from '../components/AppContext';
+
+export const useScopesApi = () => {
+  const {baseAuthPath, scopesApiSubpath} = useAppContext();
+  const scopesApiPath = `${baseAuthPath}${scopesApiSubpath}`;
+
+  const query = async (): Promise<ScopesInformation> => {
+    const response = await fetch(`${scopesApiPath}/query`);
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Failed to query scopes');
+  };
+
+  const revoke = async (scopes: string[]): Promise<ScopesInformation> => {
+    const response = await fetch(
+      `${scopesApiPath}/revoke?scopes=${scopes.join(',')}`,
+    );
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Failed to revoke scopes');
+  };
+
+  return {query, revoke};
+};

--- a/packages/apps/shopify-app-remix/src/react/components/AppContext/AppContext.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppContext/AppContext.tsx
@@ -1,0 +1,16 @@
+import {createContext, useContext} from 'react';
+
+interface AppContext {
+  baseAuthPath: string;
+  scopesApiSubpath: string;
+}
+
+export const AppContext = createContext<AppContext | undefined>(undefined);
+
+export const useAppContext = () => {
+  const context = useContext(AppContext);
+  if (!context) {
+    throw new Error('useAppContext must be used within an AppProvider');
+  }
+  return context;
+};

--- a/packages/apps/shopify-app-remix/src/react/components/AppContext/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/components/AppContext/index.ts
@@ -1,0 +1,1 @@
+export * from './AppContext';

--- a/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
@@ -9,6 +9,7 @@ import englishI18n from '@shopify/polaris/locales/en.json' with {type: 'json'};
 
 import {APP_BRIDGE_URL} from '../../const';
 import {RemixPolarisLink} from '../RemixPolarisLink';
+import {AppContext} from '../AppContext';
 
 export interface AppProviderProps
   extends Omit<PolarisAppProviderProps, 'linkComponent' | 'i18n'> {
@@ -36,6 +37,10 @@ export interface AppProviderProps
    * @private
    */
   __APP_BRIDGE_URL?: string;
+
+  baseAuthPath?: string;
+
+  scopesApiSubpath?: string;
 }
 
 /**
@@ -108,6 +113,8 @@ export function AppProvider(props: AppProviderProps) {
     i18n,
     isEmbeddedApp = true,
     __APP_BRIDGE_URL = APP_BRIDGE_URL,
+    baseAuthPath = '/auth',
+    scopesApiSubpath = '/scopes',
     ...polarisProps
   } = props;
 
@@ -119,7 +126,9 @@ export function AppProvider(props: AppProviderProps) {
         linkComponent={RemixPolarisLink}
         i18n={i18n || englishI18n}
       >
-        {children}
+        <AppContext.Provider value={{baseAuthPath, scopesApiSubpath}}>
+          {children}
+        </AppContext.Provider>
       </PolarisAppProvider>
     </>
   );

--- a/packages/apps/shopify-app-remix/src/react/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './clients';

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/setup-embedded-flow.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/setup-embedded-flow.ts
@@ -7,10 +7,14 @@ import {getJwt} from './get-jwt';
 import {setUpValidSession} from './setup-valid-session';
 import {testConfig} from './test-config';
 
-export async function setUpEmbeddedFlow(basePath = `${APP_URL}?`) {
+export async function setUpEmbeddedFlow(
+  basePath = `${APP_URL}?`,
+  scopesPath = '/scopes',
+) {
   const shopify = shopifyApp(
     testConfig({
       authPathPrefix: '/auth',
+      scopePathPrefix: scopesPath,
       future: {unstable_newEmbeddedAuthStrategy: false},
       restResources,
     }),

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/setup-embedded-flow.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/setup-embedded-flow.ts
@@ -7,9 +7,10 @@ import {getJwt} from './get-jwt';
 import {setUpValidSession} from './setup-valid-session';
 import {testConfig} from './test-config';
 
-export async function setUpEmbeddedFlow() {
+export async function setUpEmbeddedFlow(basePath = `${APP_URL}?`) {
   const shopify = shopifyApp(
     testConfig({
+      authPathPrefix: '/auth',
       future: {unstable_newEmbeddedAuthStrategy: false},
       restResources,
     }),
@@ -18,7 +19,7 @@ export async function setUpEmbeddedFlow() {
 
   const {token} = getJwt();
   const request = new Request(
-    `${APP_URL}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+    `${basePath}embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
   );
 
   return {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/respond-to-scopes-api-request.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/respond-to-scopes-api-request.test.ts
@@ -23,6 +23,27 @@ it('returns not found error when the scopes api is disabled', async () => {
   }
 });
 
+it('query request returns scopes information using a different scopes api subpath', async () => {
+  // GIVEN
+  await mockGraphqlRequest(ApiVersion.Unstable)(
+    200,
+    responses.WITH_GRANTED_AND_DECLARED,
+  );
+
+  // WHEN
+  try {
+    await requestToScopesApi('query', undefined, '/customscopessubpath');
+  } catch (response) {
+    // THEN
+    expect(response instanceof Response).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.granted.required).toEqual(['read_orders']);
+    expect(data.granted.optional).toEqual(['write_customers']);
+    expect(data.declared.required).toEqual(['write_orders', 'read_reports']);
+  }
+});
+
 it('query request returns scopes information', async () => {
   // GIVEN
   await mockGraphqlRequest(ApiVersion.Unstable)(
@@ -99,10 +120,10 @@ it('revokes request revoke the scope and returns scopes information', async () =
   }
 });
 
-async function requestToScopesApi(api: string, params?: any) {
+async function requestToScopesApi(api: string, params?: any, scopesPath = '/scopes') {
   const queryParams = new URLSearchParams(params);
-  const queryRequestPath = `${APP_URL}/auth/scopes/${api}?${queryParams.toString()}&`;
-  await setUpEmbeddedFlow(queryRequestPath);
+  const queryRequestPath = `${APP_URL}/auth${scopesPath}/${api}?${queryParams.toString()}&`;
+  await setUpEmbeddedFlow(queryRequestPath, scopesPath);
 }
 
 async function requestToDisabledScopesApi(api: string) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/respond-to-scopes-api-request.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/respond-to-scopes-api-request.test.ts
@@ -1,0 +1,128 @@
+import {restResources} from '@shopify/shopify-api/rest/admin/2023-04';
+import {ApiVersion} from '@shopify/shopify-api';
+
+import {
+  getJwt,
+  mockGraphqlRequest,
+  mockGraphqlRequests,
+  setUpEmbeddedFlow,
+  setUpValidSession,
+  testConfig,
+} from '../../../__test-helpers';
+import * as responses from '../scope/__tests__/mock-responses';
+import {APP_URL, BASE64_HOST, TEST_SHOP} from '../../../__test-helpers/const';
+import {shopifyApp} from '../../../shopify-app';
+
+it('returns not found error when the scopes api is disabled', async () => {
+  // WHEN
+  try {
+    await requestToDisabledScopesApi('query');
+  } catch (response) {
+    // THEN
+    expect(response.status).toEqual(404);
+  }
+});
+
+it('query request returns scopes information', async () => {
+  // GIVEN
+  await mockGraphqlRequest(ApiVersion.Unstable)(
+    200,
+    responses.WITH_GRANTED_AND_DECLARED,
+  );
+
+  // WHEN
+  try {
+    await requestToScopesApi('query');
+  } catch (response) {
+    // THEN
+    expect(response instanceof Response).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.granted.required).toEqual(['read_orders']);
+    expect(data.granted.optional).toEqual(['write_customers']);
+    expect(data.declared.required).toEqual(['write_orders', 'read_reports']);
+  }
+});
+
+it('request redirects to install URL when successful', async () => {
+  // GIVEN
+  await mockGraphqlRequest()(200, responses.WITH_GRANTED_AND_DECLARED);
+
+  // WHEN
+  try {
+    await requestToScopesApi('request', {
+      scopes: ['write_products', 'read_orders', 'write_customers'],
+    });
+  } catch (response) {
+    // THEN
+    expect(response.status).toEqual(401);
+    const reuthorizeHeader = response.headers.get(
+      'x-shopify-api-request-failure-reauthorize-url',
+    );
+    expect(reuthorizeHeader).not.toBeUndefined();
+    const location = new URL(reuthorizeHeader!);
+    expect(location.hostname).toBe(TEST_SHOP);
+    expect(location.pathname).toBe('/admin/oauth/install');
+    const locationParams = location.searchParams;
+    expect(locationParams.get('optional_scopes')).toBe(
+      'write_products,read_orders,write_customers',
+    );
+  }
+});
+
+it('revokes request revoke the scope and returns scopes information', async () => {
+  // GIVEN
+  await mockGraphqlRequests()(
+    {
+      body: 'AppRevokeAccessScopes',
+      responseContent: responses.REVOKED_WITHOUT_ERROR,
+    },
+    {
+      body: 'FetchAccessScopes',
+      responseContent: responses.WITH_GRANTED_AND_DECLARED,
+    },
+  );
+
+  // WHEN
+  try {
+    await requestToScopesApi('revoke', {
+      scopes: ['write_products', 'read_orders', 'write_customers'],
+    });
+  } catch (response) {
+    // THEN
+    expect(response instanceof Response).toBeTruthy();
+    const data = await response.json();
+
+    expect(data.granted.required).toEqual(['read_orders']);
+    expect(data.granted.optional).toEqual(['write_customers']);
+    expect(data.declared.required).toEqual(['write_orders', 'read_reports']);
+  }
+});
+
+async function requestToScopesApi(api: string, params?: any) {
+  const queryParams = new URLSearchParams(params);
+  const queryRequestPath = `${APP_URL}/auth/scopes/${api}?${queryParams.toString()}&`;
+  await setUpEmbeddedFlow(queryRequestPath);
+}
+
+async function requestToDisabledScopesApi(api: string) {
+  const shopify = shopifyApp(
+    testConfig({
+      authPathPrefix: '/auth',
+      future: {
+        unstable_newEmbeddedAuthStrategy: false,
+        unstable_optionalScopesApi: false,
+      },
+      restResources,
+    }),
+  );
+
+  await setUpValidSession(shopify.sessionStorage);
+
+  const {token} = getJwt();
+  const request = new Request(
+    `${APP_URL}/auth/scopes/${api}?embedded=1&shop=${TEST_SHOP}&host=${BASE64_HOST}&id_token=${token}`,
+  );
+
+  await shopify.authenticate.admin(request);
+}

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -10,6 +10,7 @@ import {
   respondToOptionsRequest,
   validateSessionToken,
 } from '../helpers';
+import {respondToScopeRequest} from '../helpers/respond-to-scopes-api-request';
 
 import {
   cancelBillingFactory,
@@ -165,6 +166,13 @@ export function authStrategyFactory<
         shop,
       });
 
+      const context = createContext(request, session, strategy, payload);
+      const scopesApi = scopesApiFactory(
+        params,
+        context.session,
+        context.admin,
+      );
+      await respondToScopeRequest(request, config, scopesApi);
       return createContext(request, session, strategy, payload);
     } catch (errorOrResponse) {
       if (errorOrResponse instanceof Response) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/respond-to-scopes-api-request.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/respond-to-scopes-api-request.ts
@@ -12,7 +12,9 @@ export async function respondToScopeRequest(
 
   const url = new URL(request.url);
 
-  const path = (path: string) => `${config.authPathPrefix}/scopes/${path}`;
+  const scopeApiSubPath = config.scopePathPrefix ?? '/scopes';
+  const path = (path: string) =>
+    `${config.authPathPrefix}${scopeApiSubPath}/${path}`;
 
   switch (url.pathname) {
     case path('request'):

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/respond-to-scopes-api-request.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/respond-to-scopes-api-request.ts
@@ -1,0 +1,56 @@
+import {AppConfigArg} from '../../config-types';
+import {ScopesApiContext} from '../admin/scope/types';
+
+export async function respondToScopeRequest(
+  request: Request,
+  config: AppConfigArg,
+  scopesApi: ScopesApiContext,
+): Promise<undefined> | never {
+  if (!config.future?.unstable_optionalScopesApi) {
+    throw new Response(undefined, {status: 404});
+  }
+
+  const url = new URL(request.url);
+
+  const path = (path: string) => `${config.authPathPrefix}/scopes/${path}`;
+
+  switch (url.pathname) {
+    case path('request'):
+      await requestScopes(url, scopesApi);
+      break;
+    case path('query'):
+      await query(scopesApi);
+      break;
+    case path('revoke'):
+      await revoke(url, scopesApi);
+      break;
+  }
+}
+
+async function query(api: ScopesApiContext) {
+  const scopesInformation = await api.query();
+
+  throw buildJsonResponse({...scopesInformation});
+}
+
+async function revoke(url: URL, api: ScopesApiContext) {
+  const scopes = url.searchParams.get('scopes')?.split(',') ?? [];
+
+  const scopesInformation = await api.revoke(scopes);
+  throw buildJsonResponse({...scopesInformation});
+}
+
+async function requestScopes(url: URL, api: ScopesApiContext) {
+  const scopes = url.searchParams.get('scopes')?.split(',') ?? [];
+
+  await api.request(scopes);
+}
+
+function buildJsonResponse(content?: object, status = 200) {
+  return new Response(content ? JSON.stringify(content) : undefined, {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
+}

--- a/packages/apps/shopify-app-remix/src/server/config-types.ts
+++ b/packages/apps/shopify-app-remix/src/server/config-types.ts
@@ -233,6 +233,8 @@ export interface AppConfigArg<
    * releases in advance and provide feedback on the new features.
    */
   future?: Future;
+
+  scopePathPrefix?: string;
 }
 
 export interface AppConfig<Storage extends SessionStorage = SessionStorage>


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes: https://github.com/Shopify/develop-app-runtime-primitives/issues/389

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Adds a 'middleware' to expose the following endpoints
  - `/auth/scopes/query` - Runs and returns the scopes.query api
  - `/auth/scopes/request?scopes=` - Runs and redirects the response using scopes.request api
  - `/auth/scopes/revoke?scopes=` - Runs and returns the scopes.revoke api
- The `/scopes` subpath is configurable when the `shopifyApp` is created. The final subpath relies on the `authPathPrefix` config param. By default the value is '/auth/scopes'
- If the unstable flag is disabled, the endpoints will return an NOT FOUND (404) error
- Adds a React hook `useScopesApi` to abstract the access to the middleware.
- Adds an `AppContext` to the `AppProvider` so the `AppProvider` config params are accessible from the children.
- Adds the following config params to the `AppProvider`. These will be used by the new `useScopesApi` hook
  - `baseAuthPath` - default `/auth`
  - `scopesApiSubpath` - default `/scopes`

- [Modifications](https://github.com/Shopify/burst-optional-scopes-app/compare/add-support-for-revoke-scopes-api...integrate-scopes-api-client) in the sample Remix app created to 🎩 the library:
  - Scopes inspector uses the new client so it's autonomous and doesn't require receiving the scopes information (we could create some kind of scopesInformation context that uses the api instead)
  - `revoke` endpoint is removed from the app as the scopes client uses the middleware endpoint
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

### Tophat 🎩
<details>
<summary><b><i><u>1. Setup using an embedded app</u></i></b></summary><br/>

- Check out the Remix sample app used to 🎩 the modifications
```sh
dev clone burst-optional-scopes-app
git checkout integrate-scopes-api-client
```
- Install the dependencies and the local copy of the `shopify-app-js` library
```sh
yarn setup
yarn install
yarn build:dependencies
```
- Install the CLI or update it to the latest version
```
npm install -g @shopify/cli@latest
```
- `link` your local app with a new remote app
```sh
shopify app config link
```
- Access the shopify internal dashboard in spin and enable the beta `app_access_optional_scopes` for the new remote app
- Edit your `toml` to include the following `scopes` configuration:
```toml
[access_scopes]
scopes = "write_customers"
optional_scopes = ["write_products"]
```
- `deploy` a new app version
```sh
shopify app deploy
```
- Run the `dev` command and preview the app
```sh
shopify app dev
```

</details>

<details>
<summary><b><i><u>2. Using the default scopes middleware path</u></i></b></summary><br/>

- The information in the scopes inspector is fetched using the client
- Access the products maker section and grant the optional scope.
- Revoke the scope from the scopes inspector that uses the client (for now you'll need to refresh the page to see the results 😅)

</details>

<details>
<summary><b><i><u>3. Using the a custom scopes middleware path</u></i></b></summary><br/>

- Stop the app
- Edit and modify the file `app/shopify.server.js`

```ts
...
const shopify = shopifyApp({
  ...
  authPathPrefix: "/auth",
  scopePathPrefix: "/custom-scopes",
  isEmbeddedApp: true,
  ...
})
...
```

- Edit and modify the file `app/routes/app.jsx`


```ts
...
AppProvider isEmbeddedApp={true} scopesApiSubpath={'/customs-scopes'} apiKey={apiKey}>
...
```

- Run the app again and you should be able to access the 

</details>

<details>
<summary><b><i><u>4. Error when the future flag is disabled</u></i></b></summary><br/>

- Stop the app
- Edit and modify the file `app/shopify.server.js`

```ts
...
const shopify = shopifyApp({
  ...
    future: {
    unstable_newEmbeddedAuthStrategy: true,
    unstable_optionalScopesApi: false,
  },
  ...
})
...
```
- Start the app
- You should see this error page because the api client is receiving 404 errors from the middleware. Maybe we could return a dynamic type for the `useScopesApi` based on some property to enable the scopes feature in the `AppContext`. So for TS devs they could see a `compile` error if the try to use any of the apis `revoke`, `query`, ....

<img src="https://github.com/user-attachments/assets/79a8092f-135b-4545-a0f7-444168a5b9c3" width=400/>



```ts
...
AppProvider isEmbeddedApp={true} scopesApiSubpath={'/customs-scopes'} apiKey={apiKey}>
...
```

- Run the app again and you should be able to access the 

</details>

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

