### PR TITLE
Fix setUpValidRequest to preserve headers

### DIFF
--- a/.changeset/short-mayflies-stare.md
+++ b/.changeset/short-mayflies-stare.md
@@ -1,0 +1,6 @@
+---
+'@shopify/shopify-app-remix': patch
+'@shopify/shopify-api': patch
+---
+
+setUpValidRequest in shopify-api now preserves headers. Documentation for test helpers now more accurately describes use cases.

--- a/packages/apps/shopify-api/docs/guides/test-helpers.md
+++ b/packages/apps/shopify-api/docs/guides/test-helpers.md
@@ -1,6 +1,6 @@
 # Testing your app
 
-This package exports two helper methods through `@shopify/shopify-api/test-helpers` to simplify end-to-end testing: `setUpValidSession()` and `setUpValidRequest()`. These methods can be used together to fake authorization during integration testing or end-to-end testing. `setUpValidSession()` creats a fake session, and `setUpValidRequest()` modifies Requests so that this package authorizes them against the fake session.
+This package exports two helper methods through `@shopify/shopify-api/test-helpers` to simplify integration testing and local end-to-end testing: `setUpValidSession()` and `setUpValidRequest()`. These methods can be used together to fake authorization. `setUpValidSession()` creats a fake session, and `setUpValidRequest()` modifies Requests so that this package authorizes them against the fake session.
 
 ## setUpValidSession()
 

--- a/packages/apps/shopify-api/test-helpers/__tests__/setup-valid-request.test.ts
+++ b/packages/apps/shopify-api/test-helpers/__tests__/setup-valid-request.test.ts
@@ -57,6 +57,22 @@ describe('setUpValidRequest', () => {
     expect(token?.length).toBeGreaterThan(0);
   });
 
+  it('bearer requests preserve headers', async () => {
+    options = {
+      type: RequestType.Bearer,
+      store: TEST_SHOP_NAME,
+      apiKey: API_KEY,
+      apiSecretKey: API_SECRET_KEY,
+    };
+
+    request.headers.set('preserved-header', 'preserved header value');
+
+    const authorizedRequest = await setUpValidRequest(options, request);
+    const preservedHeader = authorizedRequest.headers.get('preserved-header');
+
+    expect(preservedHeader).toBe('preserved header value');
+  });
+
   it('can create an extension request', async () => {
     options = {
       type: RequestType.Extension,
@@ -80,6 +96,22 @@ describe('setUpValidRequest', () => {
     expect(shopHeader).toEqual(TEST_SHOP);
     expect(testHeader).toEqual('test value');
     expect(requestBody).toEqual('test');
+  });
+
+  it('extension requests preserve headers', async () => {
+    options = {
+      type: RequestType.Extension,
+      store: TEST_SHOP_NAME,
+      apiSecretKey: API_SECRET_KEY,
+      body: 'test',
+    };
+
+    request.headers.set('preserved-header', 'preserved header value');
+
+    const authorizedRequest = await setUpValidRequest(options, request);
+    const preservedHeader = authorizedRequest.headers.get('preserved-header');
+
+    expect(preservedHeader).toBe('preserved header value');
   });
 
   it('can create a public request', async () => {

--- a/packages/apps/shopify-app-remix/README.md
+++ b/packages/apps/shopify-app-remix/README.md
@@ -239,7 +239,7 @@ const shopify = shopifyApp(config);
 ...
 ```
 
-`testConfig()` accepts a config object as an optional parameter. The config values provided override the default config values returned by `testConfig()`. This is especially useful for end-to-end testing to ensure `shopifyApp()` reads the sessions from the development database.
+`testConfig()` accepts a config object as an optional parameter. The config values provided override the default config values returned by `testConfig()`. This is especially useful for integration testing and end-to-end testing to ensure `shopifyApp()` reads the sessions from the development database.
 
 ```ts
 // my-app/app/shopify.server.ts


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`setUpValidRequest` in `@shopify/shopify-api` overwrites headers.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Fixes `setUpValidRequest` to append authorization headers.

Also improves documentation for test helpers to better describe the use cases.
<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
