### PR TITLE
Remove cookie-parse as a dependency from shopify-app-express

### DIFF
--- a/.changeset/tangy-weeks-shake.md
+++ b/.changeset/tangy-weeks-shake.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Remove cookie-parser as a dependency since it's no longer used

--- a/packages/apps/shopify-app-express/package.json
+++ b/packages/apps/shopify-app-express/package.json
@@ -46,13 +46,11 @@
     "@shopify/shopify-api": "^11.14.1",
     "@shopify/shopify-app-session-storage": "^3.0.20",
     "@shopify/shopify-app-session-storage-memory": "^4.0.20",
-    "cookie-parser": "^1.4.7",
     "express": "^4.21.2",
     "semver": "^7.7.1"
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
-    "@types/cookie-parser": "^1.4.9",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/semver": "^7.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -495,9 +495,6 @@ importers:
       '@shopify/shopify-app-session-storage-memory':
         specifier: ^4.0.20
         version: link:../session-storage/shopify-app-session-storage-memory
-      cookie-parser:
-        specifier: ^1.4.7
-        version: 1.4.7
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -508,9 +505,6 @@ importers:
       '@types/compression':
         specifier: ^1.8.1
         version: 1.8.1
-      '@types/cookie-parser':
-        specifier: ^1.4.9
-        version: 1.4.9(@types/express@4.17.21)
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
@@ -3889,11 +3883,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie-parser@1.4.9':
-    resolution: {integrity: sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==}
-    peerDependencies:
-      '@types/express': '*'
-
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -4688,10 +4677,6 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
-
-  cookie-parser@1.4.7:
-    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
-    engines: {node: '>= 0.8.0'}
 
   cookie-signature@1.0.6:
     resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
@@ -12843,10 +12828,6 @@ snapshots:
     dependencies:
       '@types/node': 24.0.15
 
-  '@types/cookie-parser@1.4.9(@types/express@4.17.21)':
-    dependencies:
-      '@types/express': 4.17.21
-
   '@types/cookie@0.6.0': {}
 
   '@types/cookiejar@2.1.5': {}
@@ -13816,11 +13797,6 @@ snapshots:
   content-type@1.0.5: {}
 
   convert-source-map@2.0.0: {}
-
-  cookie-parser@1.4.7:
-    dependencies:
-      cookie: 0.7.2
-      cookie-signature: 1.0.6
 
   cookie-signature@1.0.6: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce dependencies

### WHAT is this pull request doing?

Remove cookie-parser from the express package

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~~[ ] I have added/updated tests for this change~~ - N/A
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~ - N/A
