### PR TITLE
improvements:graphql-client

### DIFF
--- a/.changeset/few-mangos-cross.md
+++ b/.changeset/few-mangos-cross.md
@@ -1,0 +1,5 @@
+---
+'@shopify/storefront-api-client': patch
+---
+
+Improves Developer Experience and Code Robustness on the Storefront Client


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

These changes optimize the `StorefrontClient` class implementation, ensuring better performance and maintainability without introducing breaking changes. The previous implementation eagerly initialized some components, lacked streamlined error handling, and contained redundancies in code, which this PR addresses.

### WHAT is this pull request doing?

- **Lazily initialize the `client` instance**:
  - Replaced eager initialization with a `getter` to only create the client when accessed for the first time, reducing overhead.
  
- **Access token resolution logic**:
  - Moved access token logic to a dedicated private `resolveAccessToken` method for cleaner and reusable code.

- **Streamlined headers creation**:
  - Replaced `Object.entries` and `map` with a cleaner `reduce` for constructing request headers.

- **Added static constant for deprecation messages**:
  - Consolidated the deprecation message into a reusable constant to improve readability and ease future changes.

- **Improved error handling**:
  - Enhanced clarity and conditions for `throwFailedRequest`.

- **Preserved existing functionality**:
  - Ensured that no breaking changes were introduced while refactoring the code.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [] I have added/updated tests for this change
- [] I have documented new APIs/updated the documentation for modified APIs (for public APIs)