### PR TITLE
Remove future flag for released feature

### DIFF
--- a/.changeset/four-bugs-fix.md
+++ b/.changeset/four-bugs-fix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+Add Scopes API to Remix library by removing the future flag that enabled this feature

--- a/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
+++ b/packages/apps/shopify-app-remix/docs/generated/generated_docs_data.json
@@ -314,41 +314,8 @@
             "filePath": "src/server/authenticate/admin/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "AdminContext",
-            "value": "FeatureEnabled<Config['future'], 'wip_optionalScopesApi'> extends true\n    ? EmbeddedTypedAdminContext<Config, Resources> & ScopesContext\n    : EmbeddedTypedAdminContext<Config, Resources>",
+            "value": "EmbeddedTypedAdminContext<Config, Resources> & ScopesContext",
             "description": ""
-          },
-          "FeatureEnabled": {
-            "filePath": "src/server/future/flags.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "FeatureEnabled",
-            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
-            "description": ""
-          },
-          "FutureFlags": {
-            "filePath": "src/server/future/flags.ts",
-            "name": "FutureFlags",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/server/future/flags.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "unstable_newEmbeddedAuthStrategy",
-                "value": "boolean",
-                "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
-                "isOptional": true,
-                "defaultValue": "false"
-              },
-              {
-                "filePath": "src/server/future/flags.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "wip_optionalScopesApi",
-                "value": "boolean",
-                "description": "When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.",
-                "isOptional": true,
-                "defaultValue": "false"
-              }
-            ],
-            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.\n   *\n   * @default false\n   */\n  wip_optionalScopesApi?: boolean;\n}"
           },
           "EmbeddedTypedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -650,284 +617,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n    status: string;\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "name": "CheckBillingOptions",
@@ -951,71 +640,6 @@
               }
             ],
             "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "CreateUsageRecordOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -1061,50 +685,6 @@
               }
             ],
             "value": "export interface CreateUsageRecordOptions {\n  /**\n   * The description of the app usage record.\n   */\n  description: string;\n  /**\n   * The price of the app usage record.\n   */\n  price: {\n    /**\n     * The amount to charge for this usage record.\n     */\n    amount: number;\n    /**\n     * The currency code for this usage record.\n     */\n    currencyCode: string;\n  };\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest: boolean;\n  /*\n   * Defines the usage pricing plan the merchant is subscribed to.\n   */\n  subscriptionLineItemId?: string;\n  /*\n   * A unique key generated to avoid duplicate charges.\n   */\n  idempotencyKey?: string;\n}"
-          },
-          "UsageRecord": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageRecord",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "description",
-                "value": "string",
-                "description": "The description of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "idempotencyKey",
-                "value": "string",
-                "description": "The idempotency key for this request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "ActiveSubscriptionLineItem",
-                "description": "The subscription line item associated with the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "{ amount: number; currencyCode: string; }",
-                "description": "The price and currency of the usage record."
-              }
-            ],
-            "value": "export interface UsageRecord {\n    /**\n     * The ID of the usage record.\n     */\n    id: string;\n    /**\n     * The description of the usage record.\n     */\n    description: string;\n    /**\n     * The price and currency of the usage record.\n     */\n    price: {\n        /**\n         * The amount to charge for this usage record.\n         */\n        amount: number;\n        /**\n         * The currency code for this usage record.\n         */\n        currencyCode: string;\n    };\n    /**\n     * The subscription line item associated with the usage record.\n     */\n    plan: ActiveSubscriptionLineItem;\n    /**\n     * The idempotency key for this request.\n     */\n    idempotencyKey?: string;\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -1195,328 +775,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           },
           "EmbeddedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -1688,77 +946,6 @@
             "name": "RedirectTarget",
             "value": "'_self' | '_parent' | '_top' | '_blank'",
             "description": ""
-          },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           },
           "ScopesContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -2605,284 +1792,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n    status: string;\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "name": "CheckBillingOptions",
@@ -2906,71 +1815,6 @@
               }
             ],
             "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "CreateUsageRecordOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -3016,50 +1860,6 @@
               }
             ],
             "value": "export interface CreateUsageRecordOptions {\n  /**\n   * The description of the app usage record.\n   */\n  description: string;\n  /**\n   * The price of the app usage record.\n   */\n  price: {\n    /**\n     * The amount to charge for this usage record.\n     */\n    amount: number;\n    /**\n     * The currency code for this usage record.\n     */\n    currencyCode: string;\n  };\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest: boolean;\n  /*\n   * Defines the usage pricing plan the merchant is subscribed to.\n   */\n  subscriptionLineItemId?: string;\n  /*\n   * A unique key generated to avoid duplicate charges.\n   */\n  idempotencyKey?: string;\n}"
-          },
-          "UsageRecord": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageRecord",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "description",
-                "value": "string",
-                "description": "The description of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "idempotencyKey",
-                "value": "string",
-                "description": "The idempotency key for this request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "ActiveSubscriptionLineItem",
-                "description": "The subscription line item associated with the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "{ amount: number; currencyCode: string; }",
-                "description": "The price and currency of the usage record."
-              }
-            ],
-            "value": "export interface UsageRecord {\n    /**\n     * The ID of the usage record.\n     */\n    id: string;\n    /**\n     * The description of the usage record.\n     */\n    description: string;\n    /**\n     * The price and currency of the usage record.\n     */\n    price: {\n        /**\n         * The amount to charge for this usage record.\n         */\n        amount: number;\n        /**\n         * The currency code for this usage record.\n         */\n        currencyCode: string;\n    };\n    /**\n     * The subscription line item associated with the usage record.\n     */\n    plan: ActiveSubscriptionLineItem;\n    /**\n     * The idempotency key for this request.\n     */\n    idempotencyKey?: string;\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -3640,328 +2440,6 @@
               }
             ],
             "value": "export interface FlowContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Shopify session for the Flow request.</caption>\n   * <description>Use the session associated with this request to use REST resources.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { session, admin } = await authenticate.flow(request);\n   *\n   *   const products = await admin?.rest.resources.Product.all({ session });\n   *   // Use products\n   *\n   *   return new Response();\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * The payload from the Flow request.\n   *\n   * @example\n   * <caption>Flow payload.</caption>\n   * <description>Get the request's POST payload.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { payload } = await authenticate.flow(request);\n   *   return new Response();\n   * };\n   * ```\n   */\n  payload: any;\n\n  /**\n   * An admin context for the Flow request.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Flow admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/flow.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.flow(request);\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -4157,328 +2635,6 @@
             "syntaxKind": "TypeAliasDeclaration",
             "name": "FulfillmentServicePayload",
             "value": "Record<string, any> & {\n  kind: string;\n}",
-            "description": ""
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
             "description": ""
           }
         }
@@ -4821,328 +2977,6 @@
             ],
             "value": "export interface AppProxyContextWithSession<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends Context {\n  /**\n   * The session for the shop that made the request.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * Use this to get shop or user-specific data.\n   *\n   * @example\n   * <caption>Using the session object.</caption>\n   * <description>Get the session for the shop that initiated the request to the app proxy.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppModelData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }) => {\n   *   // Get the session for the shop that initiated the request to the app proxy.\n   *   const { session } =\n   *     await authenticate.public.appProxy(request);\n   *\n   *   // Use the session data to make to queries to your database or additional requests.\n   *   return json(\n   *     await getMyAppModelData({shop: session.shop})\n   *   );\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Admin API.</caption>\n   * <description>Use the `admin` object to interact with the REST or GraphQL APIs.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     {\n   *       variables: {\n   *         input: { title: \"Product Name\" }\n   *       }\n   *     }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n\n  /**\n   * Method for interacting with the Shopify Storefront Graphql API for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Storefront API.</caption>\n   * <description>Use the `storefront` object to interact with the GraphQL API.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { storefront } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await storefront.graphql(\n   *     `#graphql\n   *     query blogIds {\n   *       blogs(first: 10) {\n   *         edges {\n   *           node {\n   *             id\n   *           }\n   *         }\n   *       }\n   *     }`\n   *   );\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
           },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
           "StorefrontContext": {
             "filePath": "src/server/clients/storefront/types.ts",
             "name": "StorefrontContext",
@@ -5250,64 +3084,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October24",
-                "value": "2024-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }
@@ -5558,77 +3334,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           }
         }
       }
@@ -5812,77 +3517,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
           }
         }
       }
@@ -6294,328 +3928,6 @@
               }
             ],
             "value": "export interface WebhookContextWithSession<\n  Resources extends ShopifyRestResources,\n  Topics = string | number | symbol,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   * Webhook requests can trigger after an app is uninstalled\n   * If the app is already uninstalled, the session may be undefined.\n   * Therefore, you should check for the session before using it.\n   *\n   * @example\n   * <caption>Protecting against uninstalled apps.</caption>\n   * ```ts\n   * // /app/routes/webhooks.tsx\n   * import type { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"~/shopify.server\";\n\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { session } = await authenticate.webhook(request);\n   *   \n   *   // Webhook requests can trigger after an app is uninstalled\n   *   // If the app is already uninstalled, the session may be undefined.\n   *   if (!session) {\n   *     throw new Response();\n   *   }\n   *\n   *   // Handle webhook request\n   *   console.log(\"Received webhook webhook\");\n   *\n   *   return new Response();\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   *\n   * @example\n   * <caption>Webhook admin context.</caption>\n   * <description>Use the `admin` object in the context to interact with the Admin API.</description>\n   * ```ts\n   * // /app/routes/webhooks.tsx\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const { admin } = await authenticate.webhook(request);\n   *\n   *   // Webhook requests can trigger after an app is uninstalled\n   *   // If the app is already uninstalled, the session may be undefined.\n   *   if (!session) {\n   *     throw new Response();\n   *   }\n   *\n   *   const response = await admin?.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -6968,64 +4280,6 @@
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
           },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October24",
