### PR TITLE
Skip killling MySQL podman containers in CI workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # - name: Run package tests
-      #   run: pnpm test:ci
+      - name: Run package tests
+        run: pnpm test:ci
 
-      # - name: Run linting
-      #   run: pnpm lint
+      - name: Run linting
+        run: pnpm lint
 
       - name: Run Drizzle adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run package tests
-        run: pnpm test:ci
+      # - name: Run package tests
+      #   run: pnpm test:ci
 
-      - name: Run linting
-        run: pnpm lint
+      # - name: Run linting
+      #   run: pnpm lint
 
       - name: Run DynamoDB adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-dynamodb
@@ -49,20 +49,20 @@ jobs:
       - name: Run MongoDB adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mongodb
 
-      - name: Run MySQL adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
-
-      - name: Run PostgreSQL adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-postgresql
-
       - name: Run Prisma adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-prisma
 
       - name: Run Redis adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-redis
 
+      - name: Run PostgreSQL adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-postgresql
+
       - name: Run SQLite adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-sqlite
+
+      - name: Run MySQL adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
 
       - name: Run Drizzle adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ name: CI
 
 env:
   DISABLE_V8_COMPILE_CACHE: 1
-  IS_WORKFLOW_RUN: true
 
 jobs:
   CI:
@@ -53,17 +52,17 @@ jobs:
       - name: Run MongoDB adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mongodb
 
+      - name: Run MySQL adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
+
+      - name: Run PostgreSQL adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-postgresql
+
       - name: Run Prisma adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-prisma
 
       - name: Run Redis adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-redis
 
-      - name: Run PostgreSQL adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-postgresql
-
       - name: Run SQLite adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-sqlite
-
-      - name: Run MySQL adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,3 +67,6 @@ jobs:
 
       - name: Run MySQL adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
+
+      - name: Remove Podman containers
+        run: podman rm -f -a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,9 +37,6 @@ jobs:
       - name: Run linting
         run: pnpm lint
 
-      - name: Run Drizzle adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle
-
       - name: Run DynamoDB adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-dynamodb
 
@@ -66,3 +63,6 @@ jobs:
 
       - name: Run SQLite adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-sqlite
+
+      - name: Run Drizzle adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       # - name: Run linting
       #   run: pnpm lint
 
+      - name: Run Drizzle adapter tests
+        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle
+
       - name: Run DynamoDB adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-dynamodb
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ name: CI
 
 env:
   DISABLE_V8_COMPILE_CACHE: 1
+  IS_WORKFLOW_RUN: true
 
 jobs:
   CI:
@@ -31,11 +32,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      # - name: Run package tests
-      #   run: pnpm test:ci
+      - name: Run package tests
+        run: pnpm test:ci
 
-      # - name: Run linting
-      #   run: pnpm lint
+      - name: Run linting
+        run: pnpm lint
 
       - name: Run Drizzle adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,11 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Run package tests
-        run: pnpm test:ci
+      # - name: Run package tests
+      #   run: pnpm test:ci
 
-      - name: Run linting
-        run: pnpm lint
+      # - name: Run linting
+      #   run: pnpm lint
 
       - name: Run Drizzle adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,3 @@ jobs:
 
       - name: Run MySQL adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
-
-      - name: Run Drizzle adapter tests
-        run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-drizzle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,3 @@ jobs:
 
       - name: Run MySQL adapter tests
         run: pnpm test:ci_sessions --filter=./packages/apps/session-storage/shopify-app-session-storage-mysql
-
-      - name: Remove Podman containers
-        run: podman rm -f -a

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,7 +46,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
+      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle --stop-signal=SIGTERM",
       {encoding: 'utf8'},
     );
 
