### PR TITLE
Fixing dependabot workflow

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -19,6 +19,8 @@ jobs:
       - name: Checkout (not dev dep)
         uses: actions/checkout@master
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type != 'direct:development' }}
+        with:
+          ref: ${{ github.head_ref }}
 
       - name: Create changeset (not dev dep)
         run: .github/workflows/dependabot_auto_merge_changeset.sh

--- a/.github/workflows/dependabot_auto_merge_changeset.sh
+++ b/.github/workflows/dependabot_auto_merge_changeset.sh
@@ -24,12 +24,16 @@ do
 done
 
 dependencies='`'$(sed "s/,/\`, \`/g" <<< "$DEPENDENCIES")'`'
-echo "\nCreating changeset: $changeset_filename"
+echo "Creating changeset: $changeset_filename"
 echo "---
 $package_updates---
 
 Updated $dependencies dependencies
 " > $changeset_filename
+
+echo "Configuring git"
+git config user.name github-actions
+git config user.email github-actions@github.com
 
 echo "Adding changeset to git"
 git add $changeset_filename


### PR DESCRIPTION
This PR is hopefully the last to fix the dependabot PR to auto-create changesets, to set the right user and branch for the git operations.