### PR TITLE
Remove web-streams-polyfill

### DIFF
--- a/packages/api-clients/graphql-client/package.json
+++ b/packages/api-clients/graphql-client/package.json
@@ -88,8 +88,7 @@
   "dependencies": {},
   "devDependencies": {
     "jest-environment-jsdom": "^30.0.4",
-    "jest-fetch-mock": "^3.0.3",
-    "web-streams-polyfill": "^4.1.0"
+    "jest-fetch-mock": "^3.0.3"
   },
   "bugs": {
     "url": "https://github.com/Shopify/shopify-app-js/issues"

--- a/packages/api-clients/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/tests/graphql-client/fixtures.ts
@@ -1,7 +1,6 @@
 import {TextEncoder, TextDecoder} from 'util';
 import {Readable} from 'stream';
-
-import {ReadableStream} from 'web-streams-polyfill';
+import {ReadableStream} from 'stream/web';
 
 import {createGraphQLClient} from '../../graphql-client';
 import {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,9 +165,6 @@ importers:
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3(encoding@0.1.13)
-      web-streams-polyfill:
-        specifier: ^4.1.0
-        version: 4.2.0
 
   packages/api-clients/storefront-api-client:
     dependencies:
@@ -8352,10 +8349,6 @@ packages:
 
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
-    engines: {node: '>= 8'}
-
-  web-streams-polyfill@4.2.0:
-    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
     engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
@@ -18245,8 +18238,6 @@ snapshots:
       '@zxing/text-encoding': 0.9.0
 
   web-streams-polyfill@3.3.3: {}
-
-  web-streams-polyfill@4.2.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce maintenance by removing dependencies that aren't needed.

### WHAT is this pull request doing?

Remove `web-streams-polyfill` use `ReadableStream` from `stream/web`. Since this only affects tests, and since we test on Node >=20 this is a safe change.

## Type of change

N/A - dev dependency only

- ~~[ ] Patch: Bug (non-breaking change which fixes an issue)~~
- ~~[ ] Minor: New feature (non-breaking change which adds functionality)~~
- ~~[ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)~~

## Checklist

N/A - dev dependency only

- ~~[ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)~~
- ~~[ ] I have added/updated tests for this change~~
- ~~[ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)~~