-                "value": "2024-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
-          },
           "RestClientWithResources": {
             "filePath": "src/server/clients/admin/rest.ts",
             "syntaxKind": "TypeAliasDeclaration",
@@ -7075,421 +4329,6 @@
               }
             ],
             "value": "class RemixRestClient {\n  public session: Session;\n  private params: AdminClientOptions['params'];\n  private handleClientError: AdminClientOptions['handleClientError'];\n\n  constructor({params, session, handleClientError}: AdminClientOptions) {\n    this.params = params;\n    this.handleClientError = handleClientError;\n    this.session = session;\n  }\n\n  /**\n   * Performs a GET request on the given path.\n   */\n  public async get(params: GetRequestParams) {\n    return this.makeRequest({\n      method: 'GET' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a POST request on the given path.\n   */\n  public async post(params: PostRequestParams) {\n    return this.makeRequest({\n      method: 'POST' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a PUT request on the given path.\n   */\n  public async put(params: PutRequestParams) {\n    return this.makeRequest({\n      method: 'PUT' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a DELETE request on the given path.\n   */\n  public async delete(params: DeleteRequestParams) {\n    return this.makeRequest({\n      method: 'DELETE' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  protected async makeRequest(params: RequestParams): Promise<Response> {\n    const originalClient = new this.params.api.clients.Rest({\n      session: this.session,\n    });\n    const originalRequest = Reflect.get(originalClient, 'request');\n\n    try {\n      const apiResponse = await originalRequest.call(originalClient, params);\n\n      // We use a separate client for REST requests and REST resources because we want to override the API library\n      // client class to return a Response object instead.\n      return new Response(JSON.stringify(apiResponse.body), {\n        headers: apiResponse.headers,\n      });\n    } catch (error) {\n      if (this.handleClientError) {\n        throw await this.handleClientError({\n          error,\n          session: this.session,\n          params: this.params,\n        });\n      } else throw new Error(error);\n    }\n  }\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
-          "GetRequestParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "name": "GetRequestParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "data",
-                "value": "Record<string, any> | string",
-                "description": "The request body.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "extraHeaders",
-                "value": "HeaderParams",
-                "description": "Additional headers to be sent with the request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "path",
-                "value": "string",
-                "description": "The path to the resource, relative to the API version root."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "query",
-                "value": "SearchParams",
-                "description": "Query parameters to be sent with the request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "tries",
-                "value": "number",
-                "description": "The maximum number of times the request can be made if it fails with a throttling or server error.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "type",
-                "value": "DataType",
-                "description": "The type of data expected in the response.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface GetRequestParams {\n    /**\n     * The path to the resource, relative to the API version root.\n     */\n    path: string;\n    /**\n     * The type of data expected in the response.\n     */\n    type?: DataType;\n    /**\n     * The request body.\n     */\n    data?: Record<string, any> | string;\n    /**\n     * Query parameters to be sent with the request.\n     */\n    query?: SearchParams;\n    /**\n     * Additional headers to be sent with the request.\n     */\n    extraHeaders?: HeaderParams;\n    /**\n     * The maximum number of times the request can be made if it fails with a throttling or server error.\n     */\n    tries?: number;\n}"
-          },
-          "HeaderParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "HeaderParams",
-            "value": "Record<string, string | number | string[]>",
-            "description": "Headers to be sent with the request.",
-            "members": []
-          },
-          "DataType": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "DataType",
-            "value": "export declare enum DataType {\n    JSON = \"application/json\",\n    GraphQL = \"application/graphql\",\n    URLEncoded = \"application/x-www-form-urlencoded\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "JSON",
-                "value": "application/json"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "GraphQL",
-                "value": "application/graphql"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-                "name": "URLEncoded",
-                "value": "application/x-www-form-urlencoded"
-              }
-            ]
-          },
-          "PostRequestParams": {
-            "filePath": "../shopify-api/dist/ts/lib/clients/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "PostRequestParams",
-            "value": "GetRequestParams & {\n    data: Record<string, any> | string;\n}",
-            "description": ""
           }
         }
       }
@@ -7734,64 +4573,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October24",
-                "value": "2024-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }
@@ -8070,14 +4851,6 @@
             },
             "value": "type AddDocumentResponseHeaders = (request: Request, headers: Headers) => void;"
           },
-          "Headers": {
-            "filePath": "../shopify-api/dist/ts/runtime/http/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "Headers",
-            "value": "Record<string, string | string[]>",
-            "description": "",
-            "members": []
-          },
           "Authenticate": {
             "filePath": "src/server/types.ts",
             "name": "Authenticate",
@@ -8233,41 +5006,8 @@
             "filePath": "src/server/authenticate/admin/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
             "name": "AdminContext",
-            "value": "FeatureEnabled<Config['future'], 'wip_optionalScopesApi'> extends true\n    ? EmbeddedTypedAdminContext<Config, Resources> & ScopesContext\n    : EmbeddedTypedAdminContext<Config, Resources>",
+            "value": "EmbeddedTypedAdminContext<Config, Resources> & ScopesContext",
             "description": ""
-          },
-          "FeatureEnabled": {
-            "filePath": "src/server/future/flags.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "FeatureEnabled",
-            "value": "Future extends FutureFlags\n  ? Future[Flag] extends true\n    ? true\n    : false\n  : false",
-            "description": ""
-          },
-          "FutureFlags": {
-            "filePath": "src/server/future/flags.ts",
-            "name": "FutureFlags",
-            "description": "",
-            "members": [
-              {
-                "filePath": "src/server/future/flags.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "unstable_newEmbeddedAuthStrategy",
-                "value": "boolean",
-                "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
-                "isOptional": true,
-                "defaultValue": "false"
-              },
-              {
-                "filePath": "src/server/future/flags.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "wip_optionalScopesApi",
-                "value": "boolean",
-                "description": "When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.",
-                "isOptional": true,
-                "defaultValue": "false"
-              }
-            ],
-            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.\n   *\n   * @default false\n   */\n  wip_optionalScopesApi?: boolean;\n}"
           },
           "EmbeddedTypedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -8569,284 +5309,6 @@
             ],
             "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to issue prorated credits for the unused portion of the app subscription. There will be a corresponding\n   * deduction (based on revenue share) to your Partner account. For example, if a $10.00 app subscription\n   * (with 0% revenue share) is cancelled and prorated half way through the billing cycle, then the merchant will be\n   * credited $5.00 and that amount will be deducted from your Partner account.\n   */\n  prorate?: boolean;\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest?: boolean;\n}"
           },
-          "AppSubscription": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppSubscription",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the app subscription."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "lineItems",
-                "value": "ActiveSubscriptionLineItem[]",
-                "description": "",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test subscription."
-              }
-            ],
-            "value": "export interface AppSubscription {\n    /**\n     * The ID of the app subscription.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test subscription.\n     */\n    test: boolean;\n    lineItems?: ActiveSubscriptionLineItem[];\n    status: string;\n}"
-          },
-          "ActiveSubscriptionLineItem": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "ActiveSubscriptionLineItem",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "AppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface ActiveSubscriptionLineItem {\n    id: string;\n    plan: AppPlan;\n}"
-          },
-          "AppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "pricingDetails",
-                "value": "RecurringAppPlan | UsageAppPlan",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlan {\n    pricingDetails: RecurringAppPlan | UsageAppPlan;\n}"
-          },
-          "RecurringAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "RecurringAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "discount",
-                "value": "AppPlanDiscount",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "interval",
-                "value": "BillingInterval.Every30Days | BillingInterval.Annual",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "Money",
-                "description": ""
-              }
-            ],
-            "value": "export interface RecurringAppPlan {\n    interval: BillingInterval.Every30Days | BillingInterval.Annual;\n    price: Money;\n    discount: AppPlanDiscount;\n}"
-          },
-          "AppPlanDiscount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "AppPlanDiscount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "durationLimitInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "priceAfterDiscount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "remainingDurationInIntervals",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "value",
-                "value": "AppPlanDiscountAmount",
-                "description": ""
-              }
-            ],
-            "value": "export interface AppPlanDiscount {\n    durationLimitInIntervals: number;\n    remainingDurationInIntervals: number;\n    priceAfterDiscount: Money;\n    value: AppPlanDiscountAmount;\n}"
-          },
-          "Money": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "Money",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "currencyCode",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface Money {\n    amount: number;\n    currencyCode: string;\n}"
-          },
-          "AppPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "AppPlanDiscountAmount",
-            "value": "BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": ""
-          },
-          "BillingConfigSubscriptionPlanDiscountAmount": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountAmount",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "number",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "never",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
-                "isOptional": true
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
-          },
-          "BillingConfigSubscriptionPlanDiscountPercentage": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "amount",
-                "value": "never",
-                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "percentage",
-                "value": "number",
-                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
-              }
-            ],
-            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
-          },
-          "BillingInterval": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "BillingInterval",
-            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "OneTime",
-                "value": "ONE_TIME"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Every30Days",
-                "value": "EVERY_30_DAYS"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Annual",
-                "value": "ANNUAL"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Usage",
-                "value": "USAGE"
-              }
-            ]
-          },
-          "UsageAppPlan": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageAppPlan",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "balanceUsed",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "cappedAmount",
-                "value": "Money",
-                "description": ""
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "terms",
-                "value": "string",
-                "description": ""
-              }
-            ],
-            "value": "export interface UsageAppPlan {\n    balanceUsed: Money;\n    cappedAmount: Money;\n    terms: string;\n}"
-          },
           "CheckBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
             "name": "CheckBillingOptions",
@@ -8870,71 +5332,6 @@
               }
             ],
             "value": "export interface CheckBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans?: (keyof Config['billing'])[];\n}"
