### PR TITLE
[Patch] Resolve issue where response objects were not logged

### DIFF
--- a/.changeset/weak-cases-yell.md
+++ b/.changeset/weak-cases-yell.md
@@ -1,0 +1,16 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Log HTTP Response objects
+
+Resolves a bug where HTTP Response objects were not being logged correctly. Now when `httpRequests` is enabled, the response object is logged as a plain object.
+
+```
+// shopify.server
+shopifyApp(
+...
+logger: {
+    httpRequests: true,
+});
+```

--- a/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
+++ b/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
@@ -1,0 +1,464 @@
+import {
+  HTTPResponseLog,
+  HTTPRetryLog,
+  HTTPResponseGraphQLDeprecationNotice,
+  LogContent,
+} from '@shopify/admin-api-client';
+
+import {clientLoggerFactory} from '../common';
+import {testConfig} from '../../__tests__/test-config';
+import * as loggerModule from '../../logger';
+
+// Mock the logger module
+jest.mock('../../logger', () => ({
+  logger: jest.fn(),
+}));
+
+const mockLogger = jest.mocked(loggerModule.logger);
+const mockDebug = jest.fn();
+
+describe('clientLoggerFactory', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLogger.mockReturnValue({
+      log: jest.fn(),
+      debug: mockDebug,
+      info: jest.fn(),
+      warning: jest.fn(),
+      error: jest.fn(),
+      deprecated: jest.fn(),
+    });
+  });
+
+  describe('when httpRequests logging is enabled', () => {
+    const config = testConfig({
+      logger: {
+        httpRequests: true,
+      },
+    });
+
+    it('logs HTTP-Response events with serialized response data', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const realResponse = new Response('{"products": []}', {
+        status: 200,
+        statusText: 'OK',
+        headers: {
+          'content-type': 'application/json',
+          'x-request-id': 'abc123',
+        },
+      });
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+            headers: {'Content-Type': 'application/json'},
+          },
+          response: realResponse,
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Received response for HTTP request',
+        {
+          requestParams: JSON.stringify(httpResponseLog.content.requestParams),
+          response: expect.stringContaining('"status":200'),
+        },
+      );
+
+      // Verify the response was properly serialized
+      const loggedResponse = JSON.parse(mockDebug.mock.calls[0][1].response);
+      expect(loggedResponse).toMatchObject({
+        status: 200,
+        statusText: 'OK',
+        ok: true,
+        redirected: false,
+        type: 'default',
+        url: '',
+        headers: {
+          'content-type': 'application/json',
+          'x-request-id': 'abc123',
+        },
+      });
+    });
+
+    it('logs HTTP-Retry events with retry attempt information', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const retryResponse = new Response('{"error": "Too Many Requests"}', {
+        status: 429,
+        statusText: 'Too Many Requests',
+        headers: {
+          'retry-after': '2',
+        },
+      });
+
+      const httpRetryLog: LogContent = {
+        type: 'HTTP-Retry',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'POST',
+          },
+          retryAttempt: 2,
+          maxRetries: 3,
+          lastResponse: retryResponse,
+        },
+      };
+
+      loggerFn(httpRetryLog);
+
+      expect(mockDebug).toHaveBeenCalledWith('Retrying HTTP request', {
+        requestParams: JSON.stringify(httpRetryLog.content.requestParams),
+        retryAttempt: 2,
+        maxRetries: 3,
+        response: expect.stringContaining('"status":429'),
+      });
+
+      // Verify the retry response was properly serialized
+      const loggedResponse = JSON.parse(mockDebug.mock.calls[0][1].response);
+      expect(loggedResponse).toMatchObject({
+        status: 429,
+        statusText: 'Too Many Requests',
+        ok: false,
+        headers: {
+          'retry-after': '2',
+        },
+      });
+    });
+
+    it('logs HTTP-Retry events with undefined lastResponse', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpRetryLog: LogContent = {
+        type: 'HTTP-Retry',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          retryAttempt: 1,
+          maxRetries: 3,
+          lastResponse: undefined,
+        },
+      };
+
+      loggerFn(httpRetryLog);
+
+      expect(mockDebug).toHaveBeenCalledWith('Retrying HTTP request', {
+        requestParams: JSON.stringify(httpRetryLog.content.requestParams),
+        retryAttempt: 1,
+        maxRetries: 3,
+        response: 'undefined',
+      });
+    });
+
+    it('logs GraphQL deprecation notices', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const graphqlDeprecationLog: LogContent = {
+        type: 'HTTP-Response-GraphQL-Deprecation-Notice',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            method: 'POST',
+            body: JSON.stringify({
+              query:
+                'query { products(first: 10) { edges { node { id title } } } }',
+            }),
+          },
+          deprecationNotice:
+            'Field `Product.handle` is deprecated. Use `Product.slug` instead.',
+        },
+      };
+
+      loggerFn(graphqlDeprecationLog);
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Received response containing Deprecated GraphQL Notice',
+        {
+          requestParams: JSON.stringify(
+            graphqlDeprecationLog.content.requestParams,
+          ),
+          deprecationNotice:
+            'Field `Product.handle` is deprecated. Use `Product.slug` instead.',
+        },
+      );
+    });
+
+    it('logs unknown event types using default case', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const unknownLog: LogContent = {
+        type: 'HTTP-Unknown' as any,
+        content: 'Some unknown log content',
+      };
+
+      loggerFn(unknownLog);
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'HTTP request event: Some unknown log content',
+      );
+    });
+
+    it('handles responses without headers.entries method', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      // Create a response-like object without headers.entries method
+      const responseWithoutEntries = {
+        status: 200,
+        statusText: 'OK',
+        ok: true,
+        redirected: false,
+        type: 'basic',
+        url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+        headers: {
+          'content-type': 'application/json',
+          'x-request-id': 'abc123',
+        },
+      };
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          response: responseWithoutEntries,
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Received response for HTTP request',
+        {
+          requestParams: JSON.stringify(httpResponseLog.content.requestParams),
+          response: JSON.stringify({
+            status: 200,
+            statusText: 'OK',
+            ok: true,
+            redirected: false,
+            type: 'basic',
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            headers: {
+              'content-type': 'application/json',
+              'x-request-id': 'abc123',
+            },
+          }),
+        },
+      );
+    });
+
+    it('handles responses with no response object', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          response: null,
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Received response for HTTP request',
+        {
+          requestParams: JSON.stringify(httpResponseLog.content.requestParams),
+          response: JSON.stringify({error: 'No response object provided'}),
+        },
+      );
+    });
+
+    it('handles malformed response objects that throw during serialization', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      // Mock a response that will throw during destructuring
+      const problematicResponse = {
+        get status() {
+          throw new Error('Cannot access status');
+        },
+      };
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          response: problematicResponse,
+        },
+      };
+
+      // The serializeResponse function catches the error during destructuring
+      // and returns the original object, but JSON.stringify will still throw
+      // when trying to serialize the problematic getter
+      expect(() => loggerFn(httpResponseLog)).toThrow('Cannot access status');
+    });
+
+    it('handles response objects that throw during destructuring but are JSON serializable', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      // Create a response that throws during destructuring but can be JSON.stringify'd
+      const problematicResponse = {
+        get status() {
+          throw new Error('Cannot access status');
+        },
+        toJSON() {
+          return {serialized: 'safely'};
+        },
+      };
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          response: problematicResponse,
+        },
+      };
+
+      // This should not throw - the serializeResponse catches the destructuring error
+      // and returns the original object, which has a toJSON method
+      expect(() => loggerFn(httpResponseLog)).not.toThrow();
+
+      expect(mockDebug).toHaveBeenCalledWith(
+        'Received response for HTTP request',
+        {
+          requestParams: JSON.stringify(httpResponseLog.content.requestParams),
+          response: JSON.stringify({serialized: 'safely'}),
+        },
+      );
+    });
+  });
+
+  describe('when httpRequests logging is disabled', () => {
+    const config = testConfig({
+      logger: {
+        httpRequests: false,
+      },
+    });
+
+    it('does not log HTTP-Response events', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const realResponse = new Response('{"data": "test"}', {
+        status: 200,
+        statusText: 'OK',
+      });
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+          },
+          response: realResponse,
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expect(mockDebug).not.toHaveBeenCalled();
+    });
+
+    it('does not log HTTP-Retry events', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const retryResponse = new Response('{"error": "Server Error"}', {
+        status: 500,
+        statusText: 'Internal Server Error',
+      });
+
+      const httpRetryLog: LogContent = {
+        type: 'HTTP-Retry',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'POST',
+          },
+          retryAttempt: 1,
+          maxRetries: 3,
+          lastResponse: retryResponse,
+        },
+      };
+
+      loggerFn(httpRetryLog);
+
+      expect(mockDebug).not.toHaveBeenCalled();
+    });
+
+    it('does not log GraphQL deprecation notices', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const graphqlDeprecationLog: LogContent = {
+        type: 'HTTP-Response-GraphQL-Deprecation-Notice',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            method: 'POST',
+          },
+          deprecationNotice: 'Field deprecated',
+        },
+      };
+
+      loggerFn(graphqlDeprecationLog);
+
+      expect(mockDebug).not.toHaveBeenCalled();
+    });
+
+    it('does not log unknown event types', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const unknownLog: LogContent = {
+        type: 'HTTP-Unknown' as any,
+        content: 'Some unknown log content',
+      };
+
+      loggerFn(unknownLog);
+
+      expect(mockDebug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('logger function integration', () => {
+    it('calls logger with the correct config', () => {
+      const config = testConfig({
+        logger: {
+          httpRequests: true,
+        },
+      });
+
+      const loggerFn = clientLoggerFactory(config);
+
+      const realResponse = new Response('{}', {status: 200});
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {url: 'test-url', method: 'GET'},
+          response: realResponse,
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expect(mockLogger).toHaveBeenCalledWith(config);
+    });
+  });
+});

