### PR TITLE
Unify on compare versions

### DIFF
--- a/.changeset/funny-sloths-glow.md
+++ b/.changeset/funny-sloths-glow.md
@@ -1,0 +1,8 @@
+---
+'@shopify/shopify-app-session-storage-kv': patch
+'@shopify/shopify-app-react-router': patch
+'@shopify/shopify-app-express': patch
+'@shopify/shopify-app-remix': patch
+---
+
+Swap semver package for compare-versions package. Compare versions is a lighter weight and suits the packages needs just fine

--- a/packages/apps/session-storage/shopify-app-session-storage-kv/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-kv/package.json
@@ -45,7 +45,7 @@
     "CloudFlare"
   ],
   "dependencies": {
-    "semver": "^7.7.1"
+    "compare-versions": "^6.1.1"
   },
   "peerDependencies": {
     "@shopify/shopify-api": "^11.0.0",

--- a/packages/apps/shopify-app-express/package.json
+++ b/packages/apps/shopify-app-express/package.json
@@ -47,13 +47,13 @@
     "@shopify/shopify-app-session-storage": "^3.0.20",
     "@shopify/shopify-app-session-storage-memory": "^4.0.20",
     "express": "^4.21.2",
-    "semver": "^7.7.1"
+    "compare-versions": "^6.1.1"
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
     "@types/express": "^4.17.21",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/semver": "^7.7.0",
+    
     "jsonwebtoken": "^9.0.2"
   },
   "files": [

--- a/packages/apps/shopify-app-express/src/__tests__/test-helper.ts
+++ b/packages/apps/shopify-app-express/src/__tests__/test-helper.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 
-import semver from 'semver';
+import {compare} from 'compare-versions';
 import fetchMock, {MockParams} from 'jest-fetch-mock';
 import {LATEST_API_VERSION, ShopifyRestResources} from '@shopify/shopify-api';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
@@ -167,7 +167,7 @@ expect.extend({
     return {
       message: () =>
         `Found deprecation limited to version ${version}, please update or remove it.`,
-      pass: semver.lt(SHOPIFY_EXPRESS_LIBRARY_VERSION, version),
+      pass: compare(SHOPIFY_EXPRESS_LIBRARY_VERSION, version, '<'),
     };
   },
 });