-          },
-          "BillingCheckResponseObject": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "BillingCheckResponseObject",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "appSubscriptions",
-                "value": "AppSubscription[]",
-                "description": "The active subscriptions the shop has."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "hasActivePayment",
-                "value": "boolean",
-                "description": "Whether the user has an active payment method."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "oneTimePurchases",
-                "value": "OneTimePurchase[]",
-                "description": "The one-time purchases the shop has."
-              }
-            ],
-            "value": "export interface BillingCheckResponseObject {\n    /**\n     * Whether the user has an active payment method.\n     */\n    hasActivePayment: boolean;\n    /**\n     * The one-time purchases the shop has.\n     */\n    oneTimePurchases: OneTimePurchase[];\n    /**\n     * The active subscriptions the shop has.\n     */\n    appSubscriptions: AppSubscription[];\n}"
-          },
-          "OneTimePurchase": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "OneTimePurchase",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "name",
-                "value": "string",
-                "description": "The name of the purchased plan."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "status",
-                "value": "string",
-                "description": "The status of the one-time purchase."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "test",
-                "value": "boolean",
-                "description": "Whether this is a test purchase."
-              }
-            ],
-            "value": "export interface OneTimePurchase {\n    /**\n     * The ID of the one-time purchase.\n     */\n    id: string;\n    /**\n     * The name of the purchased plan.\n     */\n    name: string;\n    /**\n     * Whether this is a test purchase.\n     */\n    test: boolean;\n    /**\n     * The status of the one-time purchase.\n     */\n    status: string;\n}"
           },
           "CreateUsageRecordOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -8980,50 +5377,6 @@
               }
             ],
             "value": "export interface CreateUsageRecordOptions {\n  /**\n   * The description of the app usage record.\n   */\n  description: string;\n  /**\n   * The price of the app usage record.\n   */\n  price: {\n    /**\n     * The amount to charge for this usage record.\n     */\n    amount: number;\n    /**\n     * The currency code for this usage record.\n     */\n    currencyCode: string;\n  };\n  /**\n   * Whether to use the test mode. This prevents the credit card from being charged.\n   */\n  isTest: boolean;\n  /*\n   * Defines the usage pricing plan the merchant is subscribed to.\n   */\n  subscriptionLineItemId?: string;\n  /*\n   * A unique key generated to avoid duplicate charges.\n   */\n  idempotencyKey?: string;\n}"
-          },
-          "UsageRecord": {
-            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-            "name": "UsageRecord",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "description",
-                "value": "string",
-                "description": "The description of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The ID of the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "idempotencyKey",
-                "value": "string",
-                "description": "The idempotency key for this request.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "plan",
-                "value": "ActiveSubscriptionLineItem",
-                "description": "The subscription line item associated with the usage record."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "price",
-                "value": "{ amount: number; currencyCode: string; }",
-                "description": "The price and currency of the usage record."
-              }
-            ],
-            "value": "export interface UsageRecord {\n    /**\n     * The ID of the usage record.\n     */\n    id: string;\n    /**\n     * The description of the usage record.\n     */\n    description: string;\n    /**\n     * The price and currency of the usage record.\n     */\n    price: {\n        /**\n         * The amount to charge for this usage record.\n         */\n        amount: number;\n        /**\n         * The currency code for this usage record.\n         */\n        currencyCode: string;\n    };\n    /**\n     * The subscription line item associated with the usage record.\n     */\n    plan: ActiveSubscriptionLineItem;\n    /**\n     * The idempotency key for this request.\n     */\n    idempotencyKey?: string;\n}"
           },
           "RequestBillingOptions": {
             "filePath": "src/server/authenticate/admin/billing/types.ts",
@@ -9114,328 +5467,6 @@
             "description": "",
             "members": [],
             "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           },
           "EmbeddedAdminContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
@@ -9608,77 +5639,6 @@
             "value": "'_self' | '_parent' | '_top' | '_blank'",
             "description": ""
           },
-          "JwtPayload": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "JwtPayload",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "aud",
-                "value": "string",
-                "description": "The client ID of the receiving app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "dest",
-                "value": "string",
-                "description": "The shop's domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "exp",
-                "value": "number",
-                "description": "When the session token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iat",
-                "value": "number",
-                "description": "When the session token was issued."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "iss",
-                "value": "string",
-                "description": "The shop's admin domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "jti",
-                "value": "string",
-                "description": "A secure random UUID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "nbf",
-                "value": "number",
-                "description": "When the session token activates."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sid",
-                "value": "string",
-                "description": "A unique session ID per user and app."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "sub",
-                "value": "string",
-                "description": "The User that the session token is intended for."
-              }
-            ],
-            "value": "export interface JwtPayload {\n    /**\n     * The shop's admin domain.\n     */\n    iss: string;\n    /**\n     * The shop's domain.\n     */\n    dest: string;\n    /**\n     * The client ID of the receiving app.\n     */\n    aud: string;\n    /**\n     * The User that the session token is intended for.\n     */\n    sub: string;\n    /**\n     * When the session token expires.\n     */\n    exp: number;\n    /**\n     * When the session token activates.\n     */\n    nbf: number;\n    /**\n     * When the session token was issued.\n     */\n    iat: number;\n    /**\n     * A secure random UUID.\n     */\n    jti: string;\n    /**\n     * A unique session ID per user and app.\n     */\n    sid: string;\n}"
-          },
           "ScopesContext": {
             "filePath": "src/server/authenticate/admin/types.ts",
             "name": "ScopesContext",
@@ -9809,14 +5769,6 @@
             "name": "RestResourcesType",
             "value": "Config['restResources'] extends ShopifyRestResources\n    ? Config['restResources']\n    : ShopifyRestResources",
             "description": ""
-          },
-          "ShopifyRestResources": {
-            "filePath": "../shopify-api/dist/ts/rest/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "ShopifyRestResources",
-            "value": "Record<string, any>",
-            "description": "",
-            "members": []
           },
           "AuthenticateFlow": {
             "filePath": "src/server/authenticate/flow/types.ts",
@@ -10403,64 +6355,6 @@
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
           },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October24",
-                "value": "2024-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
-          },
           "AuthenticateCheckout": {
             "filePath": "src/server/authenticate/public/checkout/types.ts",
             "name": "AuthenticateCheckout",
@@ -10999,14 +6893,6 @@
             ],
             "value": "export interface RegisterWebhooksOptions {\n  /**\n   * The Shopify session used to register webhooks using the Admin API.\n   */\n  session: Session;\n}"
           },
