### PR TITLE
[bugfix] Ensure consistent behaviour when using access token from session in GQL and REST clients

### DIFF
--- a/.changeset/clever-taxis-retire.md
+++ b/.changeset/clever-taxis-retire.md
@@ -2,4 +2,6 @@
 '@shopify/shopify-api': patch
 ---
 
-[bugfix] Makes GQL client behavior on customn app config consistent with REST client
+[deprecation] Removes conditional check for `adminApiAccessToken` in REST client, deprecates `apiSecretKey` in favor of `adminApiAccessToken`
+[bugfix] Makes GQL client behavior on custom app config consistent with REST client
+[chore] Removes the warning about `adminApiAccessToken` and `apiSecretKey` being the same

--- a/.changeset/clever-taxis-retire.md
+++ b/.changeset/clever-taxis-retire.md
@@ -1,5 +1,5 @@
 ---
-'@shopify/shopify-api': minor
+'@shopify/shopify-api': patch
 ---
 
 [bugfix] Makes GQL client behavior on customn app config consistent with REST client

--- a/.changeset/clever-taxis-retire.md
+++ b/.changeset/clever-taxis-retire.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+[bugfix] Makes GQL client behavior on customn app config consistent with REST client

--- a/packages/apps/shopify-api/lib/__tests__/config.test.ts
+++ b/packages/apps/shopify-api/lib/__tests__/config.test.ts
@@ -122,19 +122,6 @@ describe('Config object', () => {
     }
   });
 
