### PR TITLE
Add missing field to recurring app plan interface

### DIFF
--- a/packages/apps/shopify-api/lib/billing/types.ts
+++ b/packages/apps/shopify-api/lib/billing/types.ts
@@ -432,6 +432,10 @@ export interface RecurringAppPlan {
    * The discount applied to the plan.
    */
   discount: AppPlanDiscount;
+  /*
+   * The app store pricing plan handle.
+   */
+  planHandle: string;
 }
 
 export interface UsageAppPlan {


### PR DESCRIPTION
### WHY are these changes introduced?

To add the new `planHandle` field that was introduced on [April 1](https://shopify.dev/changelog/new-planhandle-field-managed-pricing) in version [2025-04](https://shopify.dev/docs/api/admin-graphql/latest/objects/AppRecurringPricing#field-planhandle).

### WHAT is this pull request doing?

Add missing field to the `RecurringAppPlan` interface for `shopify-api` package.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
