### PR TITLE
[Feature] Support per-shop dynamic access scopes for embedded apps.

### DIFF
--- a/.changeset/early-jars-remain.md
+++ b/.changeset/early-jars-remain.md
@@ -1,0 +1,7 @@
+---
+'@shopify/shopify-app-express': minor
+'@shopify/shopify-app-remix': minor
+'@shopify/shopify-api': minor
+---
+
+Support per-shop dynamic access scopes for embedded apps.

--- a/packages/apps/shopify-api/lib/__tests__/config.test.ts
+++ b/packages/apps/shopify-api/lib/__tests__/config.test.ts
@@ -2,6 +2,7 @@ import * as ShopifyErrors from '../error';
 import {validateConfig} from '../config';
 import {ConfigParams} from '../base-types';
 import {ApiVersion, LATEST_API_VERSION, LogSeverity} from '../types';
+import {AuthScopes} from '../auth';
 
 let validParams: ConfigParams;
 
@@ -92,6 +93,19 @@ describe('Config object', () => {
     expect(() => validateConfig(validParams)).not.toThrow(
       ShopifyErrors.ShopifyError,
     );
+  });
+
+  it('converts array scopes to an AuthScopes instance', () => {
+    const validatedScopes = validateConfig(validParams).scopes;
+    expect(validatedScopes).toBeInstanceOf(AuthScopes);
+    expect(validatedScopes?.toString()).toEqual('scope');
+  });
+
+  it('passes scopes callback through', () => {
+    const callbackFn = (_shop: string) =>
+      Promise.resolve(new AuthScopes(['scope']));
+    validParams.scopes = callbackFn;
+    expect(validateConfig(validParams).scopes).toBe(callbackFn);
   });
 
   it("ignores a missing 'apiKey' when isCustomStoreApp is true", () => {

--- a/packages/apps/shopify-api/lib/auth/oauth/oauth.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/oauth.ts
@@ -99,7 +99,15 @@ export function begin(config: ConfigInterface): OAuthBegin {
       path: callbackPath,
     });
 
-    const scopes = config.scopes ? config.scopes.toString() : '';
+    let scopes = '';
+    if (config.scopes) {
+      if (typeof config.scopes === 'function') {
+        scopes = (await config.scopes(shop)).toString();
+      } else {
+        scopes = config.scopes.toString();
+      }
+    }
+
     const query = {
       client_id: config.apiKey,
       scope: scopes,

--- a/packages/apps/shopify-api/lib/auth/scopes/index.ts
+++ b/packages/apps/shopify-api/lib/auth/scopes/index.ts
@@ -95,4 +95,6 @@ class AuthScopes {
   }
 }
 
+export type AuthScopesCallback = (shop: string) => Promise<AuthScopes>;
+
 export {AuthScopes};

--- a/packages/apps/shopify-api/lib/base-types.ts
+++ b/packages/apps/shopify-api/lib/base-types.ts
@@ -1,7 +1,7 @@
 import {FutureFlagOptions} from '../future/flags';
 import {ShopifyRestResources} from '../rest/types';
 
-import {AuthScopes} from './auth/scopes';
+import {AuthScopes, AuthScopesCallback} from './auth/scopes';
 import {BillingConfig} from './billing/types';
 import {ApiVersion, LogSeverity} from './types';
 
@@ -29,7 +29,7 @@ export interface ConfigParams<
   /**
    * The scopes your app needs to access the API. Not required if using Shopify managed installation.
    */
-  scopes?: string[] | AuthScopes;
+  scopes?: string[] | AuthScopes | AuthScopesCallback;
   /**
    * The host name of your app.
    */
@@ -125,7 +125,7 @@ export type ConfigInterface<Params extends ConfigParams = ConfigParams> = Omit<
 > & {
   apiKey: string;
   hostScheme: 'http' | 'https';
-  scopes?: AuthScopes;
+  scopes?: AuthScopes | AuthScopesCallback;
   isCustomStoreApp: boolean;
   billing?: BillingConfig<Params['future']>;
   logger: {

--- a/packages/apps/shopify-api/lib/config.ts
+++ b/packages/apps/shopify-api/lib/config.ts
@@ -77,7 +77,10 @@ export function validateConfig<Params extends ConfigParams>(
   let scopes;
   if (params.scopes === undefined) {
     scopes = undefined;
-  } else if (params.scopes instanceof AuthScopes) {
+  } else if (
+    params.scopes instanceof AuthScopes ||
+    typeof params.scopes === 'function'
+  ) {
     scopes = params.scopes;
   } else {
     scopes = new AuthScopes(params.scopes);

--- a/packages/apps/shopify-api/lib/session/__tests__/session.test.ts
+++ b/packages/apps/shopify-api/lib/session/__tests__/session.test.ts
@@ -56,6 +56,10 @@ describe('isActive', () => {
       expires: new Date(Date.now() + 86400),
     });
 
+    if (typeof shopify.config.scopes === 'function') {
+      // This is to satisfy the typing
+      fail('Scopes should be a string.');
+    }
     expect(session.isActive(shopify.config.scopes)).toBeTruthy();
   });
 });
@@ -85,6 +89,10 @@ it('returns false if session is not active', () => {
     scope: 'test_scope',
     expires: new Date(Date.now() - 1),
   });
+  if (typeof shopify.config.scopes === 'function') {
+    // This is to satisfy the typing
+    fail('Scopes should be a string.');
+  }
   expect(session.isActive(shopify.config.scopes)).toBeFalsy();
 });
 

