### PR TITLE
Remove swc dependencies since they are not used

### DIFF
--- a/packages/apps/shopify-api/package.json
+++ b/packages/apps/shopify-api/package.json
@@ -96,7 +96,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250826.0",
-    "@swc/core": "^1.12.11",
     "@types/express": "^4.17.13",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node-fetch": "^2.6.11",
@@ -105,7 +104,6 @@
     "jest-environment-miniflare": "^2.14.4",
     "miniflare": "^4.20250709.0",
     "rollup": "^4.48.1",
-    "rollup-plugin-swc": "^0.2.1",
     "wrangler": "^3.112.0"
   },
   "files": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,9 +423,6 @@ importers:
       '@cloudflare/workers-types':
         specifier: ^4.20250826.0
         version: 4.20250826.0
-      '@swc/core':
-        specifier: ^1.12.11
-        version: 1.13.3
       '@types/express':
         specifier: ^4.17.13
         version: 4.17.21
@@ -450,9 +447,6 @@ importers:
       rollup:
         specifier: ^4.48.1
         version: 4.48.1
-      rollup-plugin-swc:
-        specifier: ^0.2.1
-        version: 0.2.1(@swc/core@1.13.3)(rollup@4.48.1)
       wrangler:
         specifier: ^3.112.0
         version: 3.112.0(@cloudflare/workers-types@4.20250826.0)
@@ -3299,10 +3293,6 @@ packages:
         optional: true
       tslib:
         optional: true
-
-  '@rollup/pluginutils@4.2.1':
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
 
   '@rollup/pluginutils@5.1.4':
     resolution: {integrity: sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==}
@@ -7462,13 +7452,6 @@ packages:
 
   rollup-plugin-node-polyfills@0.2.1:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
-
-  rollup-plugin-swc@0.2.1:
-    resolution: {integrity: sha512-wWRYt9tC0aIBvRQHNnVtwJ6DRPDj9XYpOAcOyFB11sKSkR/R+NAmbrjBACCPNVmZcxg6joV29wXgb5mU1DI7eA==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-    peerDependencies:
-      '@swc/core': '>=1.0'
-      rollup: '>=1.5.0'
 
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
@@ -12563,11 +12546,6 @@ snapshots:
       rollup: 4.48.1
       tslib: 2.8.1
 
-  '@rollup/pluginutils@4.2.1':
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-
   '@rollup/pluginutils@5.1.4(rollup@4.48.1)':
     dependencies:
       '@types/estree': 1.0.8
@@ -13100,12 +13078,15 @@ snapshots:
       '@swc/core-win32-arm64-msvc': 1.13.3
       '@swc/core-win32-ia32-msvc': 1.13.3
       '@swc/core-win32-x64-msvc': 1.13.3
+    optional: true
 
-  '@swc/counter@0.1.3': {}
+  '@swc/counter@0.1.3':
+    optional: true
 
   '@swc/types@0.1.24':
     dependencies:
       '@swc/counter': 0.1.3
+    optional: true
 
   '@testing-library/jest-dom@6.8.0':
     dependencies:
@@ -17582,12 +17563,6 @@ snapshots:
   rollup-plugin-node-polyfills@0.2.1:
     dependencies:
       rollup-plugin-inject: 3.0.2
-
-  rollup-plugin-swc@0.2.1(@swc/core@1.13.3)(rollup@4.48.1):
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      '@swc/core': 1.13.3
-      rollup: 4.48.1
 
   rollup-pluginutils@2.8.2:
     dependencies:


### PR DESCRIPTION
### WHY are these changes introduced?

`@swc/core` and `rollup-plugin-swc` are not used.  Not point keeping them as dependencies

### WHAT is this pull request doing?

Remove `@swc/core` and `rollup-plugin-swc`

## Type of change

N/A Dev dependency only

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A Dev dependency only

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