-          "RegisterReturn": {
-            "filePath": "../shopify-api/dist/ts/lib/webhooks/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "RegisterReturn",
-            "value": "Record<string, RegisterResult[]>",
-            "description": "",
-            "members": []
-          },
           "SessionStorageType": {
             "filePath": "src/server/types.ts",
             "syntaxKind": "TypeAliasDeclaration",
@@ -11234,6 +7120,607 @@
             "name": "EnforceSessionStorage",
             "value": "Base & {\n  sessionStorage: SessionStorageType<Config>;\n}",
             "description": ""
+          },
+          "Base": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "name": "Base",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "#session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "GetAccessor",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "save",
+                "value": "({ update }?: SaveArgs) => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "saveAndUpdate",
+                "value": "() => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "delete",
+                "value": "() => Promise<void>",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "serialize",
+                "value": "(saving?: boolean) => Body",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toJSON",
+                "value": "() => Body",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "request",
+                "value": "<T = unknown>(args: RequestArgs) => Promise<RestRequestReturn<T>>",
+                "description": ""
+              }
+            ],
+            "value": "export class Base {\n  // For instance attributes\n  [key: string]: any;\n\n  public static Client: typeof RestClient;\n  public static config: ConfigInterface;\n\n  public static apiVersion: string;\n  protected static resourceNames: ResourceNames[] = [];\n\n  protected static primaryKey = 'id';\n  protected static customPrefix: string | null = null;\n  protected static readOnlyAttributes: string[] = [];\n\n  protected static hasOne: Record<string, typeof Base> = {};\n  protected static hasMany: Record<string, typeof Base> = {};\n\n  protected static paths: ResourcePath[] = [];\n\n  public static setClassProperties({Client, config}: SetClassPropertiesArgs) {\n    this.Client = Client;\n    this.config = config;\n  }\n\n  protected static async baseFind<T extends Base = Base>({\n    session,\n    urlIds,\n    params,\n    requireIds = false,\n  }: BaseFindArgs): Promise<FindAllResponse<T>> {\n    if (requireIds) {\n      const hasIds = Object.entries(urlIds).some(([_key, value]) => value);\n\n      if (!hasIds) {\n        throw new RestResourceError(\n          'No IDs given for request, cannot find path',\n        );\n      }\n    }\n\n    const response = await this.request<T>({\n      http_method: 'get',\n      operation: 'get',\n      session,\n      urlIds,\n      params,\n    });\n\n    return {\n      data: this.createInstancesFromResponse<T>(session, response.body as Body),\n      headers: response.headers,\n      pageInfo: response.pageInfo,\n    };\n  }\n\n  protected static async request<T = unknown>({\n    session,\n    http_method,\n    operation,\n    urlIds,\n    params,\n    body,\n    entity,\n  }: RequestArgs): Promise<RestRequestReturn<T>> {\n    const client = new this.Client({\n      session,\n      apiVersion: this.apiVersion as ApiVersion,\n    });\n\n    const path = this.getPath({http_method, operation, urlIds, entity});\n\n    const cleanParams: Record<string, string | number> = {};\n    if (params) {\n      for (const key in params) {\n        if (params[key] !== null) {\n          cleanParams[key] = params[key];\n        }\n      }\n    }\n\n    switch (http_method) {\n      case 'get':\n        return client.get<T>({path, query: cleanParams});\n      case 'post':\n        return client.post<T>({\n          path,\n          query: cleanParams,\n          data: body!,\n          type: DataType.JSON,\n        });\n      case 'put':\n        return client.put<T>({\n          path,\n          query: cleanParams,\n          data: body!,\n          type: DataType.JSON,\n        });\n      case 'delete':\n        return client.delete<T>({path, query: cleanParams});\n      default:\n        throw new Error(`Unrecognized HTTP method \"${http_method}\"`);\n    }\n  }\n\n  protected static getJsonBodyName(): string {\n    return this.name.replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase();\n  }\n\n  protected static getPath({\n    http_method,\n    operation,\n    urlIds,\n    entity,\n  }: GetPathArgs): string {\n    let match: string | null = null;\n    let specificity = -1;\n\n    const potentialPaths: ResourcePath[] = [];\n    this.paths.forEach((path: ResourcePath) => {\n      if (\n        http_method !== path.http_method ||\n        operation !== path.operation ||\n        path.ids.length <= specificity\n      ) {\n        return;\n      }\n\n      potentialPaths.push(path);\n\n      let pathUrlIds: IdSet = {...urlIds};\n      path.ids.forEach((id) => {\n        if (!pathUrlIds[id] && entity && entity[id]) {\n          pathUrlIds[id] = entity[id];\n        }\n      });\n\n      pathUrlIds = Object.entries(pathUrlIds).reduce(\n        (acc: IdSet, [key, value]: [string, string | number | null]) => {\n          if (value) {\n            acc[key] = value;\n          }\n          return acc;\n        },\n        {},\n      );\n\n      // If we weren't given all of the path's required ids, we can't use it\n      const diff = path.ids.reduce(\n        (acc: string[], id: string) => (pathUrlIds[id] ? acc : acc.concat(id)),\n        [],\n      );\n      if (diff.length > 0) {\n        return;\n      }\n\n      specificity = path.ids.length;\n      match = path.path.replace(\n        /(<([^>]+)>)/g,\n        (_m1, _m2, id) => `${pathUrlIds[id]}`,\n      );\n    });\n\n    if (!match) {\n      const pathOptions = potentialPaths.map((path) => path.path);\n\n      throw new RestResourceError(\n        `Could not find a path for request. If you are trying to make a request to one of the following paths, ensure all relevant IDs are set. :\\n - ${pathOptions.join(\n          '\\n - ',\n        )}`,\n      );\n    }\n\n    if (this.customPrefix) {\n      return `${this.customPrefix}/${match}`;\n    } else {\n      return match;\n    }\n  }\n\n  protected static createInstancesFromResponse<T extends Base = Base>(\n    session: Session,\n    data: Body,\n  ): T[] {\n    let instances: T[] = [];\n    this.resourceNames.forEach((resourceName) => {\n      const singular = resourceName.singular;\n      const plural = resourceName.plural;\n      if (data[plural] || Array.isArray(data[singular])) {\n        instances = instances.concat(\n          (data[plural] || data[singular]).reduce(\n            (acc: T[], entry: Body) =>\n              acc.concat(this.createInstance<T>(session, entry)),\n            [],\n          ),\n        );\n      } else if (data[singular]) {\n        instances.push(this.createInstance<T>(session, data[singular]));\n      }\n    });\n\n    return instances;\n  }\n\n  protected static createInstance<T extends Base = Base>(\n    session: Session,\n    data: Body,\n    prevInstance?: T,\n  ): T {\n    const instance: T = prevInstance\n      ? prevInstance\n      : new (this as any)({session});\n\n    if (data) {\n      instance.setData(data);\n    }\n\n    return instance;\n  }\n\n  #session: Session;\n\n  get session(): Session {\n    return this.#session;\n  }\n\n  constructor({session, fromData}: BaseConstructorArgs) {\n    this.#session = session;\n\n    if (fromData) {\n      this.setData(fromData);\n    }\n  }\n\n  public async save({update = false}: SaveArgs = {}): Promise<void> {\n    const {primaryKey, resourceNames} = this.resource();\n    const method = this[primaryKey] ? 'put' : 'post';\n\n    const data = this.serialize(true);\n\n    const response = await this.resource().request({\n      http_method: method,\n      operation: method,\n      session: this.session,\n      urlIds: {},\n      body: {[this.resource().getJsonBodyName()]: data},\n      entity: this,\n    });\n\n    const flattenResourceNames: string[] = resourceNames.reduce<string[]>(\n      (acc, obj) => {\n        return acc.concat(Object.values(obj));\n      },\n      [],\n    );\n\n    const matchResourceName = Object.keys(response.body as Body).filter(\n      (key: string) => flattenResourceNames.includes(key),\n    );\n\n    const body: Body | undefined = (response.body as Body)[\n      matchResourceName[0]\n    ];\n\n    if (update && body) {\n      this.setData(body);\n    }\n  }\n\n  public async saveAndUpdate(): Promise<void> {\n    await this.save({update: true});\n  }\n\n  public async delete(): Promise<void> {\n    await this.resource().request({\n      http_method: 'delete',\n      operation: 'delete',\n      session: this.session,\n      urlIds: {},\n      entity: this,\n    });\n  }\n\n  public serialize(saving = false): Body {\n    const {hasMany, hasOne, readOnlyAttributes} = this.resource();\n\n    return Object.entries(this).reduce((acc: Body, [attribute, value]) => {\n      if (\n        ['#session'].includes(attribute) ||\n        (saving && readOnlyAttributes.includes(attribute))\n      ) {\n        return acc;\n      }\n\n      if (attribute in hasMany && value) {\n        acc[attribute] = value.reduce((attrAcc: Body, entry: Base) => {\n          return attrAcc.concat(this.serializeSubAttribute(entry, saving));\n        }, []);\n      } else if (attribute in hasOne && value) {\n        acc[attribute] = this.serializeSubAttribute(value, saving);\n      } else {\n        acc[attribute] = value;\n      }\n\n      return acc;\n    }, {});\n  }\n\n  public toJSON(): Body {\n    return this.serialize();\n  }\n\n  public request<T = unknown>(args: RequestArgs) {\n    return this.resource().request<T>(args);\n  }\n\n  protected setData(data: Body): void {\n    const {hasMany, hasOne} = this.resource();\n\n    Object.entries(data).forEach(([attribute, val]) => {\n      if (attribute in hasMany) {\n        const HasManyResource: typeof Base = hasMany[attribute];\n        this[attribute] = [];\n        val.forEach((entry: Body) => {\n          const obj = new HasManyResource({session: this.session});\n          if (entry) {\n            obj.setData(entry);\n          }\n\n          this[attribute].push(obj);\n        });\n      } else if (attribute in hasOne) {\n        const HasOneResource: typeof Base = hasOne[attribute];\n        const obj = new HasOneResource({session: this.session});\n        if (val) {\n          obj.setData(val);\n        }\n        this[attribute] = obj;\n      } else {\n        this[attribute] = val;\n      }\n    });\n  }\n\n  protected resource(): typeof Base {\n    return this.constructor as unknown as typeof Base;\n  }\n\n  private serializeSubAttribute(attribute: Base, saving: boolean): Body {\n    return attribute.serialize\n      ? attribute.serialize(saving)\n      : this.resource()\n          .createInstance(this.session, attribute)\n          .serialize(saving);\n  }\n}"
+          },
+          "Session": {
+            "filePath": "../shopify-api/lib/session/session.ts",
+            "name": "Session",
+            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain, such as `example.myshopify.com`."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "scope",
+                "value": "string",
+                "description": "The desired scopes for the access token, at the time the session was created."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "PropertyDeclaration",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isActive",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeChanged",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes if they are provided."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isScopeIncluded",
+                "value": "(scopes: string | string[] | AuthScopes) => boolean",
+                "description": "Whether the access token includes the given scopes."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "isExpired",
+                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
+                "description": "Whether the access token is expired."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toObject",
+                "value": "() => SessionParams",
+                "description": "Converts an object with data into a Session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(other: Session) => boolean",
+                "description": "Checks whether the given session is equal to this session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/session.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toPropertyArray",
+                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
+                "description": "Converts the session into an array of key-value pairs."
+              }
+            ],
+            "value": "export class Session {\n  public static fromPropertyArray(\n    entries: [string, string | number | boolean][],\n    returnUserData = false,\n  ): Session {\n    if (!Array.isArray(entries)) {\n      throw new InvalidSession(\n        'The parameter is not an array: a Session cannot be created from this object.',\n      );\n    }\n\n    const obj = Object.fromEntries(\n      entries\n        .filter(([_key, value]) => value !== null && value !== undefined)\n        // Sanitize keys\n        .map(([key, value]) => {\n          switch (key.toLowerCase()) {\n            case 'isonline':\n              return ['isOnline', value];\n            case 'accesstoken':\n              return ['accessToken', value];\n            case 'onlineaccessinfo':\n              return ['onlineAccessInfo', value];\n            case 'userid':\n              return ['userId', value];\n            case 'firstname':\n              return ['firstName', value];\n            case 'lastname':\n              return ['lastName', value];\n            case 'accountowner':\n              return ['accountOwner', value];\n            case 'emailverified':\n              return ['emailVerified', value];\n            default:\n              return [key.toLowerCase(), value];\n          }\n        }),\n    );\n\n    const sessionData = {} as SessionParams;\n    const onlineAccessInfo = {\n      associated_user: {},\n    } as OnlineAccessInfo;\n    Object.entries(obj).forEach(([key, value]) => {\n      switch (key) {\n        case 'isOnline':\n          if (typeof value === 'string') {\n            sessionData[key] = value.toString().toLowerCase() === 'true';\n          } else if (typeof value === 'number') {\n            sessionData[key] = Boolean(value);\n          } else {\n            sessionData[key] = value;\n          }\n          break;\n        case 'scope':\n          sessionData[key] = value.toString();\n          break;\n        case 'expires':\n          sessionData[key] = value ? new Date(Number(value)) : undefined;\n          break;\n        case 'onlineAccessInfo':\n          onlineAccessInfo.associated_user.id = Number(value);\n          break;\n        case 'userId':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.id = Number(value);\n            break;\n          }\n        case 'firstName':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.first_name = String(value);\n            break;\n          }\n        case 'lastName':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.last_name = String(value);\n            break;\n          }\n        case 'email':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.email = String(value);\n            break;\n          }\n        case 'accountOwner':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.account_owner = Boolean(value);\n            break;\n          }\n        case 'locale':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.locale = String(value);\n            break;\n          }\n        case 'collaborator':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.collaborator = Boolean(value);\n            break;\n          }\n        case 'emailVerified':\n          if (returnUserData) {\n            onlineAccessInfo.associated_user.email_verified = Boolean(value);\n            break;\n          }\n        // Return any user keys as passed in\n        default:\n          sessionData[key] = value;\n      }\n    });\n    if (sessionData.isOnline) {\n      sessionData.onlineAccessInfo = onlineAccessInfo;\n    }\n    const session = new Session(sessionData);\n    return session;\n  }\n\n  /**\n   * The unique identifier for the session.\n   */\n  readonly id: string;\n  /**\n   * The Shopify shop domain, such as `example.myshopify.com`.\n   */\n  public shop: string;\n  /**\n   * The state of the session. Used for the OAuth authentication code flow.\n   */\n  public state: string;\n  /**\n   * Whether the access token in the session is online or offline.\n   */\n  public isOnline: boolean;\n  /**\n   * The desired scopes for the access token, at the time the session was created.\n   */\n  public scope?: string;\n  /**\n   * The date the access token expires.\n   */\n  public expires?: Date;\n  /**\n   * The access token for the session.\n   */\n  public accessToken?: string;\n  /**\n   * Information on the user for the session. Only present for online sessions.\n   */\n  public onlineAccessInfo?: OnlineAccessInfo;\n\n  constructor(params: SessionParams) {\n    Object.assign(this, params);\n  }\n\n  /**\n   * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n   * scopes if scopes is equal to a truthy value.\n   */\n  public isActive(scopes: AuthScopes | string | string[] | undefined): boolean {\n    const hasAccessToken = Boolean(this.accessToken);\n    const isTokenNotExpired = !this.isExpired();\n    const isScopeChanged = this.isScopeChanged(scopes);\n    return !isScopeChanged && hasAccessToken && isTokenNotExpired;\n  }\n\n  /**\n   * Whether the access token includes the given scopes if they are provided.\n   */\n  public isScopeChanged(\n    scopes: AuthScopes | string | string[] | undefined,\n  ): boolean {\n    if (typeof scopes === 'undefined') {\n      return false;\n    }\n\n    return !this.isScopeIncluded(scopes);\n  }\n\n  /**\n   * Whether the access token includes the given scopes.\n   */\n  public isScopeIncluded(scopes: AuthScopes | string | string[]): boolean {\n    const requiredScopes =\n      scopes instanceof AuthScopes ? scopes : new AuthScopes(scopes);\n    const sessionScopes = new AuthScopes(this.scope);\n\n    return sessionScopes.has(requiredScopes);\n  }\n\n  /**\n   * Whether the access token is expired.\n   */\n  public isExpired(withinMillisecondsOfExpiry = 0): boolean {\n    return Boolean(\n      this.expires &&\n        this.expires.getTime() - withinMillisecondsOfExpiry < Date.now(),\n    );\n  }\n\n  /**\n   * Converts an object with data into a Session.\n   */\n  public toObject(): SessionParams {\n    const object: SessionParams = {\n      id: this.id,\n      shop: this.shop,\n      state: this.state,\n      isOnline: this.isOnline,\n    };\n\n    if (this.scope) {\n      object.scope = this.scope;\n    }\n    if (this.expires) {\n      object.expires = this.expires;\n    }\n    if (this.accessToken) {\n      object.accessToken = this.accessToken;\n    }\n    if (this.onlineAccessInfo) {\n      object.onlineAccessInfo = this.onlineAccessInfo;\n    }\n    return object;\n  }\n\n  /**\n   * Checks whether the given session is equal to this session.\n   */\n  public equals(other: Session | undefined): boolean {\n    if (!other) return false;\n\n    const mandatoryPropsMatch =\n      this.id === other.id &&\n      this.shop === other.shop &&\n      this.state === other.state &&\n      this.isOnline === other.isOnline;\n\n    if (!mandatoryPropsMatch) return false;\n\n    const copyA = this.toPropertyArray(true);\n    copyA.sort(([k1], [k2]) => (k1 < k2 ? -1 : 1));\n\n    const copyB = other.toPropertyArray(true);\n    copyB.sort(([k1], [k2]) => (k1 < k2 ? -1 : 1));\n\n    return JSON.stringify(copyA) === JSON.stringify(copyB);\n  }\n\n  /**\n   * Converts the session into an array of key-value pairs.\n   */\n  public toPropertyArray(\n    returnUserData = false,\n  ): [string, string | number | boolean][] {\n    return (\n      Object.entries(this)\n        .filter(\n          ([key, value]) =>\n            propertiesToSave.includes(key) &&\n            value !== undefined &&\n            value !== null,\n        )\n        // Prepare values for db storage\n        .flatMap(([key, value]): [string, string | number | boolean][] => {\n          switch (key) {\n            case 'expires':\n              return [[key, value ? value.getTime() : undefined]];\n            case 'onlineAccessInfo':\n              // eslint-disable-next-line no-negated-condition\n              if (!returnUserData) {\n                return [[key, value.associated_user.id]];\n              } else {\n                return [\n                  ['userId', value?.associated_user?.id],\n                  ['firstName', value?.associated_user?.first_name],\n                  ['lastName', value?.associated_user?.last_name],\n                  ['email', value?.associated_user?.email],\n                  ['locale', value?.associated_user?.locale],\n                  ['emailVerified', value?.associated_user?.email_verified],\n                  ['accountOwner', value?.associated_user?.account_owner],\n                  ['collaborator', value?.associated_user?.collaborator],\n                ];\n              }\n            default:\n              return [[key, value]];\n          }\n        })\n        // Filter out tuples with undefined values\n        .filter(([_key, value]) => value !== undefined)\n    );\n  }\n}"
+          },
+          "OnlineAccessInfo": {
+            "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+            "name": "OnlineAccessInfo",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user",
+                "value": "OnlineAccessUser",
+                "description": "The user associated with the access token."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "associated_user_scope",
+                "value": "string",
+                "description": "The effective set of scopes for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires_in",
+                "value": "number",
+                "description": "How long the access token is valid for, in seconds."
+              }
+            ],
+            "value": "export interface OnlineAccessInfo {\n  /**\n   * How long the access token is valid for, in seconds.\n   */\n  expires_in: number;\n  /**\n   * The effective set of scopes for the session.\n   */\n  associated_user_scope: string;\n  /**\n   * The user associated with the access token.\n   */\n  associated_user: OnlineAccessUser;\n}"
+          },
+          "OnlineAccessUser": {
+            "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+            "name": "OnlineAccessUser",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "account_owner",
+                "value": "boolean",
+                "description": "Whether the user is the account owner."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "collaborator",
+                "value": "boolean",
+                "description": "Whether the user is a collaborator."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "email",
+                "value": "string",
+                "description": "The user's email address."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "email_verified",
+                "value": "boolean",
+                "description": "Whether the user has verified their email address."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "first_name",
+                "value": "string",
+                "description": "The user's first name."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "number",
+                "description": "The user's ID."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "last_name",
+                "value": "string",
+                "description": "The user's last name."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/oauth/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "locale",
+                "value": "string",
+                "description": "The user's locale."
+              }
+            ],
+            "value": "export interface OnlineAccessUser {\n  /**\n   * The user's ID.\n   */\n  id: number;\n  /**\n   * The user's first name.\n   */\n  first_name: string;\n  /**\n   * The user's last name.\n   */\n  last_name: string;\n  /**\n   * The user's email address.\n   */\n  email: string;\n  /**\n   * Whether the user has verified their email address.\n   */\n  email_verified: boolean;\n  /**\n   * Whether the user is the account owner.\n   */\n  account_owner: boolean;\n  /**\n   * The user's locale.\n   */\n  locale: string;\n  /**\n   * Whether the user is a collaborator.\n   */\n  collaborator: boolean;\n}"
+          },
+          "AuthScopes": {
+            "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+            "name": "AuthScopes",
+            "description": "A class that represents a set of access token scopes.",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "has",
+                "value": "(scope: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes includes the given one."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "equals",
+                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
+                "description": "Checks whether the current set of scopes equals the given one."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toString",
+                "value": "() => string",
+                "description": "Returns a comma-separated string with the current set of scopes."
+              },
+              {
+                "filePath": "../shopify-api/lib/auth/scopes/index.ts",
+                "syntaxKind": "MethodDeclaration",
+                "name": "toArray",
+                "value": "(returnOriginalScopes?: boolean) => any[]",
+                "description": "Returns an array with the current set of scopes."
+              }
+            ],
+            "value": "class AuthScopes {\n  public static SCOPE_DELIMITER = ',';\n\n  private compressedScopes: Set<string>;\n  private expandedScopes: Set<string>;\n  private originalScopes: Set<string>;\n\n  constructor(scopes: string | string[] | AuthScopes | undefined) {\n    let scopesArray: string[] = [];\n    if (typeof scopes === 'string') {\n      scopesArray = scopes.split(\n        new RegExp(`${AuthScopes.SCOPE_DELIMITER}\\\\s*`),\n      );\n    } else if (Array.isArray(scopes)) {\n      scopesArray = scopes;\n    } else if (scopes) {\n      scopesArray = Array.from(scopes.expandedScopes);\n    }\n\n    scopesArray = scopesArray\n      .map((scope) => scope.trim())\n      .filter((scope) => scope.length);\n\n    const impliedScopes = this.getImpliedScopes(scopesArray);\n\n    const scopeSet = new Set(scopesArray);\n    const impliedSet = new Set(impliedScopes);\n\n    this.compressedScopes = new Set(\n      [...scopeSet].filter((x) => !impliedSet.has(x)),\n    );\n    this.expandedScopes = new Set([...scopeSet, ...impliedSet]);\n    this.originalScopes = scopeSet;\n  }\n\n  /**\n   * Checks whether the current set of scopes includes the given one.\n   */\n  public has(scope: string | string[] | AuthScopes | undefined) {\n    let other: AuthScopes;\n\n    if (scope instanceof AuthScopes) {\n      other = scope;\n    } else {\n      other = new AuthScopes(scope);\n    }\n\n    return (\n      other.toArray().filter((x) => !this.expandedScopes.has(x)).length === 0\n    );\n  }\n\n  /**\n   * Checks whether the current set of scopes equals the given one.\n   */\n  public equals(otherScopes: string | string[] | AuthScopes | undefined) {\n    let other: AuthScopes;\n\n    if (otherScopes instanceof AuthScopes) {\n      other = otherScopes;\n    } else {\n      other = new AuthScopes(otherScopes);\n    }\n\n    return (\n      this.compressedScopes.size === other.compressedScopes.size &&\n      this.toArray().filter((x) => !other.has(x)).length === 0\n    );\n  }\n\n  /**\n   * Returns a comma-separated string with the current set of scopes.\n   */\n  public toString() {\n    return this.toArray().join(AuthScopes.SCOPE_DELIMITER);\n  }\n\n  /**\n   * Returns an array with the current set of scopes.\n   */\n  public toArray(returnOriginalScopes = false) {\n    return returnOriginalScopes\n      ? [...this.originalScopes]\n      : [...this.compressedScopes];\n  }\n\n  private getImpliedScopes(scopesArray: string[]): string[] {\n    return scopesArray.reduce((array: string[], current: string) => {\n      const matches = current.match(/^(unauthenticated_)?write_(.*)$/);\n      if (matches) {\n        array.push(`${matches[1] ? matches[1] : ''}read_${matches[2]}`);\n      }\n\n      return array;\n    }, []);\n  }\n}"
+          },
+          "SessionParams": {
+            "filePath": "../shopify-api/lib/session/types.ts",
+            "name": "SessionParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "name": "[key: string]",
+                "value": "any"
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "accessToken",
+                "value": "string",
+                "description": "The access token for the session.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "expires",
+                "value": "Date",
+                "description": "The date the access token expires.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "id",
+                "value": "string",
+                "description": "The unique identifier for the session."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "isOnline",
+                "value": "boolean",
+                "description": "Whether the access token in the session is online or offline."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "onlineAccessInfo",
+                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
+                "description": "Information on the user for the session. Only present for online sessions.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "scope",
+                "value": "string",
+                "description": "The scopes for the access token.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "shop",
+                "value": "string",
+                "description": "The Shopify shop domain."
+              },
+              {
+                "filePath": "../shopify-api/lib/session/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "state",
+                "value": "string",
+                "description": "The state of the session. Used for the OAuth authentication code flow."
+              }
+            ],
+            "value": "export interface SessionParams {\n  /**\n   * The unique identifier for the session.\n   */\n  readonly id: string;\n  /**\n   * The Shopify shop domain.\n   */\n  shop: string;\n  /**\n   * The state of the session. Used for the OAuth authentication code flow.\n   */\n  state: string;\n  /**\n   * Whether the access token in the session is online or offline.\n   */\n  isOnline: boolean;\n  /**\n   * The scopes for the access token.\n   */\n  scope?: string;\n  /**\n   * The date the access token expires.\n   */\n  expires?: Date;\n  /**\n   * The access token for the session.\n   */\n  accessToken?: string;\n  /**\n   * Information on the user for the session. Only present for online sessions.\n   */\n  onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n  /**\n   * Additional properties of the session allowing for extension\n   */\n  [key: string]: any;\n}"
+          },
+          "StoredOnlineAccessInfo": {
+            "filePath": "../shopify-api/lib/session/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "StoredOnlineAccessInfo",
+            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n  associated_user: Partial<OnlineAccessUser>;\n}",
+            "description": ""
+          },
+          "SaveArgs": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "name": "SaveArgs",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "update",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "interface SaveArgs {\n  update?: boolean;\n}"
+          },
+          "Body": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "Body",
+            "value": "Record<string, any>",
+            "description": "",
+            "members": []
+          },
+          "RequestArgs": {
+            "filePath": "../shopify-api/rest/base.ts",
+            "name": "RequestArgs",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "body",
+                "value": "Body | null",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "entity",
+                "value": "Base | null",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "http_method",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "operation",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "params",
+                "value": "ParamSet",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "requireIds",
+                "value": "boolean",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "session",
+                "value": "Session",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/rest/base.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "urlIds",
+                "value": "IdSet",
+                "description": ""
+              }
+            ],
+            "value": "interface RequestArgs extends BaseFindArgs {\n  http_method: string;\n  operation: string;\n  body?: Body | null;\n  entity?: Base | null;\n}"
+          },
+          "ParamSet": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "ParamSet",
+            "value": "Record<string, any>",
+            "description": "",
+            "members": []
+          },
+          "IdSet": {
+            "filePath": "../shopify-api/rest/types.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "IdSet",
+            "value": "Record<string, string | number | null>",
+            "description": "",
+            "members": []
+          },
+          "RestRequestReturn": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "name": "RestRequestReturn",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "body",
+                "value": "T",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "headers",
+                "value": "Headers",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "pageInfo",
+                "value": "PageInfo",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface RestRequestReturn<T = any> {\n  body: T;\n  headers: Headers;\n  pageInfo?: PageInfo;\n}"
+          },
+          "PageInfo": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "name": "PageInfo",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "fields",
+                "value": "string[]",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "limit",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "nextPage",
+                "value": "PageInfoParams",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "nextPageUrl",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "previousPageUrl",
+                "value": "string",
+                "description": "",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "prevPage",
+                "value": "PageInfoParams",
+                "description": "",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface PageInfo {\n  limit: string;\n  fields?: string[];\n  previousPageUrl?: string;\n  nextPageUrl?: string;\n  prevPage?: PageInfoParams;\n  nextPage?: PageInfoParams;\n}"
+          },
+          "PageInfoParams": {
+            "filePath": "../shopify-api/lib/clients/admin/types.ts",
+            "name": "PageInfoParams",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "path",
+                "value": "string",
+                "description": ""
+              },
+              {
+                "filePath": "../shopify-api/lib/clients/admin/types.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "query",
+                "value": "SearchParams",
+                "description": ""
+              }
+            ],
+            "value": "export interface PageInfoParams {\n  path: string;\n  query: SearchParams;\n}"
           },
           "SingleMerchantApp": {
             "filePath": "src/server/types.ts",
@@ -11717,6 +8204,64 @@
             ],
             "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n  Future extends FutureFlagOptions = FutureFlagOptions,\n> extends Omit<\n    ApiConfigArg<Resources, ApiFutureFlags<Future>>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n    | 'future'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * Optional for apps created in the Shopify Admin.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage?: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the shop-specific webhooks your app needs.\n   * \n   * Use this to configure shop-specific webhooks. In many cases defining app-specific webhooks in the `shopify.app.toml` will be sufficient and easier to manage.  Please see:\n   * \n   * {@link https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-vs-shop-specific-subscriptions}\n   * \n   * You should only use this if you need shop-specific webhooks. If you do need shop-specific webhooks this can be in used in conjunction with the afterAuth hook, loaders or processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering shop-specific webhooks.</caption>\n   * ```ts\n   * // app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     PRODUCTS_CREATE: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks/products/create\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       // Register webhooks for the shop\n   *       // In this example, every shop will have these webhooks\n   *       // But you could wrap this in some custom shop specific conditional logic\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * \n   * @example\n   * <caption>Registering app-specific webhooks (Recommended)</caption>\n   * ```toml\n   * # shopify.app.toml\n   * [webhooks]\n   * api_version = \"2024-07\"\n\n   *   [[webhooks.subscriptions]]\n   *   topics = [\"products/create\"]\n   *   uri = \"/webhooks/products/create\"\n   * \n   * ```\n   * \n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const { topic, shop, session, payload } = await authenticate.webhook(request);\n   * \n   *   // Webhook requests can trigger after an app is uninstalled\n   *   // If the app is already uninstalled, the session may be undefined.\n   *   if (!session) {\n   *     throw new Response();\n   *   }\n   * \n   *   // Handle the webhook\n   *   console.log(`${TOPIC} webhook received with`, JSON.stringify(payload))\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * AppStore should be used for public apps that are distributed in the Shopify App Store.\n   * SingleMerchant should be used for custom apps managed in the Partner Dashboard.\n   * ShopifyAdmin should be used for apps that are managed in the merchant's Shopify Admin.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderFunctionArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n\n  /**\n   * Features that will be introduced in future releases of this package.\n   *\n   * You can opt in to these features by setting the corresponding flags. By doing so, you can prepare for future\n   * releases in advance and provide feedback on the new features.\n   */\n  future?: Future;\n}"
           },
