### PR TITLE
[Feature] Implement `enumsAsConst` config, fixes #2056

### DIFF
--- a/.changeset/hip-cases-nail.md
+++ b/.changeset/hip-cases-nail.md
@@ -1,0 +1,5 @@
+---
+'@shopify/api-codegen-preset': minor
+---
+
+Added support for `enumsAsConst` option to represent GraphQL enums as type-safe strings as opposed to using TypeScript’s enum construct which requires importing.

--- a/packages/api-clients/api-codegen-preset/README.md
+++ b/packages/api-clients/api-codegen-preset/README.md
@@ -148,7 +148,7 @@ This function creates a fully-functional project configuration.
 | documents    | `string[]?` | `./**/*.{ts,tsx}`    | Glob pattern for files to parse.                                                                                                                                   |
 | module       | `string?`   | Depends on `ApiType` | Change the module whose types will be overridden. Use this to override the types for any package, as long as it uses the same names.                               |
 | declarations | `boolean?`  | `true`               | When true, create declaration (`.d.ts`) files with the types. When false, creates `.ts` files that can be imported in app code. May slightly increase build sizes. |
-| enumsAsConst | `boolean?`  | `undefined`          | When true, generates enums as const assertions instead of TypeScript enums. This removes the need for runtime imports.                                             |
+| enumsAsConst | `boolean?`  | `false`              | When true, generates enums as const assertions instead of TypeScript enums. This removes the need for runtime imports.                                             |
 
 #### Example `.graphqlrc.ts` file
 

--- a/packages/api-clients/api-codegen-preset/README.md
+++ b/packages/api-clients/api-codegen-preset/README.md
@@ -102,6 +102,7 @@ Use this function if you want to configure a custom project, or add your own `ge
 | documents    | `string[]?` | `./**/*.{ts,tsx}`    | Glob pattern for files to parse.                                                                                                                                   |
 | module       | `string?`   | Depends on `ApiType` | Change the module whose types will be overridden. Use this to override the types for any package, as long as it uses the same names.                               |
 | declarations | `boolean?`  | `true`               | When true, create declaration (`.d.ts`) files with the types. When false, creates `.ts` files that can be imported in app code. May slightly increase build sizes. |
+| enumsAsConst | `boolean?`  | `false`              | When true, generates enums as const assertions instead of TypeScript enums. This removes the need for runtime imports.                                             |
 
 #### Example `.graphqlrc.ts` file
 
@@ -147,6 +148,7 @@ This function creates a fully-functional project configuration.
 | documents    | `string[]?` | `./**/*.{ts,tsx}`    | Glob pattern for files to parse.                                                                                                                                   |
 | module       | `string?`   | Depends on `ApiType` | Change the module whose types will be overridden. Use this to override the types for any package, as long as it uses the same names.                               |
 | declarations | `boolean?`  | `true`               | When true, create declaration (`.d.ts`) files with the types. When false, creates `.ts` files that can be imported in app code. May slightly increase build sizes. |
+| enumsAsConst | `boolean?`  | `undefined`          | When true, generates enums as const assertions instead of TypeScript enums. This removes the need for runtime imports.                                             |
 
 #### Example `.graphqlrc.ts` file
 
@@ -167,6 +169,37 @@ export default {
     }),
   },
 };
+```
+
+#### Example with `enumsAsConst` option
+
+```js
+import {shopifyApiProject, ApiType} from '@shopify/api-codegen-preset';
+
+export default {
+  schema: 'https://shopify.dev/admin-graphql-direct-proxy/2025-01',
+  documents: ['./app/**/*.{js,ts,jsx,tsx}'],
+  projects: {
+    default: shopifyApiProject({
+      apiType: ApiType.Admin,
+      apiVersion: '2025-01',
+      documents: ['./app/**/*.{js,ts,jsx,tsx}'],
+      outputDir: './app/types',
+      enumsAsConst: true, // Generate enums as const assertions
+    }),
+  },
+};
+```
+
+With `enumsAsConst: true`, you can use enum values directly without imports:
+
+```typescript
+// Without enumsAsConst (default)
+import { MetafieldOwnerType } from './app/types/admin.types';
+const variables = { ownerType: MetafieldOwnerType.Product };
+
+// With enumsAsConst: true
+const variables = { ownerType: 'PRODUCT' }; // No import needed!
 ```
 
 #### Example `.graphqlrc.ts` file with to generate types for UI extensions

