### PR TITLE
feat(shopify-app-remix): store and return cached promise from idempotent promise handler

### DIFF
--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/__tests__/idempotent-promise-handler.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/__tests__/idempotent-promise-handler.test.ts
@@ -17,12 +17,12 @@ describe('IdempotentPromiseHandler', () => {
     const promiseHandler = new IdempotentPromiseHandler();
 
     // WHEN
-    promiseHandler.handlePromise({
+    await promiseHandler.handlePromise({
       promiseFunction,
       identifier: 'first-promise',
     });
 
-    promiseHandler.handlePromise({
+    await promiseHandler.handlePromise({
       promiseFunction,
       identifier: 'first-promise',
     });
@@ -37,12 +37,12 @@ describe('IdempotentPromiseHandler', () => {
     const promiseHandler = new IdempotentPromiseHandler();
 
     // WHEN
-    promiseHandler.handlePromise({
+    await promiseHandler.handlePromise({
       promiseFunction,
       identifier: 'first-promise',
     });
 
-    promiseHandler.handlePromise({
+    await promiseHandler.handlePromise({
       promiseFunction,
       identifier: 'second-promise',
     });
@@ -51,14 +51,27 @@ describe('IdempotentPromiseHandler', () => {
     expect(mockFunction).toHaveBeenCalledTimes(2);
   });
 
+  it('returns the same promise for the same identifier', async () => {
+    // GIVEN
+    const promiseHandler = new IdempotentPromiseHandler();
+
+    // WHEN
+    const promise1 = promiseHandler.handlePromise({promiseFunction, identifier: 'same-promise'});
+    const promise2 = promiseHandler.handlePromise({promiseFunction, identifier: 'same-promise'});
+
+    // THEN
+    expect(promise1).toStrictEqual(promise2);
+    expect(mockFunction).toHaveBeenCalledTimes(1);
+  });
+
   it('clears stale identifier from hash', async () => {
     // GIVEN
     const currentDate = Date.now();
     jest.useFakeTimers().setSystemTime(currentDate);
-    const promiseHandler = new IdempotentPromiseHandler() as any;
+    const promiseHandler = new IdempotentPromiseHandler();
 
     // WHEN
-    promiseHandler.handlePromise({
+    await promiseHandler.handlePromise({
       promiseFunction,
       identifier: 'old-promise',
     });
@@ -75,15 +88,15 @@ describe('IdempotentPromiseHandler', () => {
 
   it('clears stale identifier from hash even when promise fails', async () => {
     // GIVEN
-    const promiseFunctionErr = () => {
+    const promiseFunctionErr = async () => {
       throw new ShopifyError();
     };
     const currentDate = Date.now();
     jest.useFakeTimers().setSystemTime(currentDate);
-    const promiseHandler = new IdempotentPromiseHandler() as any;
+    const promiseHandler = new IdempotentPromiseHandler();
 
     // WHEN
-    expect(
+    await expect(
       promiseHandler.handlePromise({
         promiseFunction: promiseFunctionErr,
         identifier: 'old-promise',
@@ -92,7 +105,7 @@ describe('IdempotentPromiseHandler', () => {
 
     jest.useFakeTimers().setSystemTime(currentDate + 70000);
 
-    expect(
+    await expect(
       promiseHandler.handlePromise({
         promiseFunction: promiseFunctionErr,
         identifier: 'new-promise',


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Relates to #1057 and #2081

<!--
  Context about the problem that’s being addressed.
-->

When using Shopify managed installation (`unstable_newEmbeddedAuthStrategy`), the authentication effectively happens __multiple__ times by each Remix `loader()` that calls `await authenticate.admin(request)`. For example, if the `/app` routes matches an layout route and a normal route, it will run two loaders in parallel. However, the `afterAuth` hook should only be called once during authentication, because this hook might create other resources, e.g. creates a user in the database. Since every loader does authentication, the `afterAuth` has to be de-duplicated with an [idempotent promise handler](https://github.com/Shopify/shopify-app-js/blob/main/packages/apps/shopify-app-remix/src/server/authenticate/helpers/idempotent-promise-handler.ts):
https://github.com/Shopify/shopify-app-js/blob/b8d25d087ec99e2a3aff0c4034e1d9290a541f3d/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts#L171-L185

This function uses the session token to avoid executing the same `afterAuth` multiple times by each loader. Only the first one runs the hook, every ones thereafter resolve with an empty promise.

However, this creates a condition where the first loader waits for the `afterAuth` hook to complete, while the other loaders continue with their execution after `await authenticate.admin(request)`. In other words, you cannot be sure if the hook did already complete after `await authenticate.admin(request)`. For example, if you create a user in a database and you need to access this user in the loaders, this user will not be available in all loaders.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

This PR changes the [idempotent promise handler](https://github.com/Shopify/shopify-app-js/blob/main/packages/apps/shopify-app-remix/src/server/authenticate/helpers/idempotent-promise-handler.ts) by storing the promise returned from the `afterAuth` hook in a map. Every loader that uses `await authenticate.admin(request)` will wait for the completion of the hook. The hook itself will still be only executed once, because we still maintain only one promise, but this promise might be awaited multiple times.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [X] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [X] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