+          "ApiVersion": {
+            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "ApiVersion",
+            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "October22",
+                "value": "2022-10"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "January23",
+                "value": "2023-01"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "April23",
+                "value": "2023-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July23",
+                "value": "2023-07"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "October23",
+                "value": "2023-10"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "January24",
+                "value": "2024-01"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "April24",
+                "value": "2024-04"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "July24",
+                "value": "2024-07"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "October24",
+                "value": "2024-10"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Unstable",
+                "value": "unstable"
+              }
+            ]
+          },
           "BillingConfig": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
             "name": "BillingConfig",
@@ -11736,6 +8281,53 @@
             "name": "BillingConfigItem",
             "value": "FeatureEnabled<Future, 'lineItemBilling'> extends true ? BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan : BillingConfigLegacyItem",
             "description": ""
+          },
+          "FeatureEnabled": {
+            "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+            "syntaxKind": "TypeAliasDeclaration",
+            "name": "FeatureEnabled",
+            "value": "Future extends FutureFlags ? Future[Flag] extends true ? true : false : false",
+            "description": ""
+          },
+          "FutureFlags": {
+            "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+            "name": "FutureFlags",
+            "description": "Future flags are used to enable features that are not yet available by default.",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "customerAddressDefaultFix",
+                "value": "boolean",
+                "description": "Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This resolves a conflict with the default() method in that class.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "lineItemBilling",
+                "value": "boolean",
+                "description": "Enable line item billing, to make billing configuration more similar to the GraphQL API.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "unstable_managedPricingSupport",
+                "value": "boolean",
+                "description": "Enable support for managed pricing, so apps can check for payments without needing a billing config.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/future/flags.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "v10_lineItemBilling",
+                "value": "boolean",
+                "description": "Enable line item billing, to make billing configuration more similar to the GraphQL API. Default enabling of this feature has been moved to v11. Use lineItemBilling instead.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface FutureFlags {\n    /**\n     * Enable line item billing, to make billing configuration more similar to the GraphQL API. Default enabling of this\n     * feature has been moved to v11. Use lineItemBilling instead.\n     */\n    v10_lineItemBilling?: boolean;\n    /**\n     * Enable line item billing, to make billing configuration more similar to the GraphQL API.\n     */\n    lineItemBilling?: boolean;\n    /**\n     * Enable support for managed pricing, so apps can check for payments without needing a billing config.\n     */\n    unstable_managedPricingSupport?: boolean;\n    /**\n     * Change the CustomerAddress classes to expose a `is_default` property instead of `default` when fetching data. This\n     * resolves a conflict with the default() method in that class.\n     */\n    customerAddressDefaultFix?: boolean;\n}"
           },
           "BillingConfigOneTimePlan": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -11765,6 +8357,34 @@
               }
             ],
             "value": "export interface BillingConfigOneTimePlan extends BillingConfigPlan {\n    /**\n     * Interval for this plan.\n     *\n     * Must be set to `OneTime`.\n     */\n    interval: BillingInterval.OneTime;\n}"
