### PR TITLE
[Docs] [Codegen] Document using types with direct API access

### DIFF
--- a/packages/api-clients/api-codegen-preset/README.md
+++ b/packages/api-clients/api-codegen-preset/README.md
@@ -333,3 +333,38 @@ To make your development flow faster, you can pass in the `--watch` flag to upda
 ```sh
 npm run graphql-codegen -- --watch
 ```
+
+### Using Generated Types with Direct API Access
+
+With Shopify App Bridge, you can use [Direct API Access](https://shopify.dev/docs/api/app-bridge-library#direct-api-access) to make API requests from your apps frontend directly to the Admin API.
+
+Because you are using the Fetch API directly, the responses cannot be automatically typed.
+
+```js
+import type {  GetProductsQuery } from "app/types/admin.generated";
+
+const fetchProduct = async () => {
+  const res = await fetch('shopify:admin/api/graphql.json', {
+    method: 'POST',
+    body: JSON.stringify({
+      query: `#graphql
+        query getProducts($first: Int) {
+          products(first: $first) {
+            edges {
+              cursor
+              node {
+                title
+                handle
+              }
+            }
+          }
+        }
+      ` as const,
+      variables: { first: 1 },
+    }),
+  });
+
+  const { data } = (await res.json()) as { data: GetProductsQuery };
+  console.log(data.products.edges[0]?.node);
+};
+```


### PR DESCRIPTION
### WHY are these changes introduced?

[Related to Codegen doesn't work out of the box with direct access graphql client](https://github.com/Shopify/shopify-app-js/issues/1981)
### WHAT is this pull request doing?
* Because direct API access uses the Fetch API directly, the response types cannot be automatically inferred, like when using the `admin.graphql`
* Developers could also consider creating a [custom wrapper client](https://github.com/Shopify/graphql-codegen?tab=readme-ov-file#making-graphql-clients) around fetch

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
