### PR TITLE
[Chore] Enhance error message on missing env var

### DIFF
--- a/.changeset/wet-roses-knock.md
+++ b/.changeset/wet-roses-knock.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Improved the error message when an empty appUrl configuration is received to remind the developer to set the environment variables.

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -144,9 +144,12 @@ export function deriveApi(appConfig: AppConfigArg): BasicParams['api'] {
   try {
     appUrl = new URL(appConfig.appUrl);
   } catch (error) {
-    throw new ShopifyError(
-      'Invalid appUrl provided. Please provide a valid URL.',
-    );
+    const message =
+      appConfig.appUrl === ''
+        ? `Detected an empty appUrl configuration. If you're deploying your app, make sure to set the necessary environment variables.\n` +
+          `Learn more at https://shopify.dev/docs/apps/launch/deployment/deploy-web-app/deploy-to-hosting-service#step-4-set-up-environment-variables`
+        : `Invalid appUrl configuration '${appConfig.appUrl}', please provide a valid URL.`;
+    throw new ShopifyError(message);
   }
 
   /* eslint-disable no-process-env */

--- a/packages/apps/shopify-app-remix/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-remix/src/server/shopify-app.ts
@@ -146,8 +146,8 @@ export function deriveApi(appConfig: AppConfigArg): BasicParams['api'] {
   } catch (error) {
     const message =
       appConfig.appUrl === ''
-        ? `Detected an empty appUrl configuration. If you're deploying your app, make sure to set the necessary environment variables.\n` +
-          `Learn more at https://shopify.dev/docs/apps/launch/deployment/deploy-web-app/deploy-to-hosting-service#step-4-set-up-environment-variables`
+        ? `Detected an empty appUrl configuration, please make sure to set the necessary environment variables.\n` +
+          `If you're deploying your app, you can find more information at https://shopify.dev/docs/apps/launch/deployment/deploy-web-app/deploy-to-hosting-service#step-4-set-up-environment-variables`
         : `Invalid appUrl configuration '${appConfig.appUrl}', please provide a valid URL.`;
     throw new ShopifyError(message);
   }


### PR DESCRIPTION
### WHY are these changes introduced?

When the app starts and environment variables are not set up, we're currently showing an `invalid app URL` message, which doesn't help debug the issue, particularly when deploying the app.

### WHAT is this pull request doing?

Adding a special case for an empty URL (the first value we check) to show this error message:

> Error: Detected an empty appUrl configuration. If you're deploying your app, make sure to set the necessary environment variables.
> Learn more at https://shopify.dev/docs/apps/launch/deployment/deploy-web-app/deploy-to-hosting-service#step-4-environment-variables

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)