--- a/packages/apps/shopify-app-express/src/index.ts
+++ b/packages/apps/shopify-app-express/src/index.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import {compare} from 'compare-versions';
 import '@shopify/shopify-api/adapters/node';
 import {
   shopifyApi,
@@ -167,7 +167,7 @@ function overrideLoggerPackage(logger: Shopify['logger']): Shopify['logger'] {
 
 function deprecated(warningFunction: Shopify['logger']['warning']) {
   return function (version: string, message: string): Promise<void> {
-    if (semver.gte(SHOPIFY_EXPRESS_LIBRARY_VERSION, version)) {
+    if (compare(SHOPIFY_EXPRESS_LIBRARY_VERSION, version, '>=')) {
       throw new FeatureDeprecatedError(
         `Feature was deprecated in version ${version}`,
       );

--- a/packages/apps/shopify-app-react-router/package.json
+++ b/packages/apps/shopify-app-react-router/package.json
@@ -86,7 +86,6 @@
     "@testing-library/react": "^16.3.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.1.2",
-    "@types/semver": "^7.7.0",
     "@types/testing-library__jest-dom": "^6.0.0",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.2"
@@ -97,7 +96,7 @@
     "@shopify/shopify-app-session-storage": "^3.0.20",
     "@shopify/storefront-api-client": "^1.0.9",
     "isbot": "^5.1.26",
-    "semver": "^7.7.1"
+    "compare-versions": "^6.1.1"
   },
   "peerDependencies": {
     "react-router": "^7.6.2",

--- a/packages/apps/shopify-app-react-router/src/server/override-logger.ts
+++ b/packages/apps/shopify-app-react-router/src/server/override-logger.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import {compare} from 'compare-versions';
 import {FeatureDeprecatedError, Shopify} from '@shopify/shopify-api';
 
 import {SHOPIFY_REACT_ROUTER_LIBRARY_VERSION} from './version';
@@ -16,7 +16,7 @@ export function overrideLogger(logger: Shopify['logger']): Shopify['logger'] {
 
   function deprecated(warningFunction: Shopify['logger']['warning']) {
     return function (version: string, message: string): Promise<void> {
-      if (semver.gte(SHOPIFY_REACT_ROUTER_LIBRARY_VERSION, version)) {
+      if (compare(SHOPIFY_REACT_ROUTER_LIBRARY_VERSION, version, '>=')) {
         throw new FeatureDeprecatedError(
           `Feature was deprecated in version ${version}`,
         );

--- a/packages/apps/shopify-app-remix/package.json
+++ b/packages/apps/shopify-app-remix/package.json
@@ -89,7 +89,6 @@
     "@testing-library/react": "^16.3.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.1.8",
-    "@types/semver": "^7.7.0",
     "@types/testing-library__jest-dom": "^6.0.0",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.2"
@@ -101,7 +100,7 @@
     "@shopify/shopify-app-session-storage": "^3.0.20",
     "@shopify/storefront-api-client": "^1.0.9",
     "isbot": "^5.1.26",
-    "semver": "^7.7.1"
+    "compare-versions": "^6.1.1"
   },
   "peerDependencies": {
     "@remix-run/node": "*",

--- a/packages/apps/shopify-app-remix/src/server/override-logger.ts
+++ b/packages/apps/shopify-app-remix/src/server/override-logger.ts
@@ -1,4 +1,4 @@
-import semver from 'semver';
+import {compare} from 'compare-versions';
 import {FeatureDeprecatedError, Shopify} from '@shopify/shopify-api';
 
 import {SHOPIFY_REMIX_LIBRARY_VERSION} from './version';
@@ -16,7 +16,7 @@ export function overrideLogger(logger: Shopify['logger']): Shopify['logger'] {
 
   function deprecated(warningFunction: Shopify['logger']['warning']) {
     return function (version: string, message: string): Promise<void> {
-      if (semver.gte(SHOPIFY_REMIX_LIBRARY_VERSION, version)) {
+      if (compare(SHOPIFY_REMIX_LIBRARY_VERSION, version, '>=')) {
         throw new FeatureDeprecatedError(
           `Feature was deprecated in version ${version}`,
         );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -267,9 +267,9 @@ importers:
       '@shopify/shopify-app-session-storage':
         specifier: ^3.0.0
         version: link:../shopify-app-session-storage
-      semver:
-        specifier: ^7.7.1
-        version: 7.7.1
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250711.0
@@ -495,12 +495,12 @@ importers:
       '@shopify/shopify-app-session-storage-memory':
         specifier: ^4.0.20
         version: link:../session-storage/shopify-app-session-storage-memory
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       express:
         specifier: ^4.21.2
         version: 4.21.2
-      semver:
-        specifier: ^7.7.1
-        version: 7.7.1
     devDependencies:
       '@types/compression':
         specifier: ^1.8.1
@@ -511,9 +511,6 @@ importers:
       '@types/jsonwebtoken':
         specifier: ^9.0.10
         version: 9.0.10
-      '@types/semver':
-        specifier: ^7.7.0
-        version: 7.7.0
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
@@ -532,6 +529,9 @@ importers:
       '@shopify/storefront-api-client':
         specifier: ^1.0.9
         version: link:../../api-clients/storefront-api-client
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       isbot:
         specifier: ^5.1.26
         version: 5.1.26
@@ -541,9 +541,6 @@ importers:
       react-dom:
         specifier: '>=18'
         version: 18.3.1(react@18.3.1)
-      semver:
-        specifier: ^7.7.1
-        version: 7.7.1
     devDependencies:
       '@shopify/generate-docs':
         specifier: ^0.17.1
@@ -566,9 +563,6 @@ importers:
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.8
-      '@types/semver':
-        specifier: ^7.7.0
-        version: 7.7.0
       '@types/testing-library__jest-dom':
         specifier: ^6.0.0
         version: 6.0.0
@@ -599,15 +593,15 @@ importers:
       '@shopify/storefront-api-client':
         specifier: ^1.0.9
         version: link:../../api-clients/storefront-api-client
+      compare-versions:
+        specifier: ^6.1.1
+        version: 6.1.1
       isbot:
         specifier: ^5.1.26
         version: 5.1.26
       react:
         specifier: '*'
         version: 18.3.1
-      semver:
-        specifier: ^7.7.1
-        version: 7.7.1
     devDependencies:
       '@remix-run/node':
         specifier: ^2.16.8
@@ -642,9 +636,6 @@ importers:
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
-      '@types/semver':
-        specifier: ^7.7.0
-        version: 7.7.0
       '@types/testing-library__jest-dom':
         specifier: ^6.0.0
         version: 6.0.0
@@ -3994,9 +3985,6 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
-
-  '@types/semver@7.7.0':
-    resolution: {integrity: sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==}
 
   '@types/send@0.17.4':
     resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
@@ -10635,7 +10623,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.0
       js-yaml: 4.1.0
-      minimatch: 3.1.2
+      minimatch: 9.0.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -11306,7 +11294,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.0
-      minimatch: 3.1.2
+      minimatch: 9.0.5
     transitivePeerDependencies:
       - supports-color
 
@@ -12953,8 +12941,6 @@ snapshots:
       csstype: 3.1.3
 
   '@types/resolve@1.20.2': {}
-
-  '@types/semver@7.7.0': {}
 
   '@types/send@0.17.4':
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce the number of dependencies we manage

### WHAT is this pull request doing?

Swaps `semver` package for `compare-versions`.  Previously we used both packges, now we only use `compare-versions`.    Settled on compare-versions because:

1. it's lighter weight which can be useful for some runtimes
2. It has the functionality we need
3. Should be runtime agnostic.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~~[ ] I have added/updated tests for this change~~ - N/A tests already covered this
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~ - N/A no external changes
