### PR TITLE
Update revoke operation to return revoked scopes instead of all scopes details

### DIFF
--- a/.changeset/three-dryers-wave.md
+++ b/.changeset/three-dryers-wave.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Return revoked scopes instead of querying for scopes after revoking

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/mock-responses.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/mock-responses.ts
@@ -27,21 +27,37 @@ export const WITH_GRANTED_AND_DECLARED = buildGraphqlResponseContent({
 });
 
 export const REVOKED_WITHOUT_ERROR = buildGraphqlResponseContent({
-  revoked: [
-    {
-      handle: 'read_orders',
-    },
-  ],
+  appRevokeAccessScopes: {
+    revoked: [
+      {
+        handle: 'write_discounts'
+      },
+      {
+        handle: 'read_orders'
+      }
+    ],
+    userErrors: [],
+  },
+});
+
+export const REVOKED_NOTHING = buildGraphqlResponseContent({
+  appRevokeAccessScopes: {
+    revoked: [],
+    userErrors: [],
+  },
 });
 
 export const REVOKED_WITH_ERROR = buildGraphqlResponseContent({
-  userErrors: [
-    {
-      field: 'scopes',
-      messages:
-        'The requested list of scopes to revoke includes invalid handles.',
-    },
-  ],
+  appRevokeAccessScopes: {
+    revoked: null,
+    userErrors: [
+      {
+        field: 'scopes',
+        messages:
+          'The requested list of scopes to revoke includes invalid handles.',
+      },
+    ]
+  },
 });
 
 function buildGraphqlResponseContent(content: any) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/mock-responses.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/mock-responses.ts
@@ -30,11 +30,11 @@ export const REVOKED_WITHOUT_ERROR = buildGraphqlResponseContent({
   appRevokeAccessScopes: {
     revoked: [
       {
-        handle: 'write_discounts'
+        handle: 'write_discounts',
       },
       {
-        handle: 'read_orders'
-      }
+        handle: 'read_orders',
+      },
     ],
     userErrors: [],
   },
@@ -56,7 +56,7 @@ export const REVOKED_WITH_ERROR = buildGraphqlResponseContent({
         messages:
           'The requested list of scopes to revoke includes invalid handles.',
       },
-    ]
+    ],
   },
 });
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/revoke.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/revoke.test.ts
@@ -12,7 +12,7 @@ import {
 
 import * as responses from './mock-responses';
 
-it('returns scopes information', async () => {
+it('returns successfully revoked scopes', async () => {
   // GIVEN
   const {scopes} = await setUpEmbeddedFlow();
   await mockGraphqlRequests()(
@@ -20,9 +20,23 @@ it('returns scopes information', async () => {
       body: 'AppRevokeAccessScopes',
       responseContent: responses.REVOKED_WITHOUT_ERROR,
     },
+  );
+
+  // WHEN
+  const result = await scopes.revoke(['write_discounts', 'read_orders']);
+
+  // THEN
+  expect(result).not.toBeUndefined();
+  expect(result.revoked).toEqual(['write_discounts', 'read_orders']);
+});
+
+it('returns successfully with empty list when graphql returns an empty list for the revoke operation', async () => {
+  // GIVEN
+  const {scopes} = await setUpEmbeddedFlow();
+  await mockGraphqlRequests()(
     {
-      body: 'FetchAccessScopes',
-      responseContent: responses.WITH_GRANTED_AND_DECLARED,
+      body: 'AppRevokeAccessScopes',
+      responseContent: responses.REVOKED_NOTHING,
     },
   );
 
@@ -31,9 +45,7 @@ it('returns scopes information', async () => {
 
   // THEN
   expect(result).not.toBeUndefined();
-  expect(result.detail.granted).toEqual(['read_orders', 'write_customers']);
-  expect(result.detail.required).toEqual(['read_orders', 'read_reports']);
-  expect(result.detail.optional).toEqual(['write_customers']);
+  expect(result.revoked).toEqual([]);
 });
 
 it('returns error if the list of scopes is empty', async () => {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/revoke.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/revoke.test.ts
@@ -15,12 +15,10 @@ import * as responses from './mock-responses';
 it('returns successfully revoked scopes', async () => {
   // GIVEN
   const {scopes} = await setUpEmbeddedFlow();
-  await mockGraphqlRequests()(
-    {
-      body: 'AppRevokeAccessScopes',
-      responseContent: responses.REVOKED_WITHOUT_ERROR,
-    },
-  );
+  await mockGraphqlRequests()({
+    body: 'AppRevokeAccessScopes',
+    responseContent: responses.REVOKED_WITHOUT_ERROR,
+  });
 
   // WHEN
   const result = await scopes.revoke(['write_discounts', 'read_orders']);
@@ -33,12 +31,10 @@ it('returns successfully revoked scopes', async () => {
 it('returns successfully with empty list when graphql returns an empty list for the revoke operation', async () => {
   // GIVEN
   const {scopes} = await setUpEmbeddedFlow();
-  await mockGraphqlRequests()(
-    {
-      body: 'AppRevokeAccessScopes',
-      responseContent: responses.REVOKED_NOTHING,
-    },
-  );
+  await mockGraphqlRequests()({
+    body: 'AppRevokeAccessScopes',
+    responseContent: responses.REVOKED_NOTHING,
+  });
 
   // WHEN
   const result = await scopes.revoke(['read_orders']);

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/client/revoke-scopes.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/client/revoke-scopes.ts
@@ -34,5 +34,5 @@ export async function revokeScopes(
   });
 
   const resultContent = await revokeScopesResult.json();
-  return resultContent.data;
+  return resultContent.data.appRevokeAccessScopes;
 }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/revoke.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/revoke.ts
@@ -4,8 +4,6 @@ import {AdminApiContext} from '../../../clients';
 import type {BasicParams} from '../../../types';
 
 import {revokeScopes} from './client/revoke-scopes';
-import {fetchScopeDetail} from './client/fetch-scopes-details';
-import {mapFetchScopeDetail} from './query';
 
 export function revokeScopesFactory(
   params: BasicParams,
@@ -15,12 +13,12 @@ export function revokeScopesFactory(
   return async function revoke(scopes: string[]) {
     const {logger} = params;
 
+    await validateScopes(scopes);
+
     logger.debug('Revoke scopes: ', {
       shop: session.shop,
       scopes,
     });
-
-    await validateScopes(scopes);
 
     const revokeScopesResult = await revokeScopes(admin, scopes);
     if (revokeScopesResult.userErrors?.length > 0) {
@@ -37,9 +35,8 @@ export function revokeScopesFactory(
       });
     }
 
-    const scopesDetail = await fetchScopeDetail(admin);
     return {
-      detail: mapFetchScopeDetail(scopesDetail),
+      revoked: revokeScopesResult.revoked.map((scope) => scope.handle),
     };
   };
 }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/types.ts
@@ -5,7 +5,7 @@ export interface ScopesApiContext {
 }
 
 export interface RevokeResponse {
-  detail: ScopesDetail;
+  revoked: string[];
 }
 export interface ScopesDetail {
   granted: string[];


### PR DESCRIPTION
### WHY are these changes introduced?
Currently on a successful revoke, we make a query fetch and return the entire scopes detail. However, we decided that it is better to return the same values as that of the graphql for consistency; which are the scopes that were successfully revoked.

### WHAT is this pull request doing?

In the revoke operation we return a list of revoked scopes instead of fetching the scope details and returning that.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
