### PR TITLE
Fix issue with missing sourcemaps

### DIFF
--- a/.changeset/long-pandas-think.md
+++ b/.changeset/long-pandas-think.md
@@ -1,0 +1,23 @@
+---
+'@shopify/admin-api-client': patch
+'@shopify/api-codegen-preset': patch
+'@shopify/graphql-client': patch
+'@shopify/storefront-api-client': patch
+'@shopify/shopify-app-session-storage': patch
+'@shopify/shopify-app-session-storage-drizzle': patch
+'@shopify/shopify-app-session-storage-dynamodb': patch
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-session-storage-memory': patch
+'@shopify/shopify-app-session-storage-mongodb': patch
+'@shopify/shopify-app-session-storage-mysql': patch
+'@shopify/shopify-app-session-storage-postgresql': patch
+'@shopify/shopify-app-session-storage-prisma': patch
+'@shopify/shopify-app-session-storage-redis': patch
+'@shopify/shopify-app-session-storage-sqlite': patch
+'@shopify/shopify-app-session-storage-test-utils': patch
+'@shopify/shopify-api': patch
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-remix': patch
+---
+
+Fix issue with missing sourcemaps

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "target": "ES2022",
     "downlevelIteration": true,
     "sourceMap": true,
+    "inlineSources": true,
     "noEmitOnError": false,
     "importHelpers": true,
     "stripInternal": true,


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #1208 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

Added `inlineSources: true` to the common TS config.

This ensures that the content of the files in the sourcemaps is also part of the sourcemaps. With that option, the sourcemaps work without having to include all the source files in the package itself.

This issue was raised with rollup already, and that is the current "official" solution: https://github.com/rollup/plugins/issues/260 (the issue also links to other repositories that fixed this issue with the TSConfig solution).

Here is an example for the `@shopify/admin-api-client/dist/constants.js` sourcemap:

**Sourcemaps before:**

```json
{"version":3,"file":"constants.js","sources":["../src/constants.ts"],"sourcesContent":[null],"names":[],"mappings":";;AAAO,MAAM,oBAAoB,GAAG;AACpC;AACO,MAAM,sBAAsB,GAAG;AAC/B,MAAM,mBAAmB,GAAG;AAC5B,MAAM,MAAM,GAAG;AACT,MAAA,sBAAsB,GAAG,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG;AAC7C,MAAM,uBAAuB,GAAG;;;;;;;;;"}
```

**Sourcemaps after:**

```
{"version":3,"file":"constants.js","sources":["../src/constants.ts"],"sourcesContent":["export const DEFAULT_CONTENT_TYPE = 'application/json';\n// This is value is replaced with package.json version during rollup build process\nexport const DEFAULT_CLIENT_VERSION = 'ROLLUP_REPLACE_CLIENT_VERSION';\nexport const ACCESS_TOKEN_HEADER = 'X-Shopify-Access-Token';\nexport const CLIENT = 'Admin API Client';\nexport const RETRIABLE_STATUS_CODES = [429, 500, 503];\nexport const DEFAULT_RETRY_WAIT_TIME = 1000;\n"],"names":[],"mappings":";;AAAO,MAAM,oBAAoB,GAAG;AACpC;AACO,MAAM,sBAAsB,GAAG;AAC/B,MAAM,mBAAmB,GAAG;AAC5B,MAAM,MAAM,GAAG;AACT,MAAA,sBAAsB,GAAG,CAAC,GAAG,EAAE,GAAG,EAAE,GAAG;AAC7C,MAAM,uBAAuB,GAAG;;;;;;;;;"}
```

I tested this with `pnpm add file:[path]` in our Hydrogen store with a few packages with the mentioned issue, and this change fixed it.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~I have added/updated tests for this change~
- ~I have documented new APIs/updated the documentation for modified APIs (for public APIs)~

I didn't add tests for this because it's related to the build itself. If any, it would make sense to add some checks for this to the CI/CD after the package is built. Let me know if you think this is necessary and I can try taking a look.

Also, no API was changed, so I didn't need to add documentation for it.