--- a/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -130,10 +130,14 @@ async function sessionHasValidAccessToken(
     return false;
   }
 
+  const scopes =
+    api.config.scopes && typeof api.config.scopes === 'function'
+      ? await api.config.scopes(session.shop)
+      : api.config.scopes;
+
   try {
     return (
-      session.isActive(api.config.scopes) &&
-      (await hasValidAccessToken(api, session))
+      session.isActive(scopes) && (await hasValidAccessToken(api, session))
     );
   } catch (error) {
     config.logger.error(`Could not check if session was valid: ${error}`, {

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -66,7 +66,12 @@ export function validateAuthenticatedSession({
           shop: session.shop,
         });
 
-        if (session.isActive(api.config.scopes)) {
+        const scopes =
+          api.config.scopes && typeof api.config.scopes === 'function'
+            ? await api.config.scopes(session.shop)
+            : api.config.scopes;
+
+        if (session.isActive(scopes)) {
           config.logger.debug('Request session exists and is active', {
             shop: session.shop,
           });

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
@@ -83,10 +83,15 @@ export class AuthCodeFlowStrategy<
 
     const {shop, session} = sessionContext;
 
+    const scopes =
+      typeof config.scopes === 'function'
+        ? await config.scopes(shop)
+        : config.scopes;
+
     if (!session) {
       logger.debug('No session found, redirecting to OAuth', {shop});
       await redirectToAuthPage({config, logger, api}, request, shop);
-    } else if (!session.isActive(config.scopes)) {
+    } else if (!session.isActive(scopes)) {
       logger.debug(
         'Found a session, but it has expired, redirecting to OAuth',
         {shop},


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

We have a large and complex app, with various optional features. Our aim is to keep the access scopes for our end users (shops) to a minimally required set. As shops request access to more features within our app, we dynamically increase the access scopes required for that shop. Currently, scopes are set up globally per app, these changes provide a way to have different sets of scopes per shop.

### WHAT is this pull request doing?

- Change the `scopes` parameter on an app config to optionally take a callback of the form `(shop: string) => Promise<AuthScopes>`
- When a callback is used, scopes will be resolved passing in the current shop for a given session/flow, allowing for database lookups or otherwise constructing an appropriate set of access scopes

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
  - _(I added in the callback sig against apps/shopify-api's readme, happy to add in extra docs against the remix/express readmes with a more detailed explanation as well)_
  
(cc: @henrytao-me @owlyowl)