### PR TITLE
Remove the with keyword

### DIFF
--- a/.changeset/cyan-sheep-sin.md
+++ b/.changeset/cyan-sheep-sin.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Remove with keyword from json import.

--- a/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
@@ -2,10 +2,7 @@ import {
   AppProvider as PolarisAppProvider,
   AppProviderProps as PolarisAppProviderProps,
 } from '@shopify/polaris';
-// This leads to some TS errors, but it does compile to something that works
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import englishI18n from '@shopify/polaris/locales/en.json' with {type: 'json'};
+import englishI18n from '@shopify/polaris/locales/en.json';
 
 import {APP_BRIDGE_URL} from '../../const';
 import {RemixPolarisLink} from '../RemixPolarisLink';


### PR DESCRIPTION
### WHY are these changes introduced?

This repository currently uses the with keyword when importing JSON. This keyword is deprecated and causes problems on the latest LTS node versions in strict mode. 

### WHAT is this pull request doing?

Remove the with keyword as it is not needed.

## Type of change

- [x ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
