### PR TITLE
Fix Shopify local app development

### DIFF
--- a/.changeset/lovely-lions-taste.md
+++ b/.changeset/lovely-lions-taste.md
@@ -1,0 +1,7 @@
+---
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-remix': patch
+'@shopify/shopify-api': patch
+---
+
+fix Shopify internal local app development

--- a/packages/apps/shopify-api/lib/utils/__tests__/shop-admin-url-helper.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/shop-admin-url-helper.test.ts
@@ -10,6 +10,10 @@ const VALID_URLS = [
     adminUrl: 'admin.web.abc.def-gh.ij.spin.dev/store/my-shop',
     legacyAdminUrl: 'my-shop.shopify.abc.def-gh.ij.spin.dev',
   },
+  {
+    adminUrl: 'admin.shop.dev/store/my-shop',
+    legacyAdminUrl: 'my-shop.shop.dev',
+  },
 ];
 
 const INVALID_ADMIN_URLS = [

--- a/packages/apps/shopify-api/lib/utils/__tests__/shop-validator.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/shop-validator.test.ts
@@ -26,6 +26,7 @@ const VALID_HOSTS = [
   'my-other-other-host.myshopify.io/admin',
   'admin.shopify.com/store/my-shop',
   'admin.spin.dev/store/my-shop',
+  'admin.shop.dev/store/my-shop',
 ].map((testhost) => {
   return {testhost, base64host: Buffer.from(testhost).toString('base64')};
 });

--- a/packages/apps/shopify-api/lib/utils/shop-admin-url-helper.ts
+++ b/packages/apps/shopify-api/lib/utils/shop-admin-url-helper.ts
@@ -14,9 +14,12 @@ export function shopAdminUrlToLegacyUrl(shopAdminUrl: string): string | null {
   if (matches && matches.length === 2) {
     const shopName = matches[1];
     const isSpinUrl = shopUrl.includes('spin.dev/store/');
+    const isLocalUrl = shopUrl.includes('shop.dev/store/');
 
     if (isSpinUrl) {
       return spinAdminUrlToLegacyUrl(shopUrl);
+    } else if (isLocalUrl) {
+      return localAdminUrlToLegacyUrl(shopUrl);
     } else {
       return `${shopName}.myshopify.com`;
     }
@@ -36,9 +39,11 @@ export function legacyUrlToShopAdminUrl(legacyAdminUrl: string): string | null {
     return `admin.shopify.com/store/${shopName}`;
   } else {
     const isSpinUrl = shopUrl.endsWith('spin.dev');
-
+    const isLocalUrl = shopUrl.endsWith('shop.dev');
     if (isSpinUrl) {
       return spinLegacyUrlToAdminUrl(shopUrl);
+    } else if (isLocalUrl) {
+      return localLegacyUrlToAdminUrl(shopUrl);
     } else {
       return null;
     }
@@ -58,6 +63,18 @@ function spinAdminUrlToLegacyUrl(shopAdminUrl: string) {
   }
 }
 
+function localAdminUrlToLegacyUrl(shopAdminUrl: string) {
+  const localRegex = new RegExp(`admin\\.shop\\.dev/store/(.+)`);
+  const localMatches = shopAdminUrl.match(localRegex);
+
+  if (localMatches && localMatches.length === 2) {
+    const shopName = localMatches[1];
+    return `${shopName}.shop.dev`;
+  } else {
+    return null;
+  }
+}
+
 function spinLegacyUrlToAdminUrl(legacyAdminUrl: string) {
   const spinRegex = new RegExp(`(.+)\\.shopify\\.(.+\\.spin\\.dev)`);
   const spinMatches = legacyAdminUrl.match(spinRegex);
@@ -71,6 +88,17 @@ function spinLegacyUrlToAdminUrl(legacyAdminUrl: string) {
   }
 }
 
+function localLegacyUrlToAdminUrl(legacyAdminUrl: string) {
+  const localRegex = new RegExp(`(.+)\\.shop\\.dev$`);
+  const localMatches = legacyAdminUrl.match(localRegex);
+
+  if (localMatches && localMatches.length === 2) {
+    const shopName = localMatches[1];
+    return `admin.shop.dev/store/${shopName}`;
+  } else {
+    return null;
+  }
+}
 function removeProtocol(url: string): string {
   return url.replace(/^https?:\/\//, '').replace(/\/$/, '');
 }

--- a/packages/apps/shopify-api/lib/utils/shop-validator.ts
+++ b/packages/apps/shopify-api/lib/utils/shop-validator.ts
@@ -7,7 +7,12 @@ import {shopAdminUrlToLegacyUrl} from './shop-admin-url-helper';
 export function sanitizeShop(config: ConfigInterface) {
   return (shop: string, throwOnInvalid = false): string | null => {
     let shopUrl = shop;
-    const domainsRegex = ['myshopify\\.com', 'shopify\\.com', 'myshopify\\.io'];
+    const domainsRegex = [
+      'myshopify\\.com',
+      'shopify\\.com',
+      'myshopify\\.io',
+      'shop\\.dev',
+    ];
     if (config.customShopDomains) {
       domainsRegex.push(
         ...config.customShopDomains.map((regex) =>
@@ -51,6 +56,7 @@ export function sanitizeHost() {
         'shopify\\.com',
         'myshopify\\.io',
         'spin\\.dev',
+        'shop\\.dev',
       ];
 
       const hostRegex = new RegExp(`\\.(${originsRegex.join('|')})$`);

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/csp-headers.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/csp-headers.test.ts
@@ -15,7 +15,7 @@ const TESTS: {
   [TEST_SHOP, 12345, undefined].forEach((shop) => {
     let expectedCSP = `frame-ancestors 'none';`;
     if (isEmbeddedApp && typeof shop === 'string') {
-      expectedCSP = `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev;`;
+      expectedCSP = `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`;
     }
     TESTS.push({shop, isEmbeddedApp, expectedCSP});
   });

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -52,7 +52,7 @@ describe('ensureInstalledOnShop', () => {
       },
     });
     expect(response.headers['content-security-policy']).toEqual(
-      `frame-ancestors https://${TEST_SHOP} https://admin.shopify.com https://*.spin.dev;`,
+      `frame-ancestors https://${TEST_SHOP} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
   });
 

--- a/packages/apps/shopify-app-express/src/middlewares/csp-headers.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/csp-headers.ts
@@ -23,7 +23,7 @@ export function addCSPHeader(api: Shopify, req: Request, res: Response) {
       'Content-Security-Policy',
       `frame-ancestors https://${encodeURIComponent(
         shop,
-      )} https://admin.shopify.com https://*.spin.dev;`,
+      )} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
   } else {
     res.setHeader('Content-Security-Policy', `frame-ancestors 'none';`);

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-document-request-headers.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-document-request-headers.ts
@@ -12,7 +12,7 @@ export function expectDocumentRequestHeaders(
     expect(headers.get('Content-Security-Policy')).toEqual(
       `frame-ancestors https://${encodeURIComponent(
         TEST_SHOP,
-      )} https://admin.shopify.com https://*.spin.dev;`,
+      )} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
     expect(headers.get('Link')).toEqual(
       `<${APP_BRIDGE_URL}>; rel="preload"; as="script";`,

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/add-response-headers.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/add-response-headers.ts
@@ -34,7 +34,7 @@ export function addDocumentResponseHeaders(
     if (shop) {
       headers.set(
         'Content-Security-Policy',
-        `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev;`,
+        `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
       );
     }
   } else {


### PR DESCRIPTION
### WHY are these changes introduced?

- currently local app development is broken for Shopify internal developers, as we can not render embedded apps running locally within the shopify admin
- With the transition to World, this adds the new local domains the local admin is using to the various places that need it within the app libraries
- Do we also need to support the ruby libraries for local dev? 

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

- add the necessary domains like we did for spin

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
