### PR TITLE
Use the same ts-jest version in resolutions and overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,12 +60,12 @@
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "node-fetch": "^2.6.7",
-    "ts-jest": "^29.3.0"
+    "ts-jest": "^29.3.1"
   },
   "overrides": {
     "jest": "^29.7.0",
     "jest-circus": "^29.7.0",
     "node-fetch": "^2.6.7",
-    "ts-jest": "^29.3.0"
+    "ts-jest": "^29.3.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ overrides:
   jest: ^29.7.0
   jest-circus: ^29.7.0
   node-fetch: ^2.6.7
-  ts-jest: ^29.3.0
+  ts-jest: ^29.3.1
 
 importers:
 
@@ -111,7 +111,7 @@ importers:
         specifier: ^7.1.0
         version: 7.1.0
       ts-jest:
-        specifier: ^29.3.0
+        specifier: ^29.3.1
         version: 29.3.1(@babel/core@7.26.10)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.10))(jest@29.7.0(@types/node@22.14.0)(ts-node@10.9.2(@swc/core@1.11.13)(@types/node@22.14.0)(typescript@5.7.3)))(typescript@5.7.3)
       ts-node:
         specifier: ^10.9.2


### PR DESCRIPTION
### WHY are these changes introduced?
Before these changes, the following command would fail:

```
npx @changesets/cli status --since="origin/main"
```

With this error:

```
npm ERR! code EOVERRIDE
npm ERR! Override for ts-jest@^29.3.1 conflicts with direct dependency
```

This is the cause of CI failing for all the dependabot upgrade PR's.

### WHAT is this pull request doing?

Updates resolutions and overrides for `ts-jest`.  Previously the version did not match the version is `devDependencies`, which was the root of the problem. Now the versions always match.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~~[ ] I have added/updated tests for this change~~
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~
