### PR TITLE
Remove @testing-library/jest-dom and @types/testing-library__jest-dom

### DIFF
--- a/packages/apps/shopify-app-react-router/package.json
+++ b/packages/apps/shopify-app-react-router/package.json
@@ -84,8 +84,7 @@
     "@shopify/shopify-app-session-storage-memory": "^4.0.20",
     "@testing-library/jest-dom": "^6.8.0",
     "@types/jsonwebtoken": "^9.0.10",
-    "@types/react": "^19.1.11",
-    "@types/testing-library__jest-dom": "^6.0.0",
+    "@types/react": "^19.1.2",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.2",
     "react-router": "7.8.2"

--- a/packages/apps/shopify-app-remix/package.json
+++ b/packages/apps/shopify-app-remix/package.json
@@ -89,7 +89,6 @@
     "@testing-library/jest-dom": "^6.8.0",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/react": "^19.1.11",
-    "@types/testing-library__jest-dom": "^6.0.0",
     "jest-fetch-mock": "^3.0.3",
     "jsonwebtoken": "^9.0.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -549,11 +549,8 @@ importers:
         specifier: ^9.0.10
         version: 9.0.10
       '@types/react':
-        specifier: ^19.1.11
+        specifier: ^19.1.2
         version: 19.1.11
-      '@types/testing-library__jest-dom':
-        specifier: ^6.0.0
-        version: 6.0.0
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3(encoding@0.1.13)
@@ -624,9 +621,6 @@ importers:
       '@types/react':
         specifier: ^19.1.11
         version: 19.1.11
-      '@types/testing-library__jest-dom':
-        specifier: ^6.0.0
-        version: 6.0.0
       jest-fetch-mock:
         specifier: ^3.0.3
         version: 3.0.3(encoding@0.1.13)
@@ -3863,10 +3857,6 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
-
-  '@types/testing-library__jest-dom@6.0.0':
-    resolution: {integrity: sha512-bnreXCgus6IIadyHNlN/oI5FfX4dWgvGhOPvpr7zzCYDGAPIfvyIoAozMBINmhmsVuqV0cncejF2y5KC7ScqOg==}
-    deprecated: This is a stub types definition. @testing-library/jest-dom provides its own type definitions, so you do not need this installed.
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -12513,10 +12503,6 @@ snapshots:
       '@types/node': 22.10.7
 
   '@types/stack-utils@2.0.3': {}
-
-  '@types/testing-library__jest-dom@6.0.0':
-    dependencies:
-      '@testing-library/jest-dom': 6.8.0
 
   '@types/tough-cookie@4.0.5': {}
 


### PR DESCRIPTION
### WHY are these changes introduced?

We want to reduce maintenance

### WHAT is this pull request doing?

@testing-library/jest-dom and @types/testing-library__jest-dom are not used anywhere.  No point incuring the maintenance cost of dependabot updates for them

## Type of change

N/A - devDepedendency only

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A - devDepedendency only

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
