### PR TITLE
Remove UUID jsonwebtoken require node 20

### DIFF
--- a/.changeset/calm-queens-pay.md
+++ b/.changeset/calm-queens-pay.md
@@ -1,0 +1,8 @@
+---
+'@shopify/shopify-app-react-router': major
+'@shopify/shopify-app-express': major
+'@shopify/shopify-app-remix': major
+'@shopify/shopify-api': major
+---
+
+Require Node 20. Swap jsonwebtoken for json, uuid dependency for globalThis.crypto.randomUUID()

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Check for Changeset
         run: npx @changesets/cli status --since="origin/main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # When removing v18, unpin graphql-config version
-        version: [18, 20, 22]
+        version: [20, 22, 24]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           cache: 'pnpm'
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/publish-experimental-build.yml
+++ b/.github/workflows/publish-experimental-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3.9.1
         with:
           cache: 'pnpm'
-          node-version: 18.x
+          node-version: 20.x
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/packages/apps/shopify-api/lib/auth/oauth/__tests__/create-session.test.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/__tests__/create-session.test.ts
@@ -7,8 +7,7 @@ const STATIC_UUID = 'test-uuid';
 
 jest.useFakeTimers().setSystemTime(new Date('2023-11-11'));
 
-jest.mock('uuid', () => ({v4: jest.fn(() => STATIC_UUID)}));
-jest.requireMock('uuid');
+jest.mock('crypto', () => ({randomUUID: jest.fn(() => STATIC_UUID)}));
 
 beforeEach(() => {
   shop = 'someshop.myshopify.io';

--- a/packages/apps/shopify-api/lib/auth/oauth/create-session.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/create-session.ts
@@ -1,4 +1,4 @@
-import {v4 as uuidv4} from 'uuid';
+import crypto from 'crypto';
 
 import {Session} from '../../session/session';
 import {ConfigInterface} from '../../base-types';
@@ -39,7 +39,7 @@ export function createSession({
           shop,
           `${(rest as OnlineAccessInfo).associated_user.id}`,
         )
-      : uuidv4();
+      : crypto.randomUUID();
 
     return {
       id: sessionId,

--- a/packages/apps/shopify-api/lib/auth/oauth/nonce.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/nonce.ts
@@ -1,4 +1,4 @@
-import {crypto} from '../../../runtime/crypto';
+import crypto from 'crypto';
 
 export type Nonce = () => string;
 

--- a/packages/apps/shopify-api/package.json
+++ b/packages/apps/shopify-api/package.json
@@ -89,7 +89,6 @@
     "isbot": "^5.1.26",
     "jose": "^5.9.6",
     "node-fetch": "^2.6.1",
-    "uuid": "^11.1.0",
     "tslib": "^2.8.1"
   },
   "devDependencies": {
@@ -97,7 +96,6 @@
     "@swc/core": "^1.12.11",
     "@types/express": "^4.17.13",
     "@types/node-fetch": "^2.6.11",
-    "@types/uuid": "^10.0.0",
     "expect": "^30.0.4",
     "express": "^4.21.2",
     "jest-environment-miniflare": "^2.14.4",

--- a/packages/apps/shopify-api/package.json
+++ b/packages/apps/shopify-api/package.json
@@ -78,6 +78,9 @@
     "Admin API",
     "Storefront API"
   ],
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "dependencies": {
     "@shopify/admin-api-client": "^1.1.1",
     "@shopify/graphql-client": "^1.4.1",
@@ -85,16 +88,14 @@
     "compare-versions": "^6.1.1",
     "isbot": "^5.1.26",
     "jose": "^5.9.6",
-    "jsonwebtoken": "^9.0.2",
     "node-fetch": "^2.6.1",
-    "tslib": "^2.8.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.0",
+    "tslib": "^2.8.1"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250711.0",
     "@swc/core": "^1.12.11",
     "@types/express": "^4.17.13",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/node-fetch": "^2.6.11",
     "@types/uuid": "^10.0.0",
     "expect": "^30.0.4",

--- a/packages/apps/shopify-api/runtime/crypto/crypto.ts
+++ b/packages/apps/shopify-api/runtime/crypto/crypto.ts
@@ -1,5 +1,4 @@
 // The mutable export is the whole key to the adapter architecture.
-
 // eslint-disable-next-line import/no-mutable-exports
 let cryptoVar: Crypto;
 

--- a/packages/apps/shopify-api/runtime/crypto/utils.ts
+++ b/packages/apps/shopify-api/runtime/crypto/utils.ts
@@ -1,6 +1,7 @@
+import crypto from 'crypto';
+
 import {ShopifyError} from '../../lib/error';
 
-import {crypto} from './crypto';
 import {HashFormat} from './types';
 
 export async function createSHA256HMAC(

--- a/packages/apps/shopify-api/runtime/http/__tests__/http.test.ts
+++ b/packages/apps/shopify-api/runtime/http/__tests__/http.test.ts
@@ -1,4 +1,5 @@
-import {crypto} from '../../crypto';
+import crypto from 'crypto';
+
 import {
   addHeader,
   canonicalizeHeaderName,

--- a/packages/apps/shopify-api/test-helpers/get-jwt.ts
+++ b/packages/apps/shopify-api/test-helpers/get-jwt.ts
@@ -1,4 +1,4 @@
-import jwt from 'jsonwebtoken';
+import * as jose from 'jose';
 
 import {JwtPayload} from '../lib';
 
@@ -19,12 +19,12 @@ interface TestJwt {
  * @param overrides Optional overrides for the JWT payload.
  * @returns {TestJwt} The JWT token and the JWT payload used to create the token.
  */
-export function getJwt(
+export async function getJwt(
   store: string,
   apiKey: string,
   apiSecretKey: string,
   overrides: Partial<JwtPayload> = {},
-): TestJwt {
+): Promise<TestJwt> {
   const date = new Date();
   const shop: string = getShopValue(store);
   const payload = {
@@ -40,9 +40,9 @@ export function getJwt(
     ...overrides,
   };
 
-  const token = jwt.sign(payload, apiSecretKey, {
-    algorithm: 'HS256',
-  });
+  const token = await new jose.SignJWT(payload as any)
+    .setProtectedHeader({alg: 'HS256'})
+    .sign(new TextEncoder().encode(apiSecretKey));
 
   return {token, payload};
 }

--- a/packages/apps/shopify-api/test-helpers/setup-valid-request.ts
+++ b/packages/apps/shopify-api/test-helpers/setup-valid-request.ts
@@ -52,7 +52,7 @@ export async function setUpValidRequest(
   let authenticatedRequest: Request;
   switch (options.type) {
     case RequestType.Admin:
-      authenticatedRequest = adminRequest(
+      authenticatedRequest = await adminRequest(
         request,
         options.store,
         options.apiKey,
@@ -60,7 +60,7 @@ export async function setUpValidRequest(
       );
       break;
     case RequestType.Bearer:
-      authenticatedRequest = bearerRequest(
+      authenticatedRequest = await bearerRequest(
         request,
         options.store,
         options.apiKey,
@@ -88,13 +88,13 @@ export async function setUpValidRequest(
   return authenticatedRequest;
 }
 
-function adminRequest(
+async function adminRequest(
   request: Request,
   store: string,
   apiKey: string,
   apiSecretKey: string,
 ) {
-  const {token} = getJwt(store, apiKey, apiSecretKey);
+  const {token} = await getJwt(store, apiKey, apiSecretKey);
 
   const url = new URL(request.url);
   url.searchParams.set('embedded', '1');
@@ -104,13 +104,13 @@ function adminRequest(
   return new Request(url.href, request);
 }
 
-function bearerRequest(
+async function bearerRequest(
   request: Request,
   store: string,
   apiKey: string,
   apiSecretKey: string,
 ) {
-  const {token} = getJwt(store, apiKey, apiSecretKey);
+  const {token} = await getJwt(store, apiKey, apiSecretKey);
 
   const authenticatedRequest = new Request(request);
   authenticatedRequest.headers.set('authorization', `Bearer ${token}`);

--- a/packages/apps/shopify-app-express/package.json
+++ b/packages/apps/shopify-app-express/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/Shopify/shopify-app-js/issues"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "homepage": "https://github.com/Shopify/shopify-app-js/tree/main/packages/apps/shopify-app-express",
   "author": "Shopify Inc.",
   "license": "MIT",
@@ -51,10 +54,7 @@
   },
   "devDependencies": {
     "@types/compression": "^1.8.1",
-    "@types/express": "^4.17.21",
-    "@types/jsonwebtoken": "^9.0.10",
-    
-    "jsonwebtoken": "^9.0.2"
+    "@types/express": "^4.17.21"
   },
   "files": [
     "dist/*",

--- a/packages/apps/shopify-app-express/src/__tests__/integration/oauth.test.ts
+++ b/packages/apps/shopify-app-express/src/__tests__/integration/oauth.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import express, {Express} from 'express';
-import jwt from 'jsonwebtoken';
+import * as jose from 'jose';
 import {LATEST_API_VERSION, LogSeverity} from '@shopify/shopify-api';
 
 import {ShopifyApp, shopifyApp} from '../..';
@@ -406,17 +406,13 @@ async function validSession(
   config: OAuthTestCase,
   mock: jest.Mock,
 ) {
-  const validJWT = jwt.sign(
-    {
-      sub: 1234,
-      aud: shopify.api.config.apiKey,
-      dest: `https://${TEST_SHOP}`,
-    },
-    shopify.api.config.apiSecretKey,
-    {
-      algorithm: 'HS256',
-    },
-  );
+  const validJWT = await new jose.SignJWT({
+    sub: '1234',
+    aud: shopify.api.config.apiKey,
+    dest: `https://${TEST_SHOP}`,
+  })
+    .setProtectedHeader({alg: 'HS256'})
+    .sign(new TextEncoder().encode(shopify.api.config.apiSecretKey));
 
   const headers: Record<string, string> = {};
   if (config.embedded) {

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import express, {Express} from 'express';
 import {LATEST_API_VERSION, Session} from '@shopify/shopify-api';
-import jwt from 'jsonwebtoken';
+import * as jose from 'jose';
 
 import {
   createTestHmac,
@@ -19,7 +19,7 @@ describe('validateAuthenticatedSession', () => {
   describe('for embedded apps', () => {
     let validJWT: any;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       shopify.config.auth.path = '/api/auth';
       shopify.config.auth.callbackPath = '/api/auth/callback';
       shopify.api.config.isEmbeddedApp = true;
@@ -30,17 +30,13 @@ describe('validateAuthenticatedSession', () => {
         res.json({data: {shop: {name: req.query.shop}}});
       });
 
-      validJWT = jwt.sign(
-        {
-          dummy: 'data',
-          aud: shopify.api.config.apiKey,
-          dest: `https://${shop}`,
-        },
-        shopify.api.config.apiSecretKey,
-        {
-          algorithm: 'HS256',
-        },
-      );
+      validJWT = await new jose.SignJWT({
+        dummy: 'data',
+        aud: shopify.api.config.apiKey,
+        dest: `https://${shop}`,
+      })
+        .setProtectedHeader({alg: 'HS256'})
+        .sign(new TextEncoder().encode(shopify.api.config.apiSecretKey));
       const scopes = shopify.api.config.scopes
         ? shopify.api.config.scopes.toString()
         : '';
@@ -197,15 +193,13 @@ describe('validateAuthenticatedSession', () => {
     });
 
     it('returns a 401 if the session token is invalid', async () => {
-      const invalidJWT = jwt.sign(
-        {
-          dummy: 'data',
-          aud: shopify.api.config.apiKey,
-          dest: `https://${shop}`,
-        },
-        'different-secret-key',
-        {algorithm: 'HS256'},
-      );
+      const invalidJWT = await new jose.SignJWT({
+        dummy: 'data',
+        aud: shopify.api.config.apiKey,
+        dest: `https://${shop}`,
+      })
+        .setProtectedHeader({alg: 'HS256'})
+        .sign(new TextEncoder().encode('different-secret-key'));
 
       const response = await request(app)
         .get('/test/shop?shop=my-shop.myshopify.io')

--- a/packages/apps/shopify-app-react-router/package.json
+++ b/packages/apps/shopify-app-react-router/package.json
@@ -10,6 +10,9 @@
   "bugs": {
     "url": "https://github.com/Shopify/shopify-app-js/issues"
   },
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "homepage": "https://github.com/Shopify/shopify-app-js/tree/main/packages/apps/shopify-app-react-router",
   "author": "Shopify Inc.",
   "license": "MIT",
@@ -84,11 +87,10 @@
     "@shopify/shopify-app-session-storage-memory": "^4.0.20",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.1.2",
     "@types/testing-library__jest-dom": "^6.0.0",
     "jest-fetch-mock": "^3.0.3",
-    "jsonwebtoken": "^9.0.2"
+    "jose": "^5.9.6"
   },
   "dependencies": {
     "@shopify/admin-api-client": "^1.1.1",

--- a/packages/apps/shopify-app-react-router/src/server/__test-helpers/get-jwt.ts
+++ b/packages/apps/shopify-app-react-router/src/server/__test-helpers/get-jwt.ts
@@ -3,7 +3,7 @@ import {getJwt as getJwtImport} from '@shopify/shopify-api/test-helpers';
 
 import {API_KEY, API_SECRET_KEY, TEST_SHOP_NAME} from './const';
 
-export function getJwt(
+export async function getJwt(
   overrides: Partial<JwtPayload> = {},
 ): ReturnType<typeof getJwtImport> {
   return getJwtImport(TEST_SHOP_NAME, API_KEY, API_SECRET_KEY, overrides);

--- a/packages/apps/shopify-app-remix/package.json
+++ b/packages/apps/shopify-app-remix/package.json
@@ -16,6 +16,9 @@
   "main": "./dist/cjs/server/index.js",
   "module": "./dist/esm/server/index.mjs",
   "types": "./dist/ts/server/index.d.ts",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "exports": {
     "./adapters/*": {
       "types": "./dist/ts/server/adapters/*/index.d.ts",
@@ -87,11 +90,10 @@
     "@shopify/shopify-app-session-storage-memory": "^4.0.20",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.1.8",
     "@types/testing-library__jest-dom": "^6.0.0",
     "jest-fetch-mock": "^3.0.3",
-    "jsonwebtoken": "^9.0.2"
+    "jose": "^5.9.6"
   },
   "dependencies": {
     "@remix-run/server-runtime": "^2.16.8",

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/get-jwt.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/get-jwt.ts
@@ -3,7 +3,7 @@ import {getJwt as getJwtImport} from '@shopify/shopify-api/test-helpers';
 
 import {API_KEY, API_SECRET_KEY, TEST_SHOP_NAME} from './const';
 
-export function getJwt(
+export async function getJwt(
   overrides: Partial<JwtPayload> = {},
 ): ReturnType<typeof getJwtImport> {
   return getJwtImport(TEST_SHOP_NAME, API_KEY, API_SECRET_KEY, overrides);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,18 +431,12 @@ importers:
       jose:
         specifier: ^5.9.6
         version: 5.9.6
-      jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
       node-fetch:
         specifier: ^2.6.7
         version: 2.7.0(encoding@0.1.13)
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250711.0
@@ -453,15 +447,9 @@ importers:
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.21
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
       '@types/node-fetch':
         specifier: ^2.6.11
         version: 2.6.12
-      '@types/uuid':
-        specifier: ^10.0.0
-        version: 10.0.0
       expect:
         specifier: ^30.0.4
         version: 30.0.4
@@ -508,12 +496,6 @@ importers:
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.21
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
-      jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
 
   packages/apps/shopify-app-react-router:
     dependencies:
@@ -557,9 +539,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.8
@@ -569,9 +548,9 @@ importers:
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3(encoding@0.1.13)
-      jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
       react-router:
         specifier: 7.8.1
         version: 7.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -630,9 +609,6 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.0.3(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/jsonwebtoken':
-        specifier: ^9.0.10
-        version: 9.0.10
       '@types/react':
         specifier: ^19.1.8
         version: 19.1.8
@@ -642,9 +618,9 @@ importers:
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3(encoding@0.1.13)
-      jsonwebtoken:
-        specifier: ^9.0.2
-        version: 9.0.2
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
 
 packages:
 
@@ -3916,17 +3892,11 @@ packages:
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
 
-  '@types/jsonwebtoken@9.0.10':
-    resolution: {integrity: sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==}
-
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node-fetch@2.6.12':
     resolution: {integrity: sha512-8nneRWKCg3rMtF69nLQJnOYUcbafYeFSjqkw3jCRLsqkWFlHaoQrr5mXmofFGOx3DKn7UfmBMyov8ySvLRVldA==}
@@ -4010,9 +3980,6 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
-
-  '@types/uuid@10.0.0':
-    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@types/uuid@9.0.8':
     resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
@@ -4458,9 +4425,6 @@ packages:
   bson@6.10.4:
     resolution: {integrity: sha512-WIsKqkSC0ABoBJuT1LEX+2HEvNmNKKgnTAyd0fL8qzK4SH2i9NXg+t08YtdZp/V9IZ33cxe3iV4yM0qg8lMQng==}
     engines: {node: '>=16.20.1'}
-
-  buffer-equal-constant-time@1.0.1:
-    resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -5064,9 +5028,6 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
-
-  ecdsa-sig-formatter@1.0.11:
-    resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -6419,19 +6380,9 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
-  jsonwebtoken@9.0.2:
-    resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
-    engines: {node: '>=12', npm: '>=6'}
-
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
-
-  jwa@1.4.1:
-    resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
-
-  jws@3.2.2:
-    resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -6487,32 +6438,11 @@ packages:
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
-  lodash.includes@4.3.0:
-    resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
-
-  lodash.isboolean@3.0.3:
-    resolution: {integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==}
-
-  lodash.isinteger@4.0.4:
-    resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
-
-  lodash.isnumber@3.0.3:
-    resolution: {integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==}
-
-  lodash.isplainobject@4.0.6:
-    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
-
-  lodash.isstring@4.0.1:
-    resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
-
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
-  lodash.once@4.1.1:
-    resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
@@ -8242,10 +8172,6 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
@@ -12867,16 +12793,9 @@ snapshots:
 
   '@types/json5@0.0.29': {}
 
-  '@types/jsonwebtoken@9.0.10':
-    dependencies:
-      '@types/ms': 2.1.0
-      '@types/node': 22.15.30
-
   '@types/methods@1.1.4': {}
 
   '@types/mime@1.3.5': {}
-
-  '@types/ms@2.1.0': {}
 
   '@types/node-fetch@2.6.12':
     dependencies:
@@ -12976,8 +12895,6 @@ snapshots:
       '@testing-library/jest-dom': 6.6.3
 
   '@types/tough-cookie@4.0.5': {}
-
-  '@types/uuid@10.0.0': {}
 
   '@types/uuid@9.0.8': {}
 
@@ -13558,8 +13475,6 @@ snapshots:
 
   bson@6.10.4: {}
 
-  buffer-equal-constant-time@1.0.1: {}
-
   buffer-from@1.1.2: {}
 
   buffer@5.7.1:
@@ -14052,10 +13967,6 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
-
-  ecdsa-sig-formatter@1.0.11:
-    dependencies:
-      safe-buffer: 5.2.1
 
   ee-first@1.1.1: {}
 
@@ -15925,36 +15836,12 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jsonwebtoken@9.0.2:
-    dependencies:
-      jws: 3.2.2
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.7.1
-
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.8
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
-
-  jwa@1.4.1:
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-
-  jws@3.2.2:
-    dependencies:
-      jwa: 1.4.1
-      safe-buffer: 5.2.1
 
   keyv@4.5.4:
     dependencies:
@@ -16017,23 +15904,9 @@ snapshots:
 
   lodash.debounce@4.0.8: {}
 
-  lodash.includes@4.3.0: {}
-
-  lodash.isboolean@3.0.3: {}
-
-  lodash.isinteger@4.0.4: {}
-
-  lodash.isnumber@3.0.3: {}
-
-  lodash.isplainobject@4.0.6: {}
-
-  lodash.isstring@4.0.1: {}
-
   lodash.memoize@4.1.2: {}
 
   lodash.merge@4.6.2: {}
-
-  lodash.once@4.1.1: {}
 
   lodash.sortby@4.7.0: {}
 
@@ -17158,7 +17031,8 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.1: {}
+  semver@7.7.1:
+    optional: true
 
   semver@7.7.2: {}
 
@@ -17903,8 +17777,6 @@ snapshots:
       which-typed-array: 1.1.19
 
   utils-merge@1.0.1: {}
-
-  uuid@11.1.0: {}
 
   uuid@9.0.1: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce maintenance.  We can do that by reducing dependencies. 

### WHAT is this pull request doing?

1. Unify on `jose`, rather than using both `jose` and `jsonwebtoken`
2. Remove `uuid` in favor of `globalThis.crypto.randomUUID()`
3. Require Node >=20 for Remix, RR, Express & API packages.

`jose` v5 requires Node >= 18, but Node 18 is close to LTS expiry and the CLI requries Node 20. So we decided to require Node 20 rathe than incur more major changes in future.

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [x] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- ~~[ ] I have added/updated tests for this change~~ - N/A - No functional changes
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~ - N/A - No API changes
