### PR TITLE
[Patch][shopify-api] Fix node adapter not being correctly imported

### DIFF
--- a/.changeset/fix-adapter-tree-shaking.md
+++ b/.changeset/fix-adapter-tree-shaking.md
@@ -1,0 +1,29 @@
+---
+"@shopify/shopify-api": patch
+---
+
+Fix adapter initialization issues with modern bundlers (Vite, Webpack) in SSR frameworks
+
+Adds `sideEffects` configuration to package.json to prevent bundlers from incorrectly tree-shaking adapter initialization code. This resolves the "Missing adapter implementation for 'abstractRuntimeString'" error that occurred when using the library with Nuxt 3, TanStack Start, and other frameworks.
+
+The adapters use side effects to initialize runtime functions, and modern bundlers were optimizing these away, causing runtime errors. The fix ensures these critical initialization side effects are preserved during the bundling process.
+
+Some bundlers may still tree-shake pure side-effect imports. If you encounter issues after this update, you can use the newly
+   exported `nodeAdapterInitialized` constant to ensure the adapter is loaded:
+
+  ```javascript
+  // Instead of just:
+  import '@shopify/shopify-api/adapters/node';
+
+  // You can now also import and check:
+  import { nodeAdapterInitialized } from '@shopify/shopify-api/adapters/node';
+  import { shopifyApi } from '@shopify/shopify-api';
+
+  // Optional: Ensure adapter is initialized (forces bundlers to keep the import)
+  if (!nodeAdapterInitialized) {
+    throw new Error('Node adapter not initialized');
+  }
+
+  const shopify = shopifyApi({
+    // your config
+  });

--- a/packages/apps/shopify-api/README.md
+++ b/packages/apps/shopify-api/README.md
@@ -64,6 +64,16 @@ import '@shopify/shopify-api/adapters/web-api';
 
 </div>
 
+> **Note** Some bundlers may aggressively tree-shake the adapter imports in production builds. If you encounter a "Missing adapter implementation" error, you can use the exported constant to ensure the adapter is loaded:
+>
+> ```ts
+> import { nodeAdapterInitialized } from '@shopify/shopify-api/adapters/node';
+> // Optional: Check the adapter loaded successfully
+> if (!nodeAdapterInitialized) {
+>   throw new Error('Failed to initialize Node.js adapter');
+> }
+> ```
+
 Next, configure the library - you'll need some values in advance:
 
 - Your app's API key from [Partners dashboard](https://www.shopify.com/partners) (also called `Client ID`)

--- a/packages/apps/shopify-api/adapters/node/index.ts
+++ b/packages/apps/shopify-api/adapters/node/index.ts
@@ -29,3 +29,6 @@ setAbstractConvertResponseFunc(nodeConvertAndSendResponse);
 setAbstractConvertHeadersFunc(nodeConvertAndSetHeaders);
 setAbstractRuntimeString(nodeRuntimeString);
 setCrypto(crypto as any);
+
+// Export a marker to prevent tree-shaking
+export const nodeAdapterInitialized = true;

--- a/packages/apps/shopify-api/package.json
+++ b/packages/apps/shopify-api/package.json
@@ -53,6 +53,10 @@
     "clean": "rimraf .rollup.cache dist bundle",
     "release": "pnpm build && changeset publish"
   },
+  "sideEffects": [
+    "./dist/esm/adapters/*/index.mjs",
+    "./dist/cjs/adapters/*/index.js"
+  ],
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2289

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?
* Adds `sideEffects` configuration to package.json to prevent bundlers from incorrectly tree-shaking adapter initialization code.
* Some bundlers may still tree-shake pure side-effect imports. If you encounter issues after this update, you can use the newly
   exported `nodeAdapterInitialized` constant to ensure the adapter is loaded:

  ```javascript
  // Instead of just:
  import '@shopify/shopify-api/adapters/node';

  // You can now also import and check:
  import { nodeAdapterInitialized } from '@shopify/shopify-api/adapters/node';
  import { shopifyApi } from '@shopify/shopify-api';

  // Optional: Ensure adapter is initialized (forces bundlers to keep the import)
  if (!nodeAdapterInitialized) {
    throw new Error('Node adapter not initialized');
  }

  const shopify = shopifyApi({
    // your config
  });

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
