### PR TITLE
Fixed admin.redirect issue with relative URLs

### DIFF
--- a/.changeset/unlucky-bananas-beam.md
+++ b/.changeset/unlucky-bananas-beam.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fixed an issue with relative URLs in the admin context `redirect` helper, which caused it to fail on Safari.

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/helpers/redirect.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/helpers/redirect.ts
@@ -25,7 +25,7 @@ export function redirectFactory(
 
   return function redirect(url, init: RedirectInit) {
     const {searchParams} = new URL(request.url);
-    const parsedUrl = parseURL(url, request.url, shop);
+    const parsedUrl = parseURL(url, config.appUrl, shop);
 
     logger.debug('Redirecting', {url: parsedUrl.toString()});
 


### PR DESCRIPTION
### WHY are these changes introduced?

In the admin context `redirect` helper, we build a full app URL from a relative one, but we were using `request.url` instead.

When tunnelling, we might get an HTTP URL in `request.url`, which would trigger a protocol switch, which Safari blocks.

### WHAT is this pull request doing?

Using `config.appUrl` as the base URL instead.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
