### PR TITLE
Fix dependabot auto-changeset workflow

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -15,19 +15,26 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
-      - name: Create changeset if not dev dependency
+
+      - name: Checkout (not dev dep)
+        uses: actions/checkout@master
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type != 'direct:development' }}
+
+      - name: Create changeset (not dev dep)
         run: ./dependabot_auto_merge_changeset.sh
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type != 'direct:development' }}
         env:
           DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Add skip changelog label
+
+      - name: Add skip changelog label (dev dep)
         uses: actions-ecosystem/action-add-labels@v1
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:development' }}
         with:
           labels: Skip Changelog
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Enable auto-merge for Dependabot PRs
+
+      - name: Enable auto-merge for Dependabot PRs (dev dep)
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type == 'direct:development' }}
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
This PR fixes the workflow for automatically adding a changeset to dependabot PRs which wasn't checking out the repo, and therefore couldn't run the script.