### PR TITLE
[Patch] Ensure the abort signal is properly passing through to the request

### DIFF
--- a/.changeset/curly-masks-feel.md
+++ b/.changeset/curly-masks-feel.md
@@ -1,0 +1,8 @@
+---
+'@shopify/shopify-app-react-router': patch
+'@shopify/graphql-client': patch
+'@shopify/shopify-app-remix': patch
+'@shopify/shopify-api': patch
+---
+
+Resolve bug with singal option on requests

--- a/packages/api-clients/graphql-client/src/api-client-utilities/tests/utilities.test.ts
+++ b/packages/api-clients/graphql-client/src/api-client-utilities/tests/utilities.test.ts
@@ -143,5 +143,15 @@ describe('generateGetGQLClientParams()', () => {
       expect(params[0]).toBe(operation);
       expect(params[1]).toEqual({retries});
     });
+
+    it('returns an array with the operation string and an option with signal when an abort signal was provided', () => {
+      const controller = new AbortController();
+      const params = getGQLClientParams(operation, {signal: controller.signal});
+
+      expect(params).toHaveLength(2);
+
+      expect(params[0]).toBe(operation);
+      expect(params[1]).toEqual({signal: controller.signal});
+    });
   });
 });

--- a/packages/api-clients/graphql-client/src/api-client-utilities/types.ts
+++ b/packages/api-clients/graphql-client/src/api-client-utilities/types.ts
@@ -53,6 +53,7 @@ export type ApiClientRequestOptions<
   apiVersion?: string;
   headers?: Headers;
   retries?: number;
+  signal?: AbortSignal;
 } & (Operation extends keyof Operations
   ? OperationVariables<Operation, Operations>
   : {variables?: Record<string, any>});

--- a/packages/api-clients/graphql-client/src/api-client-utilities/utilities.ts
+++ b/packages/api-clients/graphql-client/src/api-client-utilities/utilities.ts
@@ -25,13 +25,20 @@ export function generateGetGQLClientParams<
     const props: RequestParams = [operation as string];
 
     if (options && Object.keys(options).length > 0) {
-      const {variables, apiVersion: propApiVersion, headers, retries} = options;
+      const {
+        variables,
+        apiVersion: propApiVersion,
+        headers,
+        retries,
+        signal,
+      } = options as any;
 
       props.push({
         ...(variables ? {variables} : {}),
         ...(headers ? {headers: getHeaders(headers)} : {}),
         ...(propApiVersion ? {url: getApiUrl(propApiVersion)} : {}),
         ...(retries ? {retries} : {}),
+        ...(signal ? {signal} : {}),
       });
     }
 

--- a/packages/apps/shopify-api/adapters/mock/adapter.ts
+++ b/packages/apps/shopify-api/adapters/mock/adapter.ts
@@ -17,6 +17,14 @@ import {
 
 import {mockTestRequests} from './mock_test_requests';
 
+// Store request init objects for testing purposes
+export const mockRequestCapture = {
+  lastRequestInit: undefined as RequestInit | undefined,
+  reset() {
+    this.lastRequestInit = undefined;
+  },
+};
+
 interface MockAdapterArgs extends AdapterArgs {
   rawRequest: NormalizedRequest;
 }
@@ -43,6 +51,9 @@ export async function mockConvertHeaders(
 
 export const mockFetch: AbstractFetchFunc = async (url, init) => {
   const mockInit = init as RequestInit;
+
+  // Capture the init object for testing
+  mockRequestCapture.lastRequestInit = mockInit;
 
   const request = new Request(url as string, mockInit);
   const headers = Object.fromEntries(

--- a/packages/apps/shopify-api/adapters/mock/mock_test_requests.ts
+++ b/packages/apps/shopify-api/adapters/mock/mock_test_requests.ts
@@ -1,5 +1,7 @@
 import {NormalizedRequest, NormalizedResponse} from '../../runtime/http';
 
+import {mockRequestCapture} from './adapter';
+
 type RequestListEntry = NormalizedRequest;
 type ResponseListEntry = NormalizedResponse | Error;
 
@@ -36,5 +38,7 @@ export const mockTestRequests: MockedAdapter = {
   reset() {
     this.requestList = [];
     this.responseList = [];
+    // Also reset the request capture
+    mockRequestCapture.reset();
   },
 };

--- a/packages/apps/shopify-api/lib/clients/admin/__tests__/admin_graphql_client.test.ts
+++ b/packages/apps/shopify-api/lib/clients/admin/__tests__/admin_graphql_client.test.ts
@@ -13,6 +13,7 @@ import {Session} from '../../../session/session';
 import {JwtPayload} from '../../../session/types';
 import {DataType, shopifyApi} from '../../..';
 import {HttpRequestError} from '../../../error';
+import {mockRequestCapture} from '../../../../adapters/mock/adapter';
 
 const domain = 'test-shop.myshopify.io';
 const QUERY = `
@@ -320,16 +321,23 @@ describe('GraphQL client', () => {
     );
   });
 
-  it('respects the abort signal', async () => {
+  it('passes abort signal through to fetch request', async () => {
     const shopify = shopifyApi(testConfig());
     const client = new shopify.clients.Graphql({session});
     const controller = new AbortController();
 
-    controller.abort();
+    // Reset any previous captures
+    mockRequestCapture.reset();
 
-    await expect(
-      client.request(QUERY, {signal: controller.signal}),
-    ).rejects.toThrow(HttpRequestError);
+    // Mock the response
+    queueMockResponse(JSON.stringify(successResponse));
+
+    // Make the request with abort signal
+    await client.request(QUERY, {signal: controller.signal});
+
+    // Verify the signal was passed through
+    expect(mockRequestCapture.lastRequestInit).toBeDefined();
+    expect(mockRequestCapture.lastRequestInit!.signal).toBe(controller.signal);
   });
 
   it('logs deprecation headers when they are present', async () => {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2643 
* We were not properly passing the signal parameter properly through to the request.
* Our tests for this were falsely passing

### WHAT is this pull request doing?
* Modifies the utilities function in the graphql client to properly pass the signal param
* Mocking the functionality of of the abort signal proves difficult in our current test setup. (The prior tests were falsely passing.) 
* Modifies the test to just check that the param is properly being passed through.


https://github.com/user-attachments/assets/2b2b3509-237d-423a-b14f-6eb1e34233f6


## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
