### PR TITLE
Pin graphql-config version to prevent node 20 update

### DIFF
--- a/.changeset/hot-planes-lick.md
+++ b/.changeset/hot-planes-lick.md
@@ -1,0 +1,5 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+Pinned `graphql-config` version to prevent a forced upgrade to Node 20+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        # When removing v18, unpin graphql-config version
         version: [18, 20, 22]
     steps:
       - uses: actions/checkout@master

--- a/package.json
+++ b/package.json
@@ -60,6 +60,14 @@
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "node-fetch": "^2.6.7",
-    "ts-jest": "^29.1.2"
+    "ts-jest": "^29.1.3",
+    "graphql-config": "5.1.0"
+  },
+  "overrides": {
+    "jest": "^29.7.0",
+    "jest-circus": "^29.7.0",
+    "node-fetch": "^2.6.7",
+    "ts-jest": "^29.1.3",
+    "graphql-config": "5.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,8 @@ overrides:
   jest: ^29.7.0
   jest-circus: ^29.7.0
   node-fetch: ^2.6.7
-  ts-jest: ^29.1.2
+  ts-jest: ^29.1.3
+  graphql-config: 5.1.0
 
 importers:
 
@@ -111,7 +112,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       ts-jest:
-        specifier: ^29.1.2
+        specifier: ^29.1.3
         version: 29.2.3(@babel/core@7.24.4)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.4))(jest@29.7.0(@types/node@22.3.0)(ts-node@10.9.2(@swc/core@1.7.11)(@types/node@22.3.0)(typescript@5.5.4)))(typescript@5.5.4)
       ts-node:
         specifier: ^10.9.2


### PR DESCRIPTION
### WHY are these changes introduced?

In https://github.com/kamilkisiela/graphql-config/blob/master/CHANGELOG.md#511, the `minimatch` update forced the Node engine version to 20, but Node 18 is still supported.

### WHAT is this pull request doing?

Pinning the `graphql-config` version to 5.1.0 to prevent the unintended update.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
