### PR TITLE
Update billing types to use BillingConfigWithLineItems

### DIFF
--- a/packages/apps/shopify-app-react-router/src/server/config-types.ts
+++ b/packages/apps/shopify-app-react-router/src/server/config-types.ts
@@ -6,6 +6,10 @@ import {
   WebhookHandler,
 } from '@shopify/shopify-api';
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
+import type {
+  BillingConfigOneTimePlan,
+  BillingConfigSubscriptionLineItemPlan,
+} from '@shopify/shopify-api';
 
 import type {
   ApiFutureFlags,
@@ -15,6 +19,12 @@ import type {
 import type {AppDistribution} from './types';
 import type {AdminApiContext} from './clients';
 import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promise-handler';
+
+export interface BillingConfigWithLineItems {
+  [plan: string]:
+    | BillingConfigOneTimePlan
+    | BillingConfigSubscriptionLineItemPlan;
+}
 
 export interface AppConfigArg<
   Storage extends SessionStorage = SessionStorage,
@@ -27,6 +37,7 @@ export interface AppConfigArg<
     | 'apiVersion'
     | 'isCustomStoreApp'
     | 'future'
+    | 'billing'
   > {
   /**
    * The URL your app is running on.
@@ -61,6 +72,30 @@ export interface AppConfigArg<
    * ```
    */
   sessionStorage?: Storage;
+
+  /**
+   * Billing configurations for the app.
+   *
+   * Uses the new line item billing format that allows for more complex billing structures.
+   *
+   * @example
+   * ```ts
+   * import { BillingInterval } from "@shopify/shopify-api";
+   *
+   * billing: {
+   *   myPlan: {
+   *     lineItems: [
+   *       {
+   *         amount: 10,
+   *         currencyCode: 'USD',
+   *         interval: BillingInterval.Every30Days,
+   *       }
+   *     ],
+   *   },
+   * }
+   * ```
+   */
+  billing?: BillingConfigWithLineItems;
 
   /**
    * Whether your app use online or offline tokens.
@@ -255,7 +290,7 @@ export interface AppConfigArg<
 }
 
 export interface AppConfig<Storage extends SessionStorage = SessionStorage>
-  extends Omit<ApiConfig, 'future'> {
+  extends Omit<ApiConfig, 'future' | 'billing'> {
   canUseLoginForm: boolean;
   appUrl: string;
   auth: AuthConfig;
@@ -265,6 +300,7 @@ export interface AppConfig<Storage extends SessionStorage = SessionStorage>
   future: FutureFlags;
   idempotentPromiseHandler: IdempotentPromiseHandler;
   distribution: AppDistribution;
+  billing?: BillingConfigWithLineItems;
 }
 
 export interface AuthConfig {

--- a/packages/apps/shopify-app-react-router/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-react-router/src/server/shopify-app.ts
@@ -169,7 +169,7 @@ export function deriveApi(appConfig: AppConfigArg): BasicParams['api'] {
     isEmbeddedApp: appConfig.isEmbeddedApp ?? true,
     apiVersion: appConfig.apiVersion ?? LATEST_API_VERSION,
     isCustomStoreApp: appConfig.distribution === AppDistribution.ShopifyAdmin,
-    billing: appConfig.billing as ApiConfig['billing'],
+    billing: appConfig.billing,
     future: {
       lineItemBilling: true,
       unstable_managedPricingSupport: true,
@@ -197,7 +197,7 @@ function deriveConfig<Storage extends SessionStorage>(
   return {
     ...appConfig,
     ...apiConfig,
-    billing: appConfig.billing as ApiConfig['billing'],
+    billing: appConfig.billing,
     scopes: apiConfig.scopes,
     idempotentPromiseHandler: new IdempotentPromiseHandler(),
     canUseLoginForm: appConfig.distribution !== AppDistribution.ShopifyAdmin,


### PR DESCRIPTION


### WHY are these changes introduced?

* Something about removing the REST resources from the app config, broke typescripts ability to read the billing types.
* Because we force the this package to use the new billing types, add the types to explicitly use line item billing.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
