### PR TITLE
Add Scopes component to request optional scopes from the frontend

### DIFF
--- a/packages/apps/shopify-app-remix/src/react/components/AppContext/AppContext.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppContext/AppContext.tsx
@@ -1,0 +1,22 @@
+import {createContext, useContext} from 'react';
+
+export interface ScopesApiConfig {
+  basePath: string;
+  requestPath: string;
+  queryPath: string;
+}
+
+interface AppContext {
+  scopesApi: ScopesApiConfig;
+  isEmbeddedApp: boolean;
+}
+
+export const AppContext = createContext<AppContext | undefined>(undefined);
+
+export const useAppContext = () => {
+  const context = useContext(AppContext);
+  if (!context) {
+    throw new Error('useAppContext must be used within an AppProvider');
+  }
+  return context;
+};

--- a/packages/apps/shopify-app-remix/src/react/components/AppContext/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/components/AppContext/index.ts
@@ -1,0 +1,1 @@
+export * from './AppContext';

--- a/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
@@ -9,6 +9,8 @@ import englishI18n from '@shopify/polaris/locales/en.json' with {type: 'json'};
 
 import {APP_BRIDGE_URL} from '../../const';
 import {RemixPolarisLink} from '../RemixPolarisLink';
+import {AppContext, ScopesApiConfig} from '../AppContext';
+import {OptionalScopesProvider} from '../OptionalScopesProvider';
 
 export interface AppProviderProps
   extends Omit<PolarisAppProviderProps, 'linkComponent' | 'i18n'> {
@@ -36,6 +38,8 @@ export interface AppProviderProps
    * @private
    */
   __APP_BRIDGE_URL?: string;
+
+  scopesApiConfig?: Partial<ScopesApiConfig>;
 }
 
 /**
@@ -108,6 +112,7 @@ export function AppProvider(props: AppProviderProps) {
     i18n,
     isEmbeddedApp = true,
     __APP_BRIDGE_URL = APP_BRIDGE_URL,
+    scopesApiConfig,
     ...polarisProps
   } = props;
 
@@ -119,8 +124,35 @@ export function AppProvider(props: AppProviderProps) {
         linkComponent={RemixPolarisLink}
         i18n={i18n || englishI18n}
       >
-        {children}
+        <AppContext.Provider
+          value={deriveAppContext(isEmbeddedApp, scopesApiConfig)}
+        >
+          <OptionalScopesProvider>{children}</OptionalScopesProvider>
+        </AppContext.Provider>
       </PolarisAppProvider>
     </>
   );
+}
+
+function deriveAppContext(
+  isEmbeddedApp: boolean,
+  scopesApiConfig?: Partial<ScopesApiConfig>,
+) {
+  return {
+    scopesApi: deriveScopesApiConfig(scopesApiConfig),
+    isEmbeddedApp,
+  };
+}
+
+function deriveScopesApiConfig(scopesApiConfig?: Partial<ScopesApiConfig>) {
+  const defaultScopesApiConfig: ScopesApiConfig = {
+    basePath: '/auth/scopes',
+    requestPath: '/request',
+    queryPath: '/query',
+  };
+
+  return {
+    ...defaultScopesApiConfig,
+    ...scopesApiConfig,
+  };
 }

--- a/packages/apps/shopify-app-remix/src/react/components/OptionalScopesProvider/OptionalScopesProvider.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/OptionalScopesProvider/OptionalScopesProvider.tsx
@@ -1,0 +1,288 @@
+/* eslint-disable no-nested-ternary */
+import {
+  useState,
+  createContext,
+  useContext,
+  ReactNode,
+  useEffect,
+  useRef,
+} from 'react';
+// import {useNavigate} from '@remix-run/react';
+import {Modal, Spinner} from '@shopify/polaris';
+
+import {useAppContext} from '../AppContext';
+import {ScopesInformation} from '../../../server/authenticate/admin/scope/types';
+
+interface RequestScopesConfig {
+  modal?: boolean;
+}
+export interface RequestScopesParams {
+  scopes: string[];
+  onGrant: () => void;
+  onAlreadyGranted?: () => void;
+  config?: RequestScopesConfig;
+}
+interface OptionalScopesContextProps {
+  requestScopes: (params: RequestScopesParams) => Promise<void>;
+}
+
+const OptionalScopesContext = createContext<
+  OptionalScopesContextProps | undefined
+>(undefined);
+
+interface OptionalScopesProviderProps {
+  children: ReactNode;
+}
+
+export function OptionalScopesProvider({
+  children,
+}: OptionalScopesProviderProps) {
+  const {scopesApi, isEmbeddedApp} = useAppContext();
+  const [showModal, setShowModal] = useState(false);
+  const [authWindow, setAuthWindow] = useState<Window | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [granted, setGranted] = useState(false);
+  const [intervalChecker, setIntervalChecker] = useState<NodeJS.Timeout | null>(
+    null,
+  );
+  const [checkWindowClosed, setCheckWindowClosed] =
+    useState<NodeJS.Timeout | null>(null);
+  const [timeout, setTimeoutReached] = useState(false);
+  const [currentScopes, setCurrentScopes] = useState<string[]>([]);
+  const currentScopesRef = useRef(currentScopes);
+  currentScopesRef.current = currentScopes;
+  const [onGrant, setOnGrant] = useState<(() => void) | null>(null);
+  const [providerConfig, setProviderConfig] = useState<
+    RequestScopesConfig | undefined
+  >(undefined);
+
+  const showModalEnabled = (config?: RequestScopesConfig) =>
+    config?.modal !== false;
+
+  const missingScopes = async (scopes: string[]) => {
+    const {
+      granted: {optional},
+    } = await query!();
+    return scopes.filter((scope) => !optional.includes(scope));
+  };
+
+  const scopesAlreadyGranted = async (scopes: string[]) => {
+    const missing = await missingScopes(scopes);
+    return missing.length === 0;
+  };
+
+  const query = async (): Promise<ScopesInformation> => {
+    const response = await fetch(`${scopesApi.basePath}${scopesApi.queryPath}`);
+    if (response.status === 200) {
+      return response.json();
+    }
+    throw new Error('Failed to query scopes');
+  };
+
+  const requestScopes = async ({
+    scopes,
+    onGrant,
+    onAlreadyGranted,
+    config,
+  }: RequestScopesParams) => {
+    // Compnent not supported for embedded apps. Once the app bridge api to request optioanl scopes is available,
+    // it will be integrated here so the component can be used for embedded apps as well.
+    if (isEmbeddedApp) return;
+
+    setProviderConfig(config);
+    setCurrentScopes(scopes);
+    setOnGrant(() => onGrant);
+    if (await scopesAlreadyGranted(scopes)) {
+      if (onAlreadyGranted) {
+        onAlreadyGranted();
+      } else {
+        onGrant();
+      }
+    } else if (showModalEnabled(config)) {
+      setShowModal(true);
+    } else {
+      onConfirm();
+    }
+  };
+
+  const onConfirm = () => {
+    setLoading(true);
+    const width = 600;
+    const height = 600;
+    const left = screen.width / 2 - width / 2;
+    const top = screen.height / 2 - height / 2;
+    const authWindow = window.open(
+      `${scopesApi.basePath}${scopesApi.requestPath}?scopes=${currentScopesRef.current}`,
+      'Shopify - Grant Scopes',
+      `scrollbars=no, resizable=no, width=${width}, height=${height}, top=${top}, left=${left}`,
+    );
+    setAuthWindow(authWindow);
+  };
+
+  const onCancel = () => {
+    resetState();
+  };
+
+  const onOk = async () => {
+    if (onGrant) {
+      onGrant();
+    }
+    resetState();
+  };
+
+  const resetState = () => {
+    if (intervalChecker) clearInterval(intervalChecker);
+    setIntervalChecker(null);
+    if (checkWindowClosed) clearInterval(checkWindowClosed);
+    setCheckWindowClosed(null);
+    setShowModal(false);
+    if (authWindow) authWindow.close();
+    setAuthWindow(null);
+    setLoading(false);
+    setCurrentScopes([]);
+    setGranted(false);
+    setTimeoutReached(false);
+    setOnGrant(null);
+  };
+
+  const getTitle = () => {
+    if (loading) return 'Confirm permissions';
+    if (granted) return 'Permissions granted';
+    if (timeout) return 'Problem with confirmation';
+    return 'Missing permissions';
+  };
+
+  const getPrimaryAction = () => {
+    if (granted) {
+      return {
+        content: 'Close',
+        onAction: onOk,
+      };
+    }
+    if (timeout) {
+      return {
+        content: 'Close',
+        onAction: onCancel,
+      };
+    }
+    if (!loading) {
+      return {
+        content: 'Confirm',
+        onAction: onConfirm,
+      };
+    }
+    return undefined;
+  };
+
+  // Check if the popup window page has been confirmed (requested scopes are granted)
+  // Otherwise, after 60 seconds, the popup window is automatically closed
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (loading) {
+      let count = 0;
+      const interval = setInterval(async () => {
+        if (await scopesAlreadyGranted(currentScopesRef.current)) {
+          if (authWindow) authWindow.close();
+          if (checkWindowClosed) clearInterval(checkWindowClosed);
+          clearInterval(interval);
+          setLoading(false);
+          setGranted(true);
+          if (!showModalEnabled(providerConfig)) {
+            onOk();
+          }
+        } else if (count > 60) {
+          if (authWindow) authWindow.close();
+          if (checkWindowClosed) clearInterval(checkWindowClosed);
+          clearInterval(interval);
+          setLoading(false);
+          setTimeoutReached(true);
+          if (!showModalEnabled(providerConfig)) {
+            onCancel();
+          }
+        }
+        count++;
+      }, 1000);
+
+      setIntervalChecker(interval);
+      return () => clearInterval(interval);
+    }
+  }, [loading, currentScopesRef]);
+
+  // Check if the popup window has been closed manually
+  // eslint-disable-next-line consistent-return
+  useEffect(() => {
+    if (authWindow) {
+      const checkWindowClosed = setInterval(() => {
+        if (authWindow.closed) {
+          clearInterval(checkWindowClosed);
+          if (intervalChecker) clearInterval(intervalChecker);
+          setLoading(false);
+          setTimeoutReached(true);
+          if (!showModalEnabled(providerConfig)) {
+            onCancel();
+          }
+        }
+      }, 1000);
+      setCheckWindowClosed(checkWindowClosed);
+      return () => clearInterval(checkWindowClosed);
+    }
+  }, [authWindow, intervalChecker]);
+
+  return (
+    <OptionalScopesContext.Provider value={{requestScopes}}>
+      {children}
+      <Modal
+        open={showModal}
+        onClose={onCancel}
+        title={getTitle()}
+        primaryAction={getPrimaryAction()}
+        secondaryActions={
+          !loading && !granted && !timeout
+            ? [
+                {
+                  content: 'Cancel',
+                  onAction: onCancel,
+                },
+              ]
+            : undefined
+        }
+      >
+        <Modal.Section>
+          {loading ? (
+            <>
+              <Spinner size="small" accessibilityLabel="Spinner example" />
+              <p>
+                Please, grant the required permission in the opened window and
+                come back here once it's done.
+              </p>
+            </>
+          ) : granted ? (
+            <>
+              <p>You have granted the required scopes.</p>
+            </>
+          ) : timeout ? (
+            <p>
+              Unfortunately the permissions confirmation has not been completed.
+              Please, close this banner and try it again later.
+            </p>
+          ) : (
+            <p>
+              You are missing some required permissions. Please confirm to
+              request them.
+            </p>
+          )}
+        </Modal.Section>
+      </Modal>
+    </OptionalScopesContext.Provider>
+  );
+}
+
+export function useOptionalScopes() {
+  const context = useContext(OptionalScopesContext);
+  if (!context) {
+    throw new Error(
+      'useOptionalScopes must be used within a OptionalScopesProvider',
+    );
+  }
+  return context;
+}

