### PR TITLE
[Feature] Add the ability to override 'keepalive' on fetch requests

### DIFF
--- a/.changeset/heavy-seas-shave.md
+++ b/.changeset/heavy-seas-shave.md
@@ -1,0 +1,21 @@
+---
+'@shopify/graphql-client': minor
+---
+
+Make fetch's keepalive configurable when making requests
+
+Example:
+```typescript
+const shopQuery = `
+  query ShopQuery {
+    shop {
+      name
+      id
+    }
+  }
+`;
+
+const {data, errors, extensions} = await client.request(shopQuery, {
+  keepalive: true,
+});
+```

--- a/packages/api-clients/graphql-client/README.md
+++ b/packages/api-clients/graphql-client/README.md
@@ -90,6 +90,7 @@ const client = createGraphQLClient({
 | url?       | `string`                             | Alternative request API URL                                                                                                                                                                                                                          |
 | headers?   | `Record<string, string \| string[]>` | Additional and/or replacement headers to be used in the request                                                                                                                                                                                      |
 | retries?   | `number`                             | Alternative number of retries for the request. Retries only occur for requests that were abandoned or if the server responds with a `Too Many Request (429)` or `Service Unavailable (503)` response. Minimum value is `0` and maximum value is `3`. |
+| keepalive? | `boolean`                            | Whether to keep a connection alive when page is unloaded before a request has completed. Default value is `false`. |
 | signal?    | `AbortSignal`                        | If this option is set, the request can be canceled by calling `abort()` on the corresponding  `AbortController`.                                                                                                                                     |
 
 
@@ -226,6 +227,23 @@ const shopQuery = `
 // Will retry the HTTP request to the server 2 times if the requests were abandoned or the server responded with a 429 or 503 error
 const {data, errors, extensions} = await client.request(shopQuery, {
   retries: 2,
+});
+```
+
+### Make a request that should run even if page is unloaded
+
+```typescript
+const shopQuery = `
+  query ShopQuery {
+    shop {
+      name
+      id
+    }
+  }
+`;
+
+const {data, errors, extensions} = await client.request(shopQuery, {
+  keepalive: true,
 });
 ```
 

--- a/packages/api-clients/graphql-client/src/graphql-client/graphql-client.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/graphql-client.ts
@@ -111,6 +111,7 @@ function generateFetch(
       headers: overrideHeaders,
       url: overrideUrl,
       retries: overrideRetries,
+      keepalive,
       signal,
     } = options;
 
@@ -141,6 +142,7 @@ function generateFetch(
         headers: flatHeaders,
         body,
         signal,
+        keepalive,
       },
     ];
 

--- a/packages/api-clients/graphql-client/src/graphql-client/tests/http-fetch.test.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/tests/http-fetch.test.ts
@@ -85,6 +85,7 @@ describe('httpFetch utility', () => {
             body: JSON.stringify({query: operation}),
             headers: {'X-My-Header': '1'},
             signal: new AbortController().signal,
+            keepalive: true,
           },
         ];
 

--- a/packages/api-clients/graphql-client/src/graphql-client/types.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/types.ts
@@ -3,6 +3,7 @@ interface CustomRequestInit {
   headers?: HeadersInit;
   body?: string;
   signal?: AbortSignal;
+  keepalive?: boolean;
 }
 
 export type CustomFetchApi = (
@@ -94,6 +95,7 @@ export interface RequestOptions {
   url?: string;
   headers?: HeadersObject;
   retries?: number;
+  keepalive?: boolean;
   signal?: AbortSignal;
 }
 


### PR DESCRIPTION
- Optional (backwards compatible) change which allows additional customizability on fetch requests


### WHY are these changes introduced?
- Using keepalive will help use cases where we want a request to be made before a navigation occurs ([see here](https://github.com/Shopify/portable-wallets/issues/1891))

### WHAT is this pull request doing?
- Add "keepalive" to the request options and passes it into the "fetch" function

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [X] I have added/updated tests for this change
- [X] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
