### PR TITLE
Create automerge changeset for non-dev deps

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -15,6 +15,12 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
+      - name: Create changeset if not dev dependency
+        run: ./dependabot_auto_merge_changeset.sh
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type != 'direct:development' }}
+        env:
+          DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Add skip changelog label
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:development' }}

--- a/.github/workflows/dependabot_auto_merge_changeset.sh
+++ b/.github/workflows/dependabot_auto_merge_changeset.sh
@@ -1,0 +1,37 @@
+pr_number=$(gh pr view --json number --jq '.number')
+changeset_filename=".changeset/dependabot-$pr_number.md"
+
+if [ -f $changeset_filename ]; then
+  echo "Changeset $changeset_filename already exists, skipping"
+  exit 0
+fi
+
+package_names=()
+for file in $(gh pr diff --name-only)
+do
+  if [[ "$file" =~ ^packages\/.*\/package.json$ ]]; then
+    echo "Found changed package.json: $file"
+
+    package_name=$(cat $file | jq -r '.name')
+    package_names+=("$package_name")
+  fi
+done
+
+package_updates=""
+for package_name in "${package_names[@]}"
+do
+  package_updates="$package_updates'$package_name': patch\n"
+done
+
+dependencies='`'$(sed "s/,/\`, \`/g" <<< "$DEPENDENCIES")'`'
+echo "\nCreating changeset: $changeset_filename"
+echo "---
+$package_updates---
+
+Updated $dependencies dependencies
+" > $changeset_filename
+
+echo "Adding changeset to git"
+git add $changeset_filename
+git commit --amend --no-edit
+git push --force-with-lease


### PR DESCRIPTION
### WHY are these changes introduced?

Currently, when a non-dev dependency dependabot update comes in, we need to manually add a changeset to the PR, which means dependabot will no longer automatically rebase the PR and so it becomes a manual job.

### WHAT is this pull request doing?

Enhancing the auto-merge action to add a changeset file with the PR number to the existing dependabot commit, which will hopefully enable us to test, approve, and merge PRs without having to make changes in most cases, which should speed up the process.

Example output:

```
Found changed package.json: packages/apps/session-storage/shopify-app-session-storage-prisma/package.json
Found changed package.json: packages/apps/shopify-app-remix/package.json

Creating changeset: .changeset/dependabot-1266.md
```

File contents:
```
---
'@shopify/shopify-app-session-storage-prisma': patch
'@shopify/shopify-app-remix': patch
---

Updated `@prisma/client`, `prisma` dependencies
```