@@ -92,8 +92,8 @@ describe('DrizzleSessionStorageMySQL', () => {
       await connection.end();
     }
 
-    await exec(`podman kill ${containerId}`);
-    // await exec(`podman rm -f ${containerId}`);
+    // await exec(`podman kill ${containerId}`);
+    await exec(`podman rm -f ${containerId}`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,7 +46,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
+      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle --stop-signal=SIGKILL",
       {encoding: 'utf8'},
     );
 
@@ -94,7 +94,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
     // await exec(`podman kill ${containerId}`);
     // await exec(`podman rm -f ${containerId} --time=60`);
-    await exec(`podman stop ${containerId} `);
+    await exec(`podman stop ${containerId}`);
     await exec(`podman rm ${containerId}`);
   });
 

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,7 +46,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle --stop-signal=SIGKILL",
+      "podman run --stop-signal=SIGKILL -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
 

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,10 +46,9 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run --stop-signal=SIGTERM -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
+      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-    runCommand.stdout.trim();
 
     containerId = runCommand.stdout.trim();
 

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,7 +46,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run --stop-signal=SIGKILL -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
+      "podman run --stop-signal=SIGTERM -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
 

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -41,7 +41,7 @@ const sessionTable = mysqlTable('session', {
 
 describe('DrizzleSessionStorageMySQL', () => {
   let drizzleSessionStorage: DrizzleSessionStorageMySQL;
-  let containerId: string;
+  // let containerId: string;
   let connection: mysql2.Connection;
 
   beforeAll(async () => {
@@ -49,8 +49,9 @@ describe('DrizzleSessionStorageMySQL', () => {
       "podman run --stop-signal=SIGTERM -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
+    runCommand.stdout.trim();
 
-    containerId = runCommand.stdout.trim();
+    // containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -93,9 +94,9 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // await exec(`podman kill ${containerId}`);
-    // await exec(`podman rm -f ${containerId} --time=60`);
-    await exec(`podman stop ${containerId}`);
-    await exec(`podman rm ${containerId}`);
+    // await exec(`podman rm -f ${containerId}`);
+    // await exec(`podman stop ${containerId}`);
+    // await exec(`podman rm ${containerId}`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -92,6 +92,7 @@ describe('DrizzleSessionStorageMySQL', () => {
       await connection.end();
     }
 
+    // Added to prevent errors in CI when stopping MySQL containers
     // eslint-disable-next-line no-process-env
     if (!process.env.CI) {
       await exec(`podman rm -f ${containerId}`);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -93,8 +93,6 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // eslint-disable-next-line no-process-env
-    console.log(process.env.CI);
-
     if (!process.env.CI) {
       await exec(`podman rm -f ${containerId}`);
     }

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -41,7 +41,7 @@ const sessionTable = mysqlTable('session', {
 
 describe('DrizzleSessionStorageMySQL', () => {
   let drizzleSessionStorage: DrizzleSessionStorageMySQL;
-  let containerId: string;
+  // let containerId: string;
   let connection: mysql2.Connection;
 
   beforeAll(async () => {
@@ -49,8 +49,9 @@ describe('DrizzleSessionStorageMySQL', () => {
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
+    runCommand.stdout.trim();
 
-    containerId = runCommand.stdout.trim();
+    // containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -96,10 +97,10 @@ describe('DrizzleSessionStorageMySQL', () => {
     console.log(process.env.IS_WORKFLOW_RUN);
     // eslint-disable-next-line no-process-env
     console.log(process.env.IS_WORKFLOW_RUN !== 'true');
-    // eslint-disable-next-line no-process-env
-    if (process.env.IS_WORKFLOW_RUN !== 'true') {
-      await exec(`podman rm -f ${containerId}`);
-    }
+
+    // if (process.env.IS_WORKFLOW_RUN !== 'true') {
+    //   await exec(`podman rm -f ${containerId}`);
+    // }
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -94,7 +94,8 @@ describe('DrizzleSessionStorageMySQL', () => {
 
     // await exec(`podman kill ${containerId}`);
     // await exec(`podman rm -f ${containerId} --time=60`);
-    await exec(`podman stop ${containerId} && podman rm ${containerId}`);
+    await exec(`podman stop ${containerId} `);
+    await exec(`podman rm ${containerId}`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -93,6 +93,10 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // eslint-disable-next-line no-process-env
+    console.log(process.env.IS_WORKFLOW_RUN);
+    // eslint-disable-next-line no-process-env
+    console.log(process.env.IS_WORKFLOW_RUN !== 'true');
+    // eslint-disable-next-line no-process-env
     if (process.env.IS_WORKFLOW_RUN !== 'true') {
       await exec(`podman rm -f ${containerId}`);
     }

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -93,7 +93,8 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // await exec(`podman kill ${containerId}`);
-    await exec(`podman rm -f ${containerId} --time=60`);
+    // await exec(`podman rm -f ${containerId} --time=60`);
+    await exec(`podman stop ${containerId} && podman rm ${containerId}`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -41,7 +41,7 @@ const sessionTable = mysqlTable('session', {
 
 describe('DrizzleSessionStorageMySQL', () => {
   let drizzleSessionStorage: DrizzleSessionStorageMySQL;
-  // let containerId: string;
+  let containerId: string;
   let connection: mysql2.Connection;
 
   beforeAll(async () => {
@@ -49,9 +49,8 @@ describe('DrizzleSessionStorageMySQL', () => {
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-    runCommand.stdout.trim();
 
-    // containerId = runCommand.stdout.trim();
+    containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -94,13 +93,11 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // eslint-disable-next-line no-process-env
-    console.log(process.env.IS_WORKFLOW_RUN);
-    // eslint-disable-next-line no-process-env
-    console.log(process.env.IS_WORKFLOW_RUN !== 'true');
+    console.log(process.env.CI);
 
-    // if (process.env.IS_WORKFLOW_RUN !== 'true') {
-    //   await exec(`podman rm -f ${containerId}`);
-    // }
+    if (!process.env.CI) {
+      await exec(`podman rm -f ${containerId}`);
+    }
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -46,7 +46,7 @@ describe('DrizzleSessionStorageMySQL', () => {
 
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle --stop-signal=SIGTERM",
+      "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3307:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
 
@@ -93,7 +93,7 @@ describe('DrizzleSessionStorageMySQL', () => {
     }
 
     // await exec(`podman kill ${containerId}`);
-    await exec(`podman rm -f ${containerId}`);
+    await exec(`podman rm -f ${containerId} --time=60`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -92,7 +92,8 @@ describe('DrizzleSessionStorageMySQL', () => {
       await connection.end();
     }
 
-    await exec(`podman rm -f ${containerId}`);
+    await exec(`podman kill ${containerId}`);
+    // await exec(`podman rm -f ${containerId}`);
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/src/__tests__/drizzle-mysql.test.ts
@@ -41,7 +41,7 @@ const sessionTable = mysqlTable('session', {
 
 describe('DrizzleSessionStorageMySQL', () => {
   let drizzleSessionStorage: DrizzleSessionStorageMySQL;
-  // let containerId: string;
+  let containerId: string;
   let connection: mysql2.Connection;
 
   beforeAll(async () => {
@@ -51,7 +51,7 @@ describe('DrizzleSessionStorageMySQL', () => {
     );
     runCommand.stdout.trim();
 
-    // containerId = runCommand.stdout.trim();
+    containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -93,10 +93,10 @@ describe('DrizzleSessionStorageMySQL', () => {
       await connection.end();
     }
 
-    // await exec(`podman kill ${containerId}`);
-    // await exec(`podman rm -f ${containerId}`);
-    // await exec(`podman stop ${containerId}`);
-    // await exec(`podman rm ${containerId}`);
+    // eslint-disable-next-line no-process-env
+    if (process.env.IS_WORKFLOW_RUN !== 'true') {
+      await exec(`podman rm -f ${containerId}`);
+    }
   });
 
   batteryOfTests(async () => drizzleSessionStorage);

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -33,13 +33,14 @@ describe('MySQLSessionStorage', () => {
   let storage: MySQLSessionStorage;
   let storage2: MySQLSessionStorage;
 
-  let containerId: string;
+  // let containerId: string;
   beforeAll(async () => {
     const runCommand = await exec(
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3306:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-    containerId = runCommand.stdout.trim();
+    runCommand.stdout.trim();
+    // containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -72,10 +73,9 @@ describe('MySQLSessionStorage', () => {
     await storage.disconnect();
     await storage2.disconnect();
 
-    // eslint-disable-next-line no-process-env
-    if (process.env.IS_WORKFLOW_RUN !== 'true') {
-      await exec(`podman rm -f ${containerId}`);
-    }
+    // if (process.env.IS_WORKFLOW_RUN !== 'true') {
+    //   await exec(`podman rm -f ${containerId}`);
+    // }
   });
 
   const tests = [

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -72,7 +72,10 @@ describe('MySQLSessionStorage', () => {
     await storage.disconnect();
     await storage2.disconnect();
 
-    await exec(`podman rm -f ${containerId}`);
+    // eslint-disable-next-line no-process-env
+    if (process.env.IS_WORKFLOW_RUN !== 'true') {
+      await exec(`podman rm -f ${containerId}`);
+    }
   });
 
   const tests = [

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -39,7 +39,7 @@ describe('MySQLSessionStorage', () => {
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3306:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-    runCommand.stdout.trim();
+    
     containerId = runCommand.stdout.trim();
 
     await poll(

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -39,7 +39,6 @@ describe('MySQLSessionStorage', () => {
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3306:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-
     containerId = runCommand.stdout.trim();
 
     await poll(
@@ -73,6 +72,7 @@ describe('MySQLSessionStorage', () => {
     await storage.disconnect();
     await storage2.disconnect();
 
+    // Added to prevent errors in CI when stopping MySQL containers
     // eslint-disable-next-line no-process-env
     if (!process.env.CI) {
       await exec(`podman rm -f ${containerId}`);

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -33,13 +33,13 @@ describe('MySQLSessionStorage', () => {
   let storage: MySQLSessionStorage;
   let storage2: MySQLSessionStorage;
 
-   let containerId: string;
+  let containerId: string;
   beforeAll(async () => {
     const runCommand = await exec(
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3306:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
-    
+
     containerId = runCommand.stdout.trim();
 
     await poll(
@@ -73,6 +73,7 @@ describe('MySQLSessionStorage', () => {
     await storage.disconnect();
     await storage2.disconnect();
 
+    // eslint-disable-next-line no-process-env
     if (!process.env.CI) {
       await exec(`podman rm -f ${containerId}`);
     }

--- a/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mysql/src/__tests__/mysql.test.ts
@@ -33,14 +33,14 @@ describe('MySQLSessionStorage', () => {
   let storage: MySQLSessionStorage;
   let storage2: MySQLSessionStorage;
 
-  // let containerId: string;
+   let containerId: string;
   beforeAll(async () => {
     const runCommand = await exec(
       "podman run -d -e MYSQL_DATABASE='shop&test' -e MYSQL_USER='shop&fy' -e MYSQL_PASSWORD='passify#$' -e MYSQL_ROOT_PASSWORD='passify#$' -p 3306:3306 mysql:8-oracle",
       {encoding: 'utf8'},
     );
     runCommand.stdout.trim();
-    // containerId = runCommand.stdout.trim();
+    containerId = runCommand.stdout.trim();
 
     await poll(
       async () => {
@@ -73,9 +73,9 @@ describe('MySQLSessionStorage', () => {
     await storage.disconnect();
     await storage2.disconnect();
 
-    // if (process.env.IS_WORKFLOW_RUN !== 'true') {
-    //   await exec(`podman rm -f ${containerId}`);
-    // }
+    if (!process.env.CI) {
+      await exec(`podman rm -f ${containerId}`);
+    }
   });
 
   const tests = [


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

drizzle mysql test and mysql test throws errors when stopping the podman containers. We will skip this and allow the workflow itself to deal with cleanup.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

Skip command conditionally

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
