### PR TITLE
Update ts-jest version in overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "node-fetch": "^2.6.7",
-    "ts-jest": "^29.2.5"
+    "ts-jest": "^29.2.6"
   },
   "overrides": {
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "node-fetch": "^2.6.7",
-    "ts-jest": "^29.2.5"
+    "ts-jest": "^29.2.6"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   jest: ^29.7.0
   jest-circus: ^29.7.0
   node-fetch: ^2.6.7
-  ts-jest: ^29.2.5
+  ts-jest: ^29.2.6
 
 importers:
 
@@ -111,7 +111,7 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       ts-jest:
-        specifier: ^29.2.5
+        specifier: ^29.2.6
         version: 29.2.6(@babel/core@7.26.0)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.0))(jest@29.7.0(@types/node@22.13.5)(ts-node@10.9.2(@swc/core@1.10.15)(@types/node@22.13.5)(typescript@5.7.3)))(typescript@5.7.3)
       ts-node:
         specifier: ^10.9.2


### PR DESCRIPTION
Otherwise running `npx @changesets/cli status --since="origin/main"` would crash with this error:
```
$ npx @changesets/cli status --since="origin/main"
npm ERR! code EOVERRIDE
npm ERR! Override for ts-jest@^29.2.6 conflicts with direct dependency

npm ERR! A complete log of this run can be found in: /Users/arkham/.npm/_logs/2025-02-27T15_41_20_594Z-debug-0.log
```