--- a/packages/apps/shopify-app-remix/src/react/components/OptionalScopesProvider/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/components/OptionalScopesProvider/index.ts
@@ -1,0 +1,1 @@
+export * from './OptionalScopesProvider';

--- a/packages/apps/shopify-app-remix/src/react/components/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/components/index.ts
@@ -2,3 +2,4 @@ export * from './AppProvider';
 export * from './AppProxyProvider';
 export * from './AppProxyForm';
 export * from './AppProxyLink';
+export * from './OptionalScopesProvider';

--- a/packages/apps/shopify-app-remix/src/react/utilities/defer.ts
+++ b/packages/apps/shopify-app-remix/src/react/utilities/defer.ts
@@ -1,0 +1,17 @@
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason?: any) => void;
+}
+
+export function defer<T>(): Deferred<T> {
+  let resolve: (value: T) => void;
+  let reject: (reason?: any) => void;
+  // eslint-disable-next-line promise/param-names
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return {promise, resolve: resolve!, reject: reject!};
+}

--- a/packages/apps/shopify-app-remix/src/react/utilities/index.ts
+++ b/packages/apps/shopify-app-remix/src/react/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from './defer';


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Closes: https://github.com/Shopify/develop-app-runtime-primitives/issues/390

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
- Creates a new OptionalScopesProvider react component to request optional scopes from the frontend to avoid server redirections
- For now the component only supports `non embedded apps`. Once the app-bridge api to request optional scopes is available it will be integrated in this component
- The method signature to request optional scopes is:
  ```
     requestScopes({
       scopes: string[];
       onGrant: () => void;
       onAlreadyGranted?: () => void;
     }
   ```
  - `scopes` - The list of scopes to request
  - `onGrant` - The action to run in case the scopes are not granted and the user grants them (ie. update some UI)
  - `onAlreadyGranted` - The action to run in case the requested scopes are already granted (ie. create a product)

