### PR TITLE
Fix TypeScript example in webhook validation documentation

### DIFF
--- a/packages/apps/shopify-api/docs/reference/webhooks/validate.md
+++ b/packages/apps/shopify-api/docs/reference/webhooks/validate.md
@@ -9,17 +9,18 @@ This method can be used to validate app-specific and shop-specific webhooks.
 
 ```ts
 app.post('/webhooks', express.text({type: '*/*'}), async (req, res) => {
-  const {valid, topic, domain} = await shopify.webhooks.validate({
+  const result = await shopify.webhooks.validate({
     rawBody: req.body, // is a string
     rawRequest: req,
     rawResponse: res,
   });
 
-  if (!valid) {
+  if (!result.valid) {
     // This is not a valid request!
     res.send(400); // Bad Request
+    return;
   }
-
+  const { topic, domain, webhookId } = result;
   // Run my webhook-processing code here
 });
 ```


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation error in webhook validation documentation example
- Updated the example to properly handle the discriminated union return type
- Fixes #2704 

## Problem
The current documentation example attempts to destructure `topic` and `domain` directly from the webhook validation result, which causes TypeScript compilation errors because the return type is a discriminated union (`WebhookValidation`).

## Solution
Updated the example to:
1. Store the validation result first
2. Check `result.valid` to narrow the TypeScript type

🤖 Generated with [Claude Code](https://claude.ai/code)