--- a/packages/api-clients/api-codegen-preset/src/api-project.ts
+++ b/packages/api-clients/api-codegen-preset/src/api-project.ts
@@ -15,6 +15,7 @@ export const shopifyApiProject = ({
   documents = ['**/*.{ts,tsx}', '!node_modules'],
   declarations = true,
   apiKey,
+  enumsAsConst,
 }: ShopifyApiProjectOptions): IGraphQLProject => {
   const {schema, schemaFile} = getSchemaData(outputDir, apiType, {
     apiVersion,
@@ -37,6 +38,7 @@ export const shopifyApiProject = ({
           documents,
           module,
           declarations,
+          enumsAsConst,
         }),
       },
     },

--- a/packages/api-clients/api-codegen-preset/src/api-types.ts
+++ b/packages/api-clients/api-codegen-preset/src/api-types.ts
@@ -15,6 +15,7 @@ export const shopifyApiTypes = ({
   documents = ['**/*.{ts,tsx}', '!**/node_modules'],
   declarations = true,
   apiKey,
+  enumsAsConst,
 }: ShopifyApiTypesOptions): CodegenConfig['generates'] => {
   const {schema, schemaFile} = getSchemaData(outputDir, apiType, {
     apiVersion,
@@ -37,6 +38,11 @@ export const shopifyApiTypes = ({
     [`${outputDir}/${typesFile}`]: {
       schema: schemaFileExists ? schemaFile : schema,
       plugins: ['typescript'],
+      ...(enumsAsConst !== undefined && {
+        config: {
+          enumsAsConst,
+        },
+      }),
     },
     [`${outputDir}/${queryTypesFile}`]: {
       schema: schemaFileExists ? schemaFile : schema,

--- a/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
@@ -133,7 +133,9 @@ describe('shopifyApiProject', () => {
         const projectConfig = shopifyApiProject(config);
 
         // THEN
-        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual(
+        expect(
+          projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
+        ).toEqual(
           expect.objectContaining({
             schema: expect.anything(),
             plugins: ['typescript'],
@@ -156,7 +158,9 @@ describe('shopifyApiProject', () => {
         const projectConfig = shopifyApiProject(config);
 
         // THEN
-        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual(
+        expect(
+          projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
+        ).toEqual(
           expect.objectContaining({
             schema: expect.anything(),
             plugins: ['typescript'],
@@ -178,11 +182,15 @@ describe('shopifyApiProject', () => {
         const projectConfig = shopifyApiProject(config);
 
         // THEN
-        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual({
+        expect(
+          projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
+        ).toEqual({
           schema: expect.anything(),
           plugins: ['typescript'],
         });
-        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).not.toHaveProperty('config');
+        expect(
+          projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
+        ).not.toHaveProperty('config');
       });
     },
   );

--- a/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
@@ -120,6 +120,70 @@ describe('shopifyApiProject', () => {
           },
         });
       });
+
+      it('passes enumsAsConst option to shopifyApiTypes when true', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          enumsAsConst: true,
+          apiKey: 'test',
+        };
+
+        // WHEN
+        const projectConfig = shopifyApiProject(config);
+
+        // THEN
+        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual(
+          expect.objectContaining({
+            schema: expect.anything(),
+            plugins: ['typescript'],
+            config: {
+              enumsAsConst: true,
+            },
+          }),
+        );
+      });
+
+      it('passes enumsAsConst option to shopifyApiTypes when false', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          enumsAsConst: false,
+          apiKey: 'test',
+        };
+
+        // WHEN
+        const projectConfig = shopifyApiProject(config);
+
+        // THEN
+        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual(
+          expect.objectContaining({
+            schema: expect.anything(),
+            plugins: ['typescript'],
+            config: {
+              enumsAsConst: false,
+            },
+          }),
+        );
+      });
+
+      it('does not include config when enumsAsConst is not provided', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          apiKey: 'test',
+        };
+
+        // WHEN
+        const projectConfig = shopifyApiProject(config);
+
+        // THEN
+        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).toEqual({
+          schema: expect.anything(),
+          plugins: ['typescript'],
+        });
+        expect(projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`]).not.toHaveProperty('config');
+      });
     },
   );
 });

--- a/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
@@ -140,6 +140,80 @@ describe('shopifyApiTypes', () => {
           },
         });
       });
+
+      it('includes enumsAsConst config when option is true', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          enumsAsConst: true,
+          apiKey: 'test',
+        };
+
+        const spy = jest.spyOn(fs, 'existsSync');
+        spy.mockReturnValueOnce(true);
+
+        // WHEN
+        const projectConfig = shopifyApiTypes(config);
+
+        // THEN
+        expect(projectConfig[`./${type}.types.d.ts`]).toEqual(
+          expect.objectContaining({
+            schema: `./${type}.schema.json`,
+            plugins: ['typescript'],
+            config: {
+              enumsAsConst: true,
+            },
+          }),
+        );
+      });
+
+      it('includes enumsAsConst config when option is false', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          enumsAsConst: false,
+          apiKey: 'test',
+        };
+
+        const spy = jest.spyOn(fs, 'existsSync');
+        spy.mockReturnValueOnce(true);
+
+        // WHEN
+        const projectConfig = shopifyApiTypes(config);
+
+        // THEN
+        expect(projectConfig[`./${type}.types.d.ts`]).toEqual(
+          expect.objectContaining({
+            schema: `./${type}.schema.json`,
+            plugins: ['typescript'],
+            config: {
+              enumsAsConst: false,
+            },
+          }),
+        );
+      });
+
+      it('excludes config when enumsAsConst is not provided', () => {
+        // GIVEN
+        const config: ShopifyApiProjectOptions = {
+          apiType,
+          apiKey: 'test',
+        };
+
+        const spy = jest.spyOn(fs, 'existsSync');
+        spy.mockReturnValueOnce(true);
+
+        // WHEN
+        const projectConfig = shopifyApiTypes(config);
+
+        // THEN
+        expect(projectConfig[`./${type}.types.d.ts`]).toEqual({
+          schema: `./${type}.schema.json`,
+          plugins: ['typescript'],
+          // No config property expected
+        });
+        expect(projectConfig[`./${type}.types.d.ts`]).not.toHaveProperty('config');
+      });
     },
   );
 });

--- a/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
@@ -212,7 +212,9 @@ describe('shopifyApiTypes', () => {
           plugins: ['typescript'],
           // No config property expected
         });
-        expect(projectConfig[`./${type}.types.d.ts`]).not.toHaveProperty('config');
+        expect(projectConfig[`./${type}.types.d.ts`]).not.toHaveProperty(
+          'config',
+        );
       });
     },
   );

--- a/packages/api-clients/api-codegen-preset/src/types.ts
+++ b/packages/api-clients/api-codegen-preset/src/types.ts
@@ -17,6 +17,7 @@ export interface ShopifyApiProjectOptions {
   module?: string;
   declarations?: boolean;
   apiKey?: string;
+  enumsAsConst?: boolean;
 }
 
 export type ShopifyApiTypesOptions = ShopifyApiProjectOptions;


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2056

The GraphQL Code Generator's TypeScript plugin supports [an `enumsAsConst` option](https://the-guild.dev/graphql/codegen/plugins/typescript/typescript) that represents GraphQL enums as strings instead of TypeScript enums. Enums vs strings is a controversial subject, but having to import every type is certainly annoying when dealing with enums.

```typescript
// No import needed - use string literals directly
const variables = { ownerType: 'PRODUCT' };

// Instead of:
import { MetafieldOwnerType } from './types/admin.types';
const variables = { ownerType: MetafieldOwnerType.Product };
```

### WHAT is this pull request doing?

This PR adds support for the `enumsAsConst` option to both `shopifyApiTypes` and `shopifyApiProject` functions in the api-codegen-preset package.

**Changes:**
- Added `enumsAsConst?: boolean` to `ShopifyApiProjectOptions` interface
- Updated `shopifyApiTypes` to conditionally include the config when `enumsAsConst` is defined
- Updated `shopifyApiProject` to pass through the `enumsAsConst` option
- Added comprehensive test coverage for all scenarios
- Updated documentation with examples

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

## Additional Notes

- This change is fully backward compatible - when `enumsAsConst` is not specified, the current behavior is maintained
- The option defaults to `undefined`, maintaining the GraphQL Code Generator's default behavior (which is `false`)
- All existing tests continue to pass, with 6 new test cases added for the new functionality
