### PR TITLE
Change versioning-strategy to increase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,9 +13,6 @@ updates:
       interval: 'weekly'
     # Dependabot defaults to 5 open pull requests at a time
     open-pull-requests-limit: 100
-    # ignore versions already covered by a range
-    # e.g: ^1.2.3 -> 1.2.4, would be ignored
-    versioning-strategy: increase-if-necessary
 
     # Cooldown is the number of days after a release to wait until opening a PR
     # This gives us more confidence changes can be merged because changes have been community tested.


### PR DESCRIPTION
### WHY are these changes introduced?

I misunderstood how `increase-if-necessary` works.  How it works:

1. Will only update the package.json if the range doesnt match
2. If the range matches, it will update the package-lock.yml file

I chose `increase-if-necessary` because I thought it would reduce PR's. It doesn't.  We get the same number of PR's, just some of them don't touch the package.json file.

increase-if-necessary seems problematic since it may change the package-lock.yml file, but not the actual package.json file. This means our local version of a package could drift from the released version of a package, even with the same version number.  That seems like it would be hard to debug.

### WHAT is this pull request doing?

Remove versioning-strategy, which will then default to increase, which is what we had before

## Type of change

N/A - dependabot change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A - dependabot change

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
