### PR TITLE
Fix: `rest.PaymentTransaction.transactions` returns unknown

### DIFF
--- a/.changeset/tidy-items-rush.md
+++ b/.changeset/tidy-items-rush.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Fix type declaration for payment_transaction

--- a/packages/apps/shopify-api/rest/admin/2022-10/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2022-10/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.October22;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2023-01/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-01/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.January23;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2023-04/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-04/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.April23;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2023-07/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-07/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.July23;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2023-10/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2023-10/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.October23;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2024-01/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-01/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.January24;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2024-04/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-04/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.April24;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,

--- a/packages/apps/shopify-api/rest/admin/2024-07/payment_transaction.ts
+++ b/packages/apps/shopify-api/rest/admin/2024-07/payment_transaction.ts
@@ -19,6 +19,10 @@ interface TransactionsArgs {
   payout_status?: unknown;
 }
 
+interface TransactionsResponse {
+  transactions: PaymentTransaction[];
+}
+
 export class PaymentTransaction extends Base {
   public static apiVersion = ApiVersion.July24;
 
@@ -46,8 +50,8 @@ export class PaymentTransaction extends Base {
       payout_status = null,
       ...otherArgs
     }: TransactionsArgs
-  ): Promise<unknown> {
-    const response = await this.request<PaymentTransaction>({
+  ): Promise<TransactionsResponse | null> {
+    const response = await this.request<TransactionsResponse>({
       http_method: "get",
       operation: "transactions",
       session: session,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #988  <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

Previously, it was declaring an `unknown` return type. 

### WHAT is this pull request doing?

Reconciling the return type with what is actually being returned.

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
