### PR TITLE
Improved type safety of generated codegen configs

### DIFF
--- a/.changeset/yellow-apes-occur.md
+++ b/.changeset/yellow-apes-occur.md
@@ -1,0 +1,5 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+Improved type safety of generated configurations

--- a/packages/api-clients/api-codegen-preset/package.json
+++ b/packages/api-clients/api-codegen-preset/package.json
@@ -77,6 +77,7 @@
   },
   "devDependencies": {
     "@graphql-codegen/plugin-helpers": "^5.0.4",
+    "graphql-config": "5.1.0",
     "regenerator-runtime": "^0.14.1"
   }
 }

--- a/packages/api-clients/api-codegen-preset/src/api-project.ts
+++ b/packages/api-clients/api-codegen-preset/src/api-project.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 
 import {pluckConfig} from '@shopify/graphql-codegen';
+import type {IGraphQLProject, SchemaPointer} from 'graphql-config';
 
 import {type ShopifyApiProjectOptions} from './types';
 import {shopifyApiTypes} from './api-types';
@@ -14,18 +15,16 @@ export const shopifyApiProject = ({
   documents = ['**/*.{ts,tsx}', '!node_modules'],
   declarations = true,
   apiKey,
-}: ShopifyApiProjectOptions) => {
-  const {schema, schemaFile} = getSchemaData(
-    outputDir,
-    apiType,
+}: ShopifyApiProjectOptions): IGraphQLProject => {
+  const {schema, schemaFile} = getSchemaData(outputDir, apiType, {
     apiVersion,
     apiKey,
-  );
+  });
 
   const schemaFileExists = fs.existsSync(`${schemaFile}`);
 
   return {
-    schema: schemaFileExists ? schemaFile : schema,
+    schema: schemaFileExists ? schemaFile : (schema as SchemaPointer),
     documents,
     extensions: {
       codegen: {

--- a/packages/api-clients/api-codegen-preset/src/api-types.ts
+++ b/packages/api-clients/api-codegen-preset/src/api-types.ts
@@ -1,5 +1,7 @@
 import fs from 'fs';
 
+import type {CodegenConfig} from '@graphql-codegen/cli';
+
 import {preset} from './preset';
 import {type ShopifyApiTypesOptions} from './types';
 import {getSchemaData} from './helpers/get-schema-data';
@@ -13,13 +15,11 @@ export const shopifyApiTypes = ({
   documents = ['**/*.{ts,tsx}', '!**/node_modules'],
   declarations = true,
   apiKey,
-}: ShopifyApiTypesOptions) => {
-  const {schema, schemaFile} = getSchemaData(
-    outputDir,
-    apiType,
+}: ShopifyApiTypesOptions): CodegenConfig['generates'] => {
+  const {schema, schemaFile} = getSchemaData(outputDir, apiType, {
     apiVersion,
     apiKey,
-  );
+  });
   const {typesFile, queryTypesFile} = getOutputFiles(apiType, declarations);
 
   const schemaFileExists = fs.existsSync(`${schemaFile}`);

--- a/packages/api-clients/api-codegen-preset/src/helpers/get-schema-data.ts
+++ b/packages/api-clients/api-codegen-preset/src/helpers/get-schema-data.ts
@@ -1,54 +1,81 @@
+import type {CodegenConfig} from '@graphql-codegen/cli';
+
 import {ApiType} from '../types';
 
 import {apiConfigs} from './api-configs';
 
+interface SchemaData {
+  schema: CodegenConfig['schema'];
+  schemaFile: string;
+}
+
+interface ValuesOptions {
+  apiKey?: string;
+  apiVersion?: string;
+}
+
 export function getSchemaData(
   outputDir: string,
   apiType: ApiType,
-  apiVersion?: string,
-  apiKey?: string,
-) {
-  const config = apiConfigs[apiType];
-
-  if (apiType === ApiType.Customer) {
-    if (!apiKey) {
-      throw new Error('The customer API requires an API key');
-    }
-
-    const schemaUrl = (() => {
-      const schemaWithApiKey = config.schema.replace('%%API_KEY%%', apiKey);
-
-      if (apiVersion) {
-        return schemaWithApiKey.replace('%%API_VERSION%%', apiVersion);
+  values: ValuesOptions,
+): SchemaData {
+  switch (apiType) {
+    case ApiType.Customer:
+      if (!values.apiKey) {
+        throw new Error('The customer API requires an API key');
       }
 
-      return schemaWithApiKey.replace('&api_version=%%API_VERSION%%', '');
-    })();
+      return getCustomerApiSchema(outputDir, values);
+    default:
+      return getSchema(apiType, outputDir, values);
+  }
+}
 
-    const schema = [
-      {
-        [schemaUrl]: {
-          method: 'GET',
-        },
-      },
-    ];
+function getSchema(
+  apiType: ApiType,
+  outputDir: string,
+  values: ValuesOptions,
+): SchemaData {
+  const config = apiConfigs[apiType];
 
-    const schemaFile = `${outputDir}/${config.schemaFile.replace(
-      '%%API_VERSION%%',
-      apiVersion ? `-${apiVersion}` : '',
-    )}`;
-
-    return {schema, schemaFile};
+  let schema = config.schema;
+  let schemaFile = config.schemaFile;
+  if (values.apiVersion) {
+    schema = schema.replace('%%API_VERSION%%', `/${values.apiVersion}`);
+    schemaFile = schemaFile.replace('%%API_VERSION%%', `-${values.apiVersion}`);
+  } else {
+    schema = schema.replace('%%API_VERSION%%', '');
+    schemaFile = schemaFile.replace('%%API_VERSION%%', '');
   }
 
   return {
-    schema: config.schema.replace(
-      '%%API_VERSION%%',
-      apiVersion ? `/${apiVersion}` : '',
-    ),
-    schemaFile: `${outputDir}/${config.schemaFile.replace(
-      '%%API_VERSION%%',
-      apiVersion ? `-${apiVersion}` : '',
-    )}`,
+    schema,
+    schemaFile: `${outputDir}/${schemaFile}`,
+  };
+}
+
+function getCustomerApiSchema(
+  outputDir: string,
+  values: ValuesOptions,
+): SchemaData {
+  const config = apiConfigs[ApiType.Customer];
+
+  let schema = config.schema;
+  let schemaFile = config.schemaFile;
+  if (values.apiVersion) {
+    schema = schema.replace('%%API_VERSION%%', values.apiVersion);
+    schemaFile = schemaFile.replace('%%API_VERSION%%', `-${values.apiVersion}`);
+  } else {
+    schema = schema.replace('&api_version=%%API_VERSION%%', '');
+    schemaFile = schemaFile.replace('%%API_VERSION%%', '');
+  }
+
+  if (values.apiKey) {
+    schema = schema.replace('%%API_KEY%%', values.apiKey);
+  }
+
+  return {
+    schema: [{[schema]: {method: 'GET', headers: {}}}],
+    schemaFile: `${outputDir}/${schemaFile}`,
   };
 }

--- a/packages/api-clients/api-codegen-preset/src/tests/helpers.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/helpers.ts
@@ -5,6 +5,7 @@ export function getExpectedSchema(type: string, versioned: boolean) {
           [`https://app.myshopify.com/services/graphql/introspection/customer?api_client_api_key=test${versioned ? '&api_version=2023-10' : ''}`]:
             {
               method: 'GET',
+              headers: {},
             },
         },
       ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,6 +164,9 @@ importers:
       '@graphql-codegen/plugin-helpers':
         specifier: ^5.0.4
         version: 5.0.4(graphql@16.9.0)
+      graphql-config:
+        specifier: 5.1.0
+        version: 5.1.0(@types/node@22.3.0)(encoding@0.1.13)(graphql@16.9.0)(typescript@5.5.4)
       regenerator-runtime:
         specifier: ^0.14.1
         version: 0.14.1
@@ -2943,29 +2946,29 @@ packages:
     os: [win32]
 
   '@shopify/babel-preset@25.0.0':
-    resolution: {integrity: sha512-2eVmLPGMLEdZ2u93pikVcwAf+XTpzYMtphFwuE1ZwlxBSQZg2H6OWbt/rnS79fAiJUmS7DSUel+ZlBzdSlg6Bg==}
+    resolution: {integrity: sha512-2eVmLPGMLEdZ2u93pikVcwAf+XTpzYMtphFwuE1ZwlxBSQZg2H6OWbt/rnS79fAiJUmS7DSUel+ZlBzdSlg6Bg==, tarball: https://registry.npmjs.org/@shopify/babel-preset/-/babel-preset-25.0.0.tgz}
 
   '@shopify/eslint-plugin@45.0.0':
-    resolution: {integrity: sha512-aRgVkl+EovLk6OC4WzT+C6hgAyta5VReEIdetpe+/bJhVovlqbFjYa3yHGvEM4VuWv8sim7XH2VV3ZsDiwpgvQ==}
+    resolution: {integrity: sha512-aRgVkl+EovLk6OC4WzT+C6hgAyta5VReEIdetpe+/bJhVovlqbFjYa3yHGvEM4VuWv8sim7XH2VV3ZsDiwpgvQ==, tarball: https://registry.npmjs.org/@shopify/eslint-plugin/-/eslint-plugin-45.0.0.tgz}
     peerDependencies:
       eslint: ^8.56.0
 
   '@shopify/generate-docs@0.16.3':
-    resolution: {integrity: sha512-JebkdZ1u0oF3iKDaejrT3nn/tI0Q2az81h/GSbM/viTQ6Qs4IPxOJr8coPmcGBelMjbT5/zZE03N5YYJl/YlOA==}
+    resolution: {integrity: sha512-JebkdZ1u0oF3iKDaejrT3nn/tI0Q2az81h/GSbM/viTQ6Qs4IPxOJr8coPmcGBelMjbT5/zZE03N5YYJl/YlOA==, tarball: https://registry.npmjs.org/@shopify/generate-docs/-/generate-docs-0.16.3.tgz}
     hasBin: true
 
   '@shopify/graphql-codegen@0.1.0':
-    resolution: {integrity: sha512-G3sSesLj7Czt/J2Bj+XlQ8u4pkfQEt32hsjoS3UGZlf1eAiVw0aBBddp+NI5HqBAi0gM/f7GLRAhG3kktPhZmA==}
+    resolution: {integrity: sha512-G3sSesLj7Czt/J2Bj+XlQ8u4pkfQEt32hsjoS3UGZlf1eAiVw0aBBddp+NI5HqBAi0gM/f7GLRAhG3kktPhZmA==, tarball: https://registry.npmjs.org/@shopify/graphql-codegen/-/graphql-codegen-0.1.0.tgz}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
   '@shopify/network@3.3.0':
-    resolution: {integrity: sha512-Lln7vglzLK9KiYhl9ucQFVM7ArlpUM21xkDriBX8kVrqsoBsi+4vFIjf1wjhNPT0J/zHMjky7jiTnxVfdm+xXw==}
+    resolution: {integrity: sha512-Lln7vglzLK9KiYhl9ucQFVM7ArlpUM21xkDriBX8kVrqsoBsi+4vFIjf1wjhNPT0J/zHMjky7jiTnxVfdm+xXw==, tarball: https://registry.npmjs.org/@shopify/network/-/network-3.3.0.tgz}
     engines: {node: '>=18.12.0'}
 
   '@shopify/polaris-icons@8.11.1':
-    resolution: {integrity: sha512-2HLzvJWMejKIwS5P2bs7k5CAjBKwPnD/iy9ncPzcgqRjmFInBXLtUXFQhPWDw6JwXzb1ZjNQK/ssTctcfz87Sw==}
+    resolution: {integrity: sha512-2HLzvJWMejKIwS5P2bs7k5CAjBKwPnD/iy9ncPzcgqRjmFInBXLtUXFQhPWDw6JwXzb1ZjNQK/ssTctcfz87Sw==, tarball: https://registry.npmjs.org/@shopify/polaris-icons/-/polaris-icons-8.11.1.tgz}
     engines: {node: ^16.17.0 || >=18.12.0}
     peerDependencies:
       react: '*'
@@ -2974,31 +2977,31 @@ packages:
         optional: true
 
   '@shopify/polaris-tokens@8.10.0':
-    resolution: {integrity: sha512-y4PDtRbFKGHwA6Lu7a3L4N9SDP6gZv4tw6u0viumtcXcbF0T2j1xPmyuJZNc9c7vmhNSARCg27NGQFpPgxuaEg==}
+    resolution: {integrity: sha512-y4PDtRbFKGHwA6Lu7a3L4N9SDP6gZv4tw6u0viumtcXcbF0T2j1xPmyuJZNc9c7vmhNSARCg27NGQFpPgxuaEg==, tarball: https://registry.npmjs.org/@shopify/polaris-tokens/-/polaris-tokens-8.10.0.tgz}
     engines: {node: ^16.17.0 || >=18.12.0}
 
   '@shopify/polaris@12.27.0':
-    resolution: {integrity: sha512-Y8yus6iEjcfW2ZtEJtlqxbWeDJqTX3S/MOLH4GWRvU5gFYJQhlaHaETs0+OimbhEpO95mXbY8qB+KnIJaVBHwA==}
+    resolution: {integrity: sha512-Y8yus6iEjcfW2ZtEJtlqxbWeDJqTX3S/MOLH4GWRvU5gFYJQhlaHaETs0+OimbhEpO95mXbY8qB+KnIJaVBHwA==, tarball: https://registry.npmjs.org/@shopify/polaris/-/polaris-12.27.0.tgz}
     engines: {node: ^16.17.0 || >=18.12.0}
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
 
   '@shopify/prettier-config@1.1.2':
-    resolution: {integrity: sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==}
+    resolution: {integrity: sha512-5ugCL9sPGzmOaZjeRGaWUWhHgAbemrS6z+R7v6gwiD+BiqSeoFhIY+imLpfdFCVpuOGalpHeCv6o3gv++EHs0A==, tarball: https://registry.npmjs.org/@shopify/prettier-config/-/prettier-config-1.1.2.tgz}
 
   '@shopify/react-testing@5.4.0':
-    resolution: {integrity: sha512-qlu6NUnMK9Mq/1lu6MIvZMSKT/AtXnHGyuu148DMshVF8d7E5+JDtgTVGeKKV8nnjL5cly4K91dyPVt6fHq5yA==}
+    resolution: {integrity: sha512-qlu6NUnMK9Mq/1lu6MIvZMSKT/AtXnHGyuu148DMshVF8d7E5+JDtgTVGeKKV8nnjL5cly4K91dyPVt6fHq5yA==, tarball: https://registry.npmjs.org/@shopify/react-testing/-/react-testing-5.4.0.tgz}
     engines: {node: '>=18.12.0'}
     peerDependencies:
       react: '>=18.0.0 <19.0.0'
       react-dom: '>=16.8.0 <19.0.0'
 
   '@shopify/typescript-configs@5.1.0':
-    resolution: {integrity: sha512-RywGBTR+nQyJLxcrUcihPkHPIG3pIQI6i0YwMrM5rs9nWJ0+9A5HKEcboyGPLH+8V08EXGfFQ6H820O9ajyk4A==}
+    resolution: {integrity: sha512-RywGBTR+nQyJLxcrUcihPkHPIG3pIQI6i0YwMrM5rs9nWJ0+9A5HKEcboyGPLH+8V08EXGfFQ6H820O9ajyk4A==, tarball: https://registry.npmjs.org/@shopify/typescript-configs/-/typescript-configs-5.1.0.tgz}
 
   '@shopify/useful-types@5.3.0':
-    resolution: {integrity: sha512-8BlaedSqR7ssQAhCsa88K+l2eIImSBlTLlnf7/dlqSlMSEqGVUf+O8oPsnyy9Oh3aDMt+rD4Q5JPOo984Cbz7Q==}
+    resolution: {integrity: sha512-8BlaedSqR7ssQAhCsa88K+l2eIImSBlTLlnf7/dlqSlMSEqGVUf+O8oPsnyy9Oh3aDMt+rD4Q5JPOo984Cbz7Q==, tarball: https://registry.npmjs.org/@shopify/useful-types/-/useful-types-5.3.0.tgz}
     engines: {node: '>=18.12.0'}
 
   '@sinclair/typebox@0.27.8':
@@ -5757,10 +5760,12 @@ packages:
 
   libsql@0.3.19:
     resolution: {integrity: sha512-Aj5cQ5uk/6fHdmeW0TiXK42FqUlwx7ytmMLPSaUQPin5HKKKuUPD62MAbN4OEweGBBI7q1BekoEN4gPUEL6MZA==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   libsql@0.4.1:
     resolution: {integrity: sha512-qZlR9Yu1zMBeLChzkE/cKfoKV3Esp9cn9Vx5Zirn4AVhDWPcjYhKwbtJcMuHehgk3mH+fJr9qW+3vesBWbQpBg==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lines-and-columns@1.2.4:
@@ -7368,9 +7373,9 @@ packages:
     resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
     engines: {node: '>=14.0'}
 
-  undici@6.19.7:
-    resolution: {integrity: sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==}
-    engines: {node: '>=18.17'}
+  undici@6.13.0:
+    resolution: {integrity: sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==}
+    engines: {node: '>=18.0'}
 
   unenv-nightly@1.10.0-1717606461.a117952:
     resolution: {integrity: sha512-u3TfBX02WzbHTpaEfWEKwDijDSFAHcgXkayUZ+MVDrjhLFvgAJzFGTSTmwlEhwWi2exyRQey23ah9wELMM6etg==}
@@ -10569,7 +10574,7 @@ snapshots:
       cookie-signature: 1.2.1
       source-map-support: 0.5.21
       stream-slice: 0.1.2
-      undici: 6.19.7
+      undici: 6.13.0
     optionalDependencies:
       typescript: 5.5.4
 
@@ -16072,7 +16077,7 @@ snapshots:
     dependencies:
       '@fastify/busboy': 2.1.1
 
-  undici@6.19.7: {}
+  undici@6.13.0: {}
 
   unenv-nightly@1.10.0-1717606461.a117952:
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

We recently added support for generating configurations for the customer API for graphql-codegen. While those configs are valid, the types we used didn't match the expected config types.

### WHAT is this pull request doing?

Typing those configs more strongly so we don't run into this kind of regression in the future.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
