### PR TITLE
Use a different action bot for auto-changesets

### DIFF
--- a/.github/workflows/dependabot_auto_merge.yml
+++ b/.github/workflows/dependabot_auto_merge.yml
@@ -29,7 +29,7 @@ jobs:
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' && steps.metadata.outputs.dependency-type != 'direct:development' }}
         env:
           DEPENDENCIES: ${{ steps.metadata.outputs.dependency-names }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SHOPIFY_GH_ACCESS_TOKEN }}
 
       - name: Add skip changelog label (dev dep)
         uses: actions-ecosystem/action-add-labels@v1

--- a/.github/workflows/dependabot_auto_merge_changeset.sh
+++ b/.github/workflows/dependabot_auto_merge_changeset.sh
@@ -32,8 +32,8 @@ echo "---$package_updates
 Updated $dependencies dependencies" > $changeset_filename
 
 echo "Committing changeset"
-git config user.name "github-actions[bot]"
-git config user.email "github-actions[bot]@users.noreply.github.com"
+git config user.name "shopify-github-actions-access[bot]"
+git config user.email "shopify-github-actions-access[bot]@users.noreply.github.com"
 git add .changeset
 git commit -m "[dependabot skip] Adding changeset for dependabot update"
 git push


### PR DESCRIPTION
This PR sets up the auto-changesets job to use the GAAP bot instead of the normal actions-bot from GH, so we can run workflows after commits.