+          },
+          "BillingInterval": {
+            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+            "syntaxKind": "EnumDeclaration",
+            "name": "BillingInterval",
+            "value": "export declare enum BillingInterval {\n    OneTime = \"ONE_TIME\",\n    Every30Days = \"EVERY_30_DAYS\",\n    Annual = \"ANNUAL\",\n    Usage = \"USAGE\"\n}",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "OneTime",
+                "value": "ONE_TIME"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Every30Days",
+                "value": "EVERY_30_DAYS"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Annual",
+                "value": "ANNUAL"
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
+                "name": "Usage",
+                "value": "USAGE"
+              }
+            ]
           },
           "BillingConfigSubscriptionLineItemPlan": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -11856,6 +8476,52 @@
               }
             ],
             "value": "export interface BillingConfigSubscriptionPlanDiscount {\n    /**\n     * The number of intervals to apply the discount for.\n     */\n    durationLimitInIntervals?: number;\n    /**\n     * The discount to apply.\n     */\n    value: BillingConfigSubscriptionPlanDiscountAmount | BillingConfigSubscriptionPlanDiscountPercentage;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountAmount": {
+            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountAmount",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "number",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set."
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "never",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set.",
+                "isOptional": true
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountAmount {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount: number;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage?: never;\n}"
+          },
+          "BillingConfigSubscriptionPlanDiscountPercentage": {
+            "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+            "name": "BillingConfigSubscriptionPlanDiscountPercentage",
+            "description": "",
+            "members": [
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "amount",
+                "value": "never",
+                "description": "The amount to discount.\n\nCannot be set if `percentage` is set.",
+                "isOptional": true
+              },
+              {
+                "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
+                "syntaxKind": "PropertySignature",
+                "name": "percentage",
+                "value": "number",
+                "description": "The percentage to discount.\n\nCannot be set if `amount` is set."
+              }
+            ],
+            "value": "export interface BillingConfigSubscriptionPlanDiscountPercentage {\n    /**\n     * The amount to discount.\n     *\n     * Cannot be set if `percentage` is set.\n     */\n    amount?: never;\n    /**\n     * The percentage to discount.\n     *\n     * Cannot be set if `amount` is set.\n     */\n    percentage: number;\n}"
           },
           "BillingConfigUsageLineItem": {
             "filePath": "../shopify-api/dist/ts/lib/billing/types.d.ts",
@@ -12085,32 +8751,6 @@
             ],
             "value": "export interface AfterAuthOptions<\n  R extends ShopifyRestResources = ShopifyRestResources,\n> {\n  session: Session;\n  admin: AdminApiContext<R>;\n}"
           },
