### PR TITLE
Fix @shopify/shopify-api client exports to include RestClient

### DIFF
--- a/.changeset/pretty-years-dream.md
+++ b/.changeset/pretty-years-dream.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Export RestClient from lib/clients/types

--- a/packages/apps/shopify-api/lib/clients/types.ts
+++ b/packages/apps/shopify-api/lib/clients/types.ts
@@ -34,6 +34,7 @@ export enum DataType {
   GraphQL = 'application/graphql',
   URLEncoded = 'application/x-www-form-urlencoded',
 }
+
 /* eslint-enable @shopify/typescript/prefer-pascal-case-enums */
 
 export interface GetRequestParams {
@@ -116,6 +117,7 @@ export interface GraphqlQueryOptions<
 }
 
 export {GraphqlClient} from './admin/graphql/client';
+export {RestClient} from './admin/rest/client';
 
 export interface ShopifyClients {
   Rest: typeof RestClient;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2665

### WHAT is this pull request doing?

Exports RestClient alongside GraphqlClient.

## Type of change

- [X] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
