### PR TITLE
Fix changeset workflow line breaks

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           .github/workflows/dependabot_auto_merge_changeset.sh
           git config user.name "github-actions[bot]"
-          git config user.email "noreply@shopify.com"
+          git config user.email "github-actions@github.com"
           git add .changeset
           git commit -m "[dependabot skip] Adding changeset for dependabot update"
           git push

--- a/.github/workflows/dependabot_auto_merge_changeset.sh
+++ b/.github/workflows/dependabot_auto_merge_changeset.sh
@@ -20,13 +20,13 @@ done
 package_updates=""
 for package_name in "${package_names[@]}"
 do
-  package_updates="$package_updates"`printf "'%s': patch%s" $package_name "\n"`
+  package_updates="$package_updates"`printf "
+'%s': patch" $package_name`
 done
 
 dependencies='`'$(sed "s/,/\`, \`/g" <<< "$DEPENDENCIES")'`'
 echo "Creating changeset: $changeset_filename"
-echo "---
-$package_updates---
+echo "---$package_updates
+---
 
-Updated $dependencies dependencies
-" > $changeset_filename
+Updated $dependencies dependencies" > $changeset_filename


### PR DESCRIPTION
This PR stops using `\n`s in the code for the workflow since those don't translate to actions.