-          "LogFunction": {
-            "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts",
-            "name": "LogFunction",
-            "description": "A function used by the library to log events related to Shopify.",
-            "params": [
-              {
-                "name": "severity",
-                "description": "",
-                "value": "LogSeverity",
-                "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts"
-              },
-              {
-                "name": "msg",
-                "description": "",
-                "value": "string",
-                "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts"
-              }
-            ],
-            "returns": {
-              "filePath": "../shopify-api/dist/ts/lib/base-types.d.ts",
-              "description": "",
-              "name": "void",
-              "value": "void"
-            },
-            "value": "export type LogFunction = (severity: LogSeverity, msg: string) => void;"
-          },
           "LogSeverity": {
             "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
             "syntaxKind": "EnumDeclaration",
@@ -12167,18 +8807,9 @@
                 "description": "When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange). This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n\nLearn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).",
                 "isOptional": true,
                 "defaultValue": "false"
-              },
-              {
-                "filePath": "src/server/future/flags.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "wip_optionalScopesApi",
-                "value": "boolean",
-                "description": "When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.",
-                "isOptional": true,
-                "defaultValue": "false"
               }
             ],
-            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n\n  /**\n   * When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.\n   *\n   * @default false\n   */\n  wip_optionalScopesApi?: boolean;\n}"
+            "value": "export interface FutureFlags {\n  /**\n   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).\n   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).\n   *\n   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).\n   *\n   * @default false\n   */\n  unstable_newEmbeddedAuthStrategy?: boolean;\n}"
           }
         }
       }
@@ -12442,328 +9073,6 @@
               }
             ],
             "value": "export interface UnauthenticatedAdminContext<\n  Resources extends ShopifyRestResources,\n> {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use to get shop-specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.admin(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the given store.\n   *\n   * @example\n   * <caption>Performing a GET request to the REST API.</caption>\n   * <description>Use `admin.rest.get` to make custom requests to make a request to to the `customer/count` endpoint</description>\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *  const { admin, session } = await unauthenticated.admin(request);\n   *\n   *  const response = await admin.rest.get(\n   *    {\n   *      path: \"/customers/count.json\"\n   *    }\n   *  );\n   *  const customers = await response.json();\n   *\n   *  return json({ customers });\n   * };\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *  restResources,\n   *  // ...etc\n   * });\n   *\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `admin.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *  const { admin } = await unauthenticated.admin(request);\n   *\n   *  const response = await admin.graphql(\n   *    `#graphql\n   *    mutation populateProduct($input: ProductInput!) {\n   *      productCreate(input: $input) {\n   *        product {\n   *          id\n   *        }\n   *      }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *  const productData = await response.json();\n   *  return json({ data: productData.data });\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *  restResources,\n   *  // ...etc\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n}"
-          },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
           }
         }
       }
@@ -12935,328 +9244,6 @@
             ],
             "value": "export interface UnauthenticatedStorefrontContext {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use this to get shop specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { LoaderFunctionArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.storefront(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Method for interacting with the Shopify GraphQL Storefront API for the given store.\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `storefront.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionFunctionArgs) {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   *\n   * @example\n   * <caption>Handling GraphQL errors.</caption>\n   * <description>Catch `GraphqlQueryError` errors to see error messages from the API.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { ActionFunctionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const action = async ({ request }: ActionFunctionArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { storefront } = await unauthenticated.storefront(shop);\n   *\n   *   try {\n   *     const response = await storefront.graphql(\n   *       `#graphql\n   *       query incorrectQuery {\n   *         products(first: 10) {\n   *           nodes {\n   *             not_a_field\n   *           }\n   *         }\n   *       }`,\n   *     );\n   *\n   *     return json({ data: await response.json() });\n   *   } catch (error) {\n   *     if (error instanceof GraphqlQueryError) {\n   *       // { errors: { graphQLErrors: [\n   *       //   { message: \"Field 'not_a_field' doesn't exist on type 'Product'\" }\n   *       // ] } }\n   *       return json({ errors: error.body?.errors }, { status: 500 });\n   *     }\n   *     return json({ message: \"An error occurred\" }, { status: 500 });\n   *   }\n   * }\n   * ```\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...\n   * });\n   * export default shopify;\n   * export const unauthenticated = shopify.unauthenticated;\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
           },