-  it(`logs warning if adminApiAccessToken same value as apiSecretKey`, () => {
-    validParams.isCustomStoreApp = true;
-    validParams.adminApiAccessToken = validParams.apiSecretKey;
-
-    const config = validateConfig(validParams);
-
-    expect(config.logger.log).toHaveBeenCalledWith(
-      LogSeverity.Warning,
-      expect.stringContaining('adminApiAccessToken is set'),
-    );
-    validParams.isCustomStoreApp = false;
-  });
-
   it('can partially override logger settings', () => {
     const configWithLogger = {...validParams};
     configWithLogger.logger = {

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/admin_graphql_client.test.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/admin_graphql_client.test.ts
@@ -127,6 +127,33 @@ describe('GraphQL client', () => {
     }).toMatchMadeHttpRequest();
   });
 
+  it('adapts to private app requests only if isCustomStoreApp', async () => {
+    const shopify = shopifyApi(
+      testConfig({
+        isCustomStoreApp: false,
+        adminApiAccessToken: 'dangit-another-access-token',
+      }),
+    );
+
+    const client = new shopify.clients.Graphql({session});
+    queueMockResponse(JSON.stringify(successResponse));
+
+    await expect(client.request(QUERY)).resolves.toEqual(
+      expect.objectContaining(successResponse),
+    );
+
+    const customHeaders: Record<string, string> = {};
+    customHeaders[ShopifyHeader.AccessToken] = accessToken;
+
+    expect({
+      method: 'POST',
+      domain,
+      path: `/admin/api/${shopify.config.apiVersion}/graphql.json`,
+      data: {query: QUERY},
+      headers: customHeaders,
+    }).toMatchMadeHttpRequest();
+  });
+
   it('fails to instantiate without access token', () => {
     const shopify = shopifyApi(testConfig());
 

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/rest_client.test.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/rest_client.test.ts
@@ -418,6 +418,33 @@ describe('REST client', () => {
     }).toMatchMadeHttpRequest();
   });
 
+  it('adapts to private app requests only if isCustomStoreApp', async () => {
+    const shopify = shopifyApi(
+      testConfig({
+        isCustomStoreApp: false,
+        adminApiAccessToken: 'test-admin-api-access-token',
+      }),
+    );
+
+    const client = new shopify.clients.Rest({session});
+
+    queueMockResponse(JSON.stringify(successResponse));
+
+    await expect(client.get({path: 'products'})).resolves.toEqual(
+      buildExpectedResponse(successResponse),
+    );
+
+    const customHeaders: Record<string, string> = {};
+    customHeaders[ShopifyHeader.AccessToken] = accessToken;
+
+    expect({
+      method: 'GET',
+      domain,
+      path: `/admin/api/${shopify.config.apiVersion}/products.json`,
+      headers: customHeaders,
+    }).toMatchMadeHttpRequest();
+  });
+  
   it('fails to instantiate without access token', () => {
     const shopify = shopifyApi(testConfig());
 

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/rest_client.test.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/rest_client.test.ts
@@ -444,7 +444,7 @@ describe('REST client', () => {
       headers: customHeaders,
     }).toMatchMadeHttpRequest();
   });
-  
+
   it('fails to instantiate without access token', () => {
     const shopify = shopifyApi(testConfig());
 

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -52,6 +52,7 @@ export class GraphqlClient {
 
       logger(config).debug(message);
     }
+
     const customStoreAppAccessToken = config.adminApiAccessToken ?? config.apiSecretKey;
 
     this.session = params.session;

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -56,6 +56,7 @@ export class GraphqlClient {
 
     this.session = params.session;
     this.apiVersion = params.apiVersion;
+
     this.client = createAdminApiClient({
       accessToken: config.isCustomStoreApp
         ? customStoreAppAccessToken

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -53,7 +53,8 @@ export class GraphqlClient {
       logger(config).debug(message);
     }
 
-    const customStoreAppAccessToken = config.adminApiAccessToken ?? config.apiSecretKey;
+    const customStoreAppAccessToken =
+      config.adminApiAccessToken ?? config.apiSecretKey;
 
     this.session = params.session;
     this.apiVersion = params.apiVersion;

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -52,11 +52,14 @@ export class GraphqlClient {
 
       logger(config).debug(message);
     }
+    const customStoreAppAccessToken = config.adminApiAccessToken ?? config.apiSecretKey;
 
     this.session = params.session;
     this.apiVersion = params.apiVersion;
     this.client = createAdminApiClient({
-      accessToken: config.adminApiAccessToken ?? this.session.accessToken!,
+      accessToken: config.isCustomStoreApp
+        ? customStoreAppAccessToken
+        : this.session.accessToken!,
       apiVersion: this.apiVersion ?? config.apiVersion,
       storeDomain: this.session.shop,
       customFetchApi: abstractFetch,

--- a/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/graphql/client.ts
@@ -53,15 +53,12 @@ export class GraphqlClient {
       logger(config).debug(message);
     }
 
-    const customStoreAppAccessToken =
-      config.adminApiAccessToken ?? config.apiSecretKey;
-
     this.session = params.session;
     this.apiVersion = params.apiVersion;
 
     this.client = createAdminApiClient({
       accessToken: config.isCustomStoreApp
-        ? customStoreAppAccessToken
+        ? config.adminApiAccessToken!
         : this.session.accessToken!,
       apiVersion: this.apiVersion ?? config.apiVersion,
       storeDomain: this.session.shop,

--- a/packages/apps/shopify-api/lib/clients/admin/rest/client.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/rest/client.ts
@@ -80,9 +80,6 @@ export class RestClient {
       logger(config).debug(message);
     }
 
-    const customStoreAppAccessToken =
-      config.adminApiAccessToken ?? config.apiSecretKey;
-
     this.session = session;
     this.apiVersion = apiVersion ?? config.apiVersion;
     this.client = createAdminRestApiClient({
@@ -90,7 +87,7 @@ export class RestClient {
       storeDomain: session.shop,
       apiVersion: apiVersion ?? config.apiVersion,
       accessToken: config.isCustomStoreApp
-        ? customStoreAppAccessToken
+        ? config.adminApiAccessToken!
         : session.accessToken!,
       customFetchApi: abstractFetch,
       logger: clientLoggerFactory(config),

--- a/packages/apps/shopify-api/lib/config.ts
+++ b/packages/apps/shopify-api/lib/config.ts
@@ -2,7 +2,6 @@ import {ShopifyError} from './error';
 import {ConfigInterface, ConfigParams} from './base-types';
 import {LATEST_API_VERSION, LogSeverity} from './types';
 import {AuthScopes} from './auth/scopes';
-import {logger as createLogger} from './logger';
 
 export function validateConfig<Params extends ConfigParams>(
   params: Params,

--- a/packages/apps/shopify-api/lib/config.ts
+++ b/packages/apps/shopify-api/lib/config.ts
@@ -98,15 +98,6 @@ export function validateConfig<Params extends ConfigParams>(
     future: future ?? config.future,
   });
 
-  if (
-    config.isCustomStoreApp &&
-    params.adminApiAccessToken === params.apiSecretKey
-  ) {
-    createLogger(config).warning(
-      "adminApiAccessToken is set to the same value as apiSecretKey. adminApiAccessToken should be set to the Admin API access token for custom store apps; apiSecretKey should be set to the custom store app's API secret key.",
-    );
-  }
-
   return config;
 }
 


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes https://github.com/Shopify/shopify-app-js/issues/1756

Passing real session to REST and GQL clients result in inconsistent behaviour. This is due to a custom `if` condition in the REST client that the GQL client doesn't have.

This only happens when using the `testConfig` test helper. While the consistent behaviour between the two is highly encouraged. It's not recommended to use a real session when using a `testConfig`. It's supposed to be a quick helper for unit tests, so all requests should be mocked.

For e2e tests, use a real config that points to a test Shopify store.

### WHAT is this pull request doing?

This pull request includes changes to make the GraphQL (GQL) client behavior on custom app configurations consistent with the REST client. The most important changes include adding tests to ensure the correct behavior and updating the client classes to handle custom store app access tokens appropriately.

### Consistent Behavior for Custom App Configurations:

* [`.changeset/clever-taxis-retire.md`](diffhunk://#diff-63bc40ce8481d68d7d975feaae38bf97ed09d31d3ec11e8791e40f4154f00f1dR1-R5): Added a minor bugfix entry to make GQL client behavior on custom app configurations consistent with the REST client.

### Test Enhancements:

* [`packages/apps/shopify-api/lib/clients/admin/__tests__/admin_graphql_client.test.ts`](diffhunk://#diff-dce84efeb0dd3e3ac8b6385d30114da3c82523cd3ad47b4e1f036af657d109caR130-R156): Added a test to verify that the GraphQL client adapts to private app requests only if `isCustomStoreApp` is set to false.
* [`packages/apps/shopify-api/lib/clients/admin/__tests__/rest_client.test.ts`](diffhunk://#diff-92ff4dd561353c9b85c3a24fd5f70ba36abb0390d086bbc7132149bf36c0a2bcR421-R447): Added a test to verify that the REST client adapts to private app requests only if `isCustomStoreApp` is set to false.

### Client Class Updates:

* [`packages/apps/shopify-api/lib/clients/admin/graphql/client.ts`](diffhunk://#diff-0cdbaf55d61c2d50c48c03b28d1cccec2b365a71b9f96c0626381d1553cfc451R56-R65): Updated the `GraphqlClient` class to use the appropriate access token based on the `isCustomStoreApp` configuration.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