- How the component works
  - Checks if the requested scopes are already granted or not. In case of the former, the onAlreadyGranted is executed and the action returns automatically
  - Otherwise, opens a modal to warn the user that some scopes are missing and a new window will be open to display the admin grant page
  - If the user goes on, a new popup window with the grant page is opened.
    - The window is automatically closed if the user grants the missing scopes
    - The window is automatically closed if the scopes are not granted after 60 seconds (inactivity or the user cancel the grant page)
  - After the window is closed, the user closes the modal and the `onGrant` action is executed if the user has confirmed the scopes

- Requirements 
  - The app should expose an endpoint to return the `ScopesInformation` using the `scopes.query` api
  - The app should expose an endpoint to run the redirection to the grant page using the `scopes.request` api. The `scopes` are sent as a query param
  - By default the endpoints used by the component are
    - `{APP_URL}/auth/scopes/query`
    -  `{APP_URL}/auth/scopes/request?scopes=`
  - The base path `/auth/scopes` and the subpaths `query` and `request` are configurable through the `AppProvider`

- [Modifications](https://github.com/Shopify/burst-optional-scopes-app/compare/add-support-for-revoke-scopes-api...add-support-for-the-scopes-react-provider) in the sample Remix app created to 🎩 the library:
  - Configured the app as `non embedded`
  - Access to the `Products maker` section requires `read_products` using server side redirection
  - The button to create a new product requires `write_products` and will use the new component to request it
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

### Tophat 🎩
<details>
<summary><b><i><u>1. Setup using a non embedded app</u></i></b></summary><br/>

- Check out the Remix sample app used to 🎩 the modifications
```sh
dev clone burst-optional-scopes-app
git checkout add-support-for-the-scopes-react-provider
```
- Install the dependencies and the local copy of the `shopify-app-js` library
```sh
yarn setup
yarn install
yarn build:dependencies
```
- Install the CLI or update it to the latest version
```
npm install -g @shopify/cli@latest
```
- `link` your local app with a new remote app
```sh
shopify app config link
```
- Access the shopify internal dashboard in spin and enable the beta `app_access_optional_scopes` for the new remote app
- Edit your `toml` to include the following `scopes` configuration:
```toml
embedded = false
...
[access_scopes]
scopes = "write_customers"
optional_scopes = ["write_products"]
```
- `deploy` a new app version
```sh
shopify app deploy
```
- Run the `dev` command and preview the app
```sh
shopify app dev
```

</details>

<details>
<summary><b><i><u>2. Granting the scope to create products</u></i></b></summary><br/>

- Access the `Products maker` section and grant the `read_products` scope when it's required
- Click on the button to create a product
- Confirm the modal to go to the grant page
- A new window will be opened with the grant page. Confirm it
- Click on the create product button again and a new product will be created.

</details>

[Demo video](https://share.descript.com/view/nFZBzZxxMgS)


## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