--- a/packages/apps/shopify-api/lib/clients/common.ts
+++ b/packages/apps/shopify-api/lib/clients/common.ts
@@ -26,6 +26,35 @@ export function getUserAgent(config: ConfigInterface): string {
   return userAgentPrefix;
 }
 
+function serializeResponse(response: Response | any) {
+  if (!response) {
+    return {error: 'No response object provided'};
+  }
+
+  try {
+    const {status, statusText, ok, redirected, type, url, headers} = response;
+
+    const serialized: any = {
+      status,
+      statusText,
+      ok,
+      redirected,
+      type,
+      url,
+    };
+
+    if (headers?.entries) {
+      serialized.headers = Object.fromEntries(headers.entries());
+    } else if (headers) {
+      serialized.headers = headers;
+    }
+
+    return serialized;
+  } catch {
+    return response;
+  }
+}
+
 export function clientLoggerFactory(config: ConfigInterface) {
   return (logContent: LogContent) => {
     if (config.logger.httpRequests) {
@@ -34,7 +63,7 @@ export function clientLoggerFactory(config: ConfigInterface) {
           const responseLog: HTTPResponseLog['content'] = logContent.content;
           logger(config).debug('Received response for HTTP request', {
             requestParams: JSON.stringify(responseLog.requestParams),
-            response: JSON.stringify(responseLog.response),
+            response: JSON.stringify(serializeResponse(responseLog.response)),
           });
           break;
         }
@@ -44,7 +73,9 @@ export function clientLoggerFactory(config: ConfigInterface) {
             requestParams: JSON.stringify(responseLog.requestParams),
             retryAttempt: responseLog.retryAttempt,
             maxRetries: responseLog.maxRetries,
-            response: JSON.stringify(responseLog.lastResponse),
+            response: responseLog.lastResponse
+              ? JSON.stringify(serializeResponse(responseLog.lastResponse))
+              : 'undefined',
           });
           break;
         }


### PR DESCRIPTION
### WHY are these changes introduced?
* When `httpRequests` was set to true, the response object was not getting logged

e.g.
```
[shopify-api/DEBUG] Received response for HTTP request | {requestParams: ["https://dev-prototype.myshopify.com/admin/api/2025-01/graphql.json",{"method":"POST","headers":{"Content-Type":"application/json","Accept":"application/json","X-Shopify-Access-Token":"shpua_e23a074fc8caf01037028291dfde5af1","User-Agent":"Shopify Remix
Library v3.8.2 | Shopify API Library v11.12.0 | Remix | Admin API Client v1.0.8","X-SDK-Variant":"shopify-graphql-client","X-SDK-Version":"1.3.2"},"body":"{\"query\":\"#graphql\\n        query getLatestProduct {\\n          products(first: 1, sortKey: CREATED_AT, reverse: true) {\\n            nodes {\\n              id\\n              title\\n
   handle\\n              createdAt\\n              metafields(first: 10) {\\n                nodes {\\n                  id\\n                  namespace\\n                  key\\n                  value\\n                  type\\n                }\\n              }\\n            }\\n          }\\n          metafieldDefinitions(ownerType: PRODUCT, first:
 20) {\\n            nodes {\\n              id\\n              namespace\\n              key\\n              name\\n              description\\n              type {\\n                name\\n                category\\n              }\\n            }\\n          }\\n        }\\n      \"}"}], response: {}}
```
`response: {}}` response was logged as an empty object.

This is because you cannot JSON.stringify a web API response object.
<img width="814" alt="Building complex Shopify Functions made easy 2025-06-03 10-39-03" src="https://github.com/user-attachments/assets/d927818d-a805-4786-8ed8-bc58c050cab2" />

### WHAT is this pull request doing?
Manually serializes the request object before turning to JSON

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
