### PR TITLE
Remove eslint-plugin-prettier as its not used anywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "changeset": "changeset",
     "version-packages": "changeset version"
   },
-  "dependencies": {},
   "devDependencies": {
     "@babel/preset-env": "^7.28.0",
     "@changesets/cli": "^2.29.5",
@@ -37,7 +36,6 @@
     "@types/supertest": "^6.0.3",
     "eslint": "^8.57.1",
     "eslint-plugin-jest": "^28.13.5",
-    "eslint-plugin-prettier": "^5.5.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^30.0.4",
     "jest-fetch-mock": "^3.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ importers:
       eslint-plugin-jest:
         specifier: ^28.13.5
         version: 28.13.5(@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(jest@29.7.0(@types/node@24.3.0)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@24.3.0)(typescript@5.8.3)))(typescript@5.8.3)
-      eslint-plugin-prettier:
-        specifier: ^5.5.1
-        version: 5.5.4(eslint-config-prettier@9.1.0(eslint@8.57.1))(eslint@8.57.1)(prettier@3.6.2)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@24.3.0)(ts-node@10.9.2(@swc/core@1.13.3)(@types/node@24.3.0)(typescript@5.8.3))
@@ -11688,7 +11685,7 @@ snapshots:
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.4
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@libsql/client@0.15.12(encoding@0.1.13)':
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce dependencies to reduce maintenance burden

### WHAT is this pull request doing?

Remove eslint-plugin-prettier  as its not used anywhere

## Type of change

N/A - devDependency only

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A - devDependency only

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