-          "Session": {
-            "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-            "name": "Session",
-            "description": "Stores App information from logged in merchants so they can make authenticated requests to the Admin API.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain, such as `example.myshopify.com`."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "scope",
-                "value": "string",
-                "description": "The desired scopes for the access token, at the time the session was created."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "PropertyDeclaration",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isActive",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the session is active. Active sessions have an access token that is not expired, and has has the given scopes if scopes is equal to a truthy value."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeChanged",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes if they are provided."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isScopeIncluded",
-                "value": "(scopes: string | string[] | AuthScopes) => boolean",
-                "description": "Whether the access token includes the given scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "isExpired",
-                "value": "(withinMillisecondsOfExpiry?: number) => boolean",
-                "description": "Whether the access token is expired."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toObject",
-                "value": "() => SessionParams",
-                "description": "Converts an object with data into a Session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(other: Session) => boolean",
-                "description": "Checks whether the given session is equal to this session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/session.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toPropertyArray",
-                "value": "(returnUserData?: boolean) => [string, string | number | boolean][]",
-                "description": "Converts the session into an array of key-value pairs."
-              }
-            ],
-            "value": "export declare class Session {\n    static fromPropertyArray(entries: [string, string | number | boolean][], returnUserData?: boolean): Session;\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain, such as `example.myshopify.com`.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The desired scopes for the access token, at the time the session was created.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo;\n    constructor(params: SessionParams);\n    /**\n     * Whether the session is active. Active sessions have an access token that is not expired, and has has the given\n     * scopes if scopes is equal to a truthy value.\n     */\n    isActive(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes if they are provided.\n     */\n    isScopeChanged(scopes: AuthScopes | string | string[] | undefined): boolean;\n    /**\n     * Whether the access token includes the given scopes.\n     */\n    isScopeIncluded(scopes: AuthScopes | string | string[]): boolean;\n    /**\n     * Whether the access token is expired.\n     */\n    isExpired(withinMillisecondsOfExpiry?: number): boolean;\n    /**\n     * Converts an object with data into a Session.\n     */\n    toObject(): SessionParams;\n    /**\n     * Checks whether the given session is equal to this session.\n     */\n    equals(other: Session | undefined): boolean;\n    /**\n     * Converts the session into an array of key-value pairs.\n     */\n    toPropertyArray(returnUserData?: boolean): [string, string | number | boolean][];\n}"
-          },
-          "OnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessInfo",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user",
-                "value": "OnlineAccessUser",
-                "description": "The user associated with the access token."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "associated_user_scope",
-                "value": "string",
-                "description": "The effective set of scopes for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires_in",
-                "value": "number",
-                "description": "How long the access token is valid for, in seconds."
-              }
-            ],
-            "value": "export interface OnlineAccessInfo {\n    /**\n     * How long the access token is valid for, in seconds.\n     */\n    expires_in: number;\n    /**\n     * The effective set of scopes for the session.\n     */\n    associated_user_scope: string;\n    /**\n     * The user associated with the access token.\n     */\n    associated_user: OnlineAccessUser;\n}"
-          },
-          "OnlineAccessUser": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-            "name": "OnlineAccessUser",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "account_owner",
-                "value": "boolean",
-                "description": "Whether the user is the account owner."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "collaborator",
-                "value": "boolean",
-                "description": "Whether the user is a collaborator."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email",
-                "value": "string",
-                "description": "The user's email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "email_verified",
-                "value": "boolean",
-                "description": "Whether the user has verified their email address."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "first_name",
-                "value": "string",
-                "description": "The user's first name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "number",
-                "description": "The user's ID."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "last_name",
-                "value": "string",
-                "description": "The user's last name."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/oauth/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "locale",
-                "value": "string",
-                "description": "The user's locale."
-              }
-            ],
-            "value": "export interface OnlineAccessUser {\n    /**\n     * The user's ID.\n     */\n    id: number;\n    /**\n     * The user's first name.\n     */\n    first_name: string;\n    /**\n     * The user's last name.\n     */\n    last_name: string;\n    /**\n     * The user's email address.\n     */\n    email: string;\n    /**\n     * Whether the user has verified their email address.\n     */\n    email_verified: boolean;\n    /**\n     * Whether the user is the account owner.\n     */\n    account_owner: boolean;\n    /**\n     * The user's locale.\n     */\n    locale: string;\n    /**\n     * Whether the user is a collaborator.\n     */\n    collaborator: boolean;\n}"
-          },
-          "AuthScopes": {
-            "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-            "name": "AuthScopes",
-            "description": "A class that represents a set of access token scopes.",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "has",
-                "value": "(scope: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes includes the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "equals",
-                "value": "(otherScopes: string | string[] | AuthScopes) => boolean",
-                "description": "Checks whether the current set of scopes equals the given one."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toString",
-                "value": "() => string",
-                "description": "Returns a comma-separated string with the current set of scopes."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/auth/scopes/index.d.ts",
-                "syntaxKind": "MethodDeclaration",
-                "name": "toArray",
-                "value": "(returnOriginalScopes?: boolean) => string[]",
-                "description": "Returns an array with the current set of scopes."
-              }
-            ],
-            "value": "declare class AuthScopes {\n    static SCOPE_DELIMITER: string;\n    private compressedScopes;\n    private expandedScopes;\n    private originalScopes;\n    constructor(scopes: string | string[] | AuthScopes | undefined);\n    /**\n     * Checks whether the current set of scopes includes the given one.\n     */\n    has(scope: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Checks whether the current set of scopes equals the given one.\n     */\n    equals(otherScopes: string | string[] | AuthScopes | undefined): boolean;\n    /**\n     * Returns a comma-separated string with the current set of scopes.\n     */\n    toString(): string;\n    /**\n     * Returns an array with the current set of scopes.\n     */\n    toArray(returnOriginalScopes?: boolean): string[];\n    private getImpliedScopes;\n}"
-          },
-          "SessionParams": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "name": "SessionParams",
-            "description": "",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "name": "[key: string]",
-                "value": "any"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "accessToken",
-                "value": "string",
-                "description": "The access token for the session.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "expires",
-                "value": "Date",
-                "description": "The date the access token expires.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "id",
-                "value": "string",
-                "description": "The unique identifier for the session."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "isOnline",
-                "value": "boolean",
-                "description": "Whether the access token in the session is online or offline."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "onlineAccessInfo",
-                "value": "OnlineAccessInfo | StoredOnlineAccessInfo",
-                "description": "Information on the user for the session. Only present for online sessions.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "scope",
-                "value": "string",
-                "description": "The scopes for the access token.",
-                "isOptional": true
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "shop",
-                "value": "string",
-                "description": "The Shopify shop domain."
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-                "syntaxKind": "PropertySignature",
-                "name": "state",
-                "value": "string",
-                "description": "The state of the session. Used for the OAuth authentication code flow."
-              }
-            ],
-            "value": "export interface SessionParams {\n    /**\n     * The unique identifier for the session.\n     */\n    readonly id: string;\n    /**\n     * The Shopify shop domain.\n     */\n    shop: string;\n    /**\n     * The state of the session. Used for the OAuth authentication code flow.\n     */\n    state: string;\n    /**\n     * Whether the access token in the session is online or offline.\n     */\n    isOnline: boolean;\n    /**\n     * The scopes for the access token.\n     */\n    scope?: string;\n    /**\n     * The date the access token expires.\n     */\n    expires?: Date;\n    /**\n     * The access token for the session.\n     */\n    accessToken?: string;\n    /**\n     * Information on the user for the session. Only present for online sessions.\n     */\n    onlineAccessInfo?: OnlineAccessInfo | StoredOnlineAccessInfo;\n    /**\n     * Additional properties of the session allowing for extension\n     */\n    [key: string]: any;\n}"
-          },
-          "StoredOnlineAccessInfo": {
-            "filePath": "../shopify-api/dist/ts/lib/session/types.d.ts",
-            "syntaxKind": "TypeAliasDeclaration",
-            "name": "StoredOnlineAccessInfo",
-            "value": "Omit<OnlineAccessInfo, 'associated_user'> & {\n    associated_user: Partial<OnlineAccessUser>;\n}",
-            "description": ""
-          },
           "StorefrontContext": {
             "filePath": "src/server/clients/storefront/types.ts",
             "name": "StorefrontContext",
@@ -13364,64 +9351,6 @@
               }
             ],
             "value": "export interface GraphQLQueryOptions<\n  Operation extends keyof Operations,\n  Operations extends AllOperations,\n> {\n  /**\n   * The variables to pass to the operation.\n   */\n  variables?: ApiClientRequestOptions<Operation, Operations>['variables'];\n  /**\n   * The version of the API to use for the request.\n   */\n  apiVersion?: ApiVersion;\n  /**\n   * Additional headers to include in the request.\n   */\n  headers?: Record<string, any>;\n  /**\n   * The total number of times to try the request if it fails.\n   */\n  tries?: number;\n}"
-          },
-          "ApiVersion": {
-            "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-            "syntaxKind": "EnumDeclaration",
-            "name": "ApiVersion",
-            "value": "export declare enum ApiVersion {\n    October22 = \"2022-10\",\n    January23 = \"2023-01\",\n    April23 = \"2023-04\",\n    July23 = \"2023-07\",\n    October23 = \"2023-10\",\n    January24 = \"2024-01\",\n    April24 = \"2024-04\",\n    July24 = \"2024-07\",\n    October24 = \"2024-10\",\n    Unstable = \"unstable\"\n}",
-            "members": [
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October22",
-                "value": "2022-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January23",
-                "value": "2023-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April23",
-                "value": "2023-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July23",
-                "value": "2023-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October23",
-                "value": "2023-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "January24",
-                "value": "2024-01"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "April24",
-                "value": "2024-04"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "July24",
-                "value": "2024-07"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "October24",
-                "value": "2024-10"
-              },
-              {
-                "filePath": "../shopify-api/dist/ts/lib/types.d.ts",
-                "name": "Unstable",
-                "value": "unstable"
-              }
-            ]
           }
         }
       }

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -14,7 +14,6 @@ import type {FutureFlags, FutureFlagOptions} from '../future/flags';
  */
 const TEST_FUTURE_FLAGS: Required<{[key in keyof FutureFlags]: true}> = {
   unstable_newEmbeddedAuthStrategy: true,
-  wip_optionalScopesApi: true,
 } as const;
 
 // Override the helper's future flags and logger settings for our purposes

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -132,13 +132,10 @@ export function authStrategyFactory<
   }
 
   function addScopesFeatures(context: AdminContextBase) {
-    if (config.future.wip_optionalScopesApi) {
-      return {
-        ...context,
-        scopes: scopesApiFactory(params, context.session, context.admin),
-      };
-    }
-    return context;
+    return {
+      ...context,
+      scopes: scopesApiFactory(params, context.session, context.admin),
+    };
   }
 
   return async function authenticateAdmin(request: Request) {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/request.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/scope/__tests__/request.test.ts
@@ -17,13 +17,13 @@ import * as redirect from '../../helpers/redirect-to-install-page';
 
 import * as responses from './mock-responses';
 
-it('when the future flag is disabled the scopes api is not available', async () => {
+it('scopes api is available without any future flags', async () => {
   // GIVEN
   const shopify = shopifyApp(
     testConfig({
       isEmbeddedApp: false,
       scopes: undefined,
-      future: {wip_optionalScopesApi: false},
+      future: {},
     }),
   );
   const session = await setUpValidSession(shopify.sessionStorage);
@@ -39,7 +39,7 @@ it('when the future flag is disabled the scopes api is not available', async () 
   const adminApi = await shopify.authenticate.admin(request);
 
   // THEN
-  expect(adminApi).not.toHaveProperty('scopes');
+  expect(adminApi).toHaveProperty('scopes');
 });
 
 it('when scopes are empty the request is not redirected', async () => {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/types.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/types.ts
@@ -3,7 +3,6 @@ import {JwtPayload, Session, ShopifyRestResources} from '@shopify/shopify-api';
 import {EnsureCORSFunction} from '../helpers/ensure-cors-headers';
 import type {AppConfigArg} from '../../config-types';
 import type {AdminApiContext} from '../../clients';
-import {FeatureEnabled} from '../../future/flags';
 
 import type {BillingContext} from './billing/types';
 import {RedirectFunction} from './helpers/redirect';
@@ -205,10 +204,7 @@ export interface ScopesContext {
 export type AdminContext<
   Config extends AppConfigArg,
   Resources extends ShopifyRestResources,
-> =
-  FeatureEnabled<Config['future'], 'wip_optionalScopesApi'> extends true
-    ? EmbeddedTypedAdminContext<Config, Resources> & ScopesContext
-    : EmbeddedTypedAdminContext<Config, Resources>;
+> = EmbeddedTypedAdminContext<Config, Resources> & ScopesContext;
 
 export type AuthenticateAdmin<
   Config extends AppConfigArg,

--- a/packages/apps/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/apps/shopify-app-remix/src/server/future/flags.ts
@@ -18,13 +18,6 @@ export interface FutureFlags {
    * @default false
    */
   unstable_newEmbeddedAuthStrategy?: boolean;
-
-  /**
-   * When enabled, the Scopes API will be available. This feature is in development and requires special permissions from Shopify for now.
-   *
-   * @default false
-   */
-  wip_optionalScopesApi?: boolean;
 }
 
 // When adding new flags, use this format:
@@ -61,13 +54,6 @@ export function logDisabledFutureFlags(
       'unstable_newEmbeddedAuthStrategy',
       'Enable this to use OAuth token exchange instead of auth code to generate API access tokens.' +
         '\n  Your app must be using Shopify managed install: https://shopify.dev/docs/apps/auth/installation',
-    );
-  }
-
-  if (!config.future.wip_optionalScopesApi) {
-    logFlag(
-      'wip_optionalScopesApi',
-      'Enable this to use the optionalScopes API to request additional scopes and manage them. ',
     );
   }
 }


### PR DESCRIPTION
### WHY are these changes introduced?
Closes:
- https://github.com/Shopify/develop-app-runtime-primitives/issues/540

When optional scopes feature is released, we have the option to either:
* Enable scopes future flag by default for new apps and communicate to apps to enable this future flag to use `Scopes` API OR
* Remove the future flag so that apps can use `Scopes` API automatically. 

I think removing the future flag makes more sense since we're adding new feature and not modifying existing behaviour of the library.

### WHAT is this pull request doing?
Removes future flag `wip_optionalScopesApi`.

### Top hatting
I tested by linking my app to a local version of the remix library. I can use the Scopes API without adding the future flag.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
