### PR TITLE
docs: Add docs for expiring offline access tokens

### DIFF
--- a/packages/apps/session-storage/shopify-app-session-storage-prisma/MIGRATION_TO_EXPIRING_TOKENS.md
+++ b/packages/apps/session-storage/shopify-app-session-storage-prisma/MIGRATION_TO_EXPIRING_TOKENS.md
@@ -1,0 +1,54 @@
+# Migrating to Expiring Tokens
+
+The `@shopify/shopify-app-session-storage-prisma` package now supports expiring offline access tokens. The refresh token and its expiration date are now stored as part of the session if your app is using expiring offline access tokens. This change requires updating the Prisma schema to include the refresh token information.
+
+## Updating the Prisma schema
+
+Update the `Session` model in the Prisma schema to include the refresh token information:
+
+```prisma
+model Session {
+  id            String    @id
+  shop          String
+  state         String
+  isOnline      Boolean   @default(false)
+  scope         String?
+  expires       DateTime?
+  accessToken   String
+  userId        BigInt?
+  // ... existing fields ...
+  // New fields
+  refreshToken        String?
+  refreshTokenExpires DateTime?
+}
+```
+
+Run the following prisma commands to update the database schema:
+
+```sh
+npx prisma migrate dev
+```
+
+### Update Types
+
+Update the generated types to include the new fields:
+
+```sh
+npx prisma generate
+```
+
+## Using the refreshToken
+
+The refresh token will now be available on the `Session` object if your app is using expiring offline access tokens.
+
+You can enable expiring offline access tokens in the `shopifyApp` object in your `shopify.server` file.
+
+```diff
+const shopify = shopifyApp({
+  apiKey: process.env.SHOPIFY_API_KEY,
+  sessionStorage: new PrismaSessionStorage(prisma),
+  distribution: AppDistribution.AppStore,
++ future: {
++   expiringOfflineAccessTokens: true,
++ },
+```

--- a/packages/apps/session-storage/shopify-app-session-storage-prisma/README.md
+++ b/packages/apps/session-storage/shopify-app-session-storage-prisma/README.md
@@ -21,6 +21,8 @@ model Session {
   locale        String?
   collaborator  Boolean?
   emailVerified Boolean?
+  refreshToken  String?
+  refreshTokenExpires DateTime?
 }
 ```
 

--- a/packages/apps/shopify-api/docs/guides/oauth.md
+++ b/packages/apps/shopify-api/docs/guides/oauth.md
@@ -104,6 +104,42 @@ To perform [Client Credentials Grant](https://shopify.dev/beta/developer-dashboa
 3. Use the obtained access token to make authenticated API queries, see [After OAuth](#after-oauth)
 
 
+## Expiring Access Tokens
+
+Expiring offline access tokens have a limited lifetime. When they expire, your app must refresh them to continue making API calls.
+
+### Offline Tokens
+
+Traditionally, offline access tokens did not expire. However, Shopify is moving towards expiring offline access tokens for better security.
+
+#### Migrating to Expiring Offline Tokens
+
+If you have existing non-expiring offline tokens, you can migrate them to expiring tokens using [`shopify.auth.migrateToExpiringToken`](../reference/auth/migrateToExpiringToken.md).
+
+```ts
+const response = await shopify.auth.migrateToExpiringToken({
+  shop: 'my-shop.myshopify.com',
+  nonExpiringOfflineAccessToken: 'existing-offline-token',
+});
+
+const {session} = response;
+// Save the new session which now contains an expiring access token and a refresh token
+```
+
+#### Refreshing Tokens
+
+When a token expires (or is about to), you can use the refresh token stored in the session to obtain a new access token using [`shopify.auth.refreshToken`](../reference/auth/refreshToken.md).
+
+```ts
+const response = await shopify.auth.refreshToken({
+  shop: 'my-shop.myshopify.com',
+  refreshToken: 'refresh-token-from-session',
+});
+
+const {session} = response;
+// Use the new session with updated access token and (potentially) new refresh token
+```
+
 ## After OAuth
 
 Once you complete the OAuth process, you'll be able to call [shopify.session.getCurrentId](../reference/session/getCurrentId.md) to fetch your session, and create API clients.

--- a/packages/apps/shopify-api/docs/guides/session-storage.md
+++ b/packages/apps/shopify-api/docs/guides/session-storage.md
@@ -29,6 +29,8 @@ The previous implementations of `SessionStorage` are now available in their own 
 |      scope       |      string      |     no     |
 |     expires      |       Date       |     no     |
 |   accessToken    |      string      |     no     |
+|   refreshToken   |      string      |     no     |
+| refreshTokenExpires |    Date       |     no     |
 | onlineAccessInfo | OnlineAccessInfo |     no     |
 
 > **Note** 1. These data are the same as the `SessionParams` object that's passed into the `Session` class constructor.

--- a/packages/apps/shopify-api/docs/reference/auth/README.md
+++ b/packages/apps/shopify-api/docs/reference/auth/README.md
@@ -9,6 +9,7 @@ Learn more about [token exchange](../../guides/oauth.md#token-exchange).
 | Property                                        | Description                                                                                       |
 | ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
 | [tokenExchange](./tokenExchange.md)             | Performs token exchange to get access token from session token                                    |
+| [migrateToExpiringToken](./migrateToExpiringToken.md) | Exchanges a non-expiring offline access token for an expiring one                               |
 
 ## Authorization Code Grant Flow
 
@@ -19,6 +20,14 @@ Learn more about [authorization code grant flow](../../guides/oauth.md#authoriza
 | [begin](./begin.md)                             | Redirect the user to Shopify to request authorization for the app.                                |
 | [callback](./callback.md)                       | Receive Shopify's callback after the user approves the app installation.                          |
 | [nonce](./nonce.md)                             | Generates a random string of characters to be used as the state value for OAuth.                  |
+
+## Refresh Token
+
+Learn more about [Refreshing Token](../../guides/oauth.md#refreshing-token).
+
+| Property                                        | Description                                                                                       |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| [refreshToken](./refreshToken.md)               | Refreshes an access token using a refresh token                                                   |
 
 ## Client Credentials Grant
 

--- a/packages/apps/shopify-api/docs/reference/auth/migrateToExpiringToken.md
+++ b/packages/apps/shopify-api/docs/reference/auth/migrateToExpiringToken.md
@@ -1,0 +1,128 @@
+# shopify.auth.migrateToExpiringToken
+
+Exchanges a non-expiring offline access token for an expiring offline access token and a refresh token.
+
+This is part of the migration process to move from non-expiring offline tokens to expiring ones for better security.
+
+> [!WARNING]
+> This is a **one-time, irreversible migration** per shop. Once you migrate a shop's token to an expiring token, you cannot convert it back to a non-expiring token. The shop would need to reinstall your app with `expiring_offline_access_tokens: false` in your Context configuration to obtain a new non-expiring token.
+
+## Examples
+
+### Node.js
+
+```ts
+const response = await shopify.auth.migrateToExpiringToken({
+  shop: 'my-shop.myshopify.com',
+  nonExpiringOfflineAccessToken: 'existing-offline-token',
+});
+
+const {session} = response;
+// Save the new session which now contains an expiring access token and a refresh token
+```
+
+## Parameters
+
+### shop
+
+`string` | required
+
+A Shopify domain name in the form `{exampleshop}.myshopify.com`.
+
+### nonExpiringOfflineAccessToken
+
+`string` | required
+
+The existing non-expiring offline access token that you want to exchange.
+
+## Return
+
+`Promise<{session: Session}>`
+
+Returns a promise resolving to an object containing the new [`Session`](../../../lib/session/session.ts) with the expiring offline access token and refresh token.
+
+
+## Migration Strategy
+
+When migrating your app to use expiring tokens, follow this order:
+
+1. **Update your prisma schema** to add `refreshToken` (String?) and `refreshTokenExpires` (DateTime?) columns.
+    ```prisma
+    model Session {
+        id            String    @id
+        shop          String
+        ...
+        refreshToken  String? // new column
+        refreshTokenExpires DateTime? // new column
+    }
+    ```
+2. Run the following prisma commands to update the database schema:
+    ```sh
+    npx prisma migrate dev
+    ```
+3. **Update Types**
+
+    Update the generated types to include the new fields:
+    ```sh
+    npx prisma generate
+    ```
+4. **Enable expiring tokens in your config setup** so new installations will request and receive expiring tokens:
+   ```js
+    const shopify = shopifyApi({
+        apiKey: 'APIKeyFromPartnersDashboard',
+        apiSecretKey: 'APISecretFromPartnersDashboard',
+        ...
+        expiringOfflineAccessTokens: true
+    });
+   ```
+5. **Implement refresh logic** in your app to handle token expiration using `shopify.auth.refreshToken`
+6. **Migrate existing non-expiring tokens** for shops that have already installed your app using the migration method above
+
+    You can use a background job to migrate your existing shops. Here is an example script using Prisma:
+
+    ```ts
+    import { PrismaClient } from '@prisma/client';
+    import { shopify } from './shopify.js'; // Your shopify object
+    import { sessionStorage } from './session-storage.js'; // Your session storage instance
+
+    const prisma = new PrismaClient();
+
+    async function migrateShops() {
+      // 1. Fetch all offline sessions that haven't been migrated yet
+      const sessions = await prisma.session.findMany({
+        where: {
+          isOnline: false,
+          expires: null,
+          refreshToken: null,
+        },
+      });
+
+      console.log(`Found ${sessions.length} sessions to migrate.`);
+
+      for (const session of sessions) {
+        if (!session.accessToken) continue;
+
+        try {
+          console.log(`Migrating shop: ${session.shop}`);
+
+          // 2. Exchange the token
+          const response = await shopify.auth.migrateToExpiringToken({
+            shop: session.shop,
+            nonExpiringOfflineAccessToken: session.accessToken,
+          });
+
+          // 3. Save the new session (updates the existing record with refresh token)
+          await sessionStorage.storeSession(response.session);
+
+          console.log(`Successfully migrated ${session.shop}`);
+        } catch (error) {
+          console.error(`Failed to migrate ${session.shop}:`, error);
+        }
+      }
+    }
+
+    migrateShops();
+    ```
+
+[Back to shopify.auth](./README.md)
+

--- a/packages/apps/shopify-api/docs/reference/auth/refreshToken.md
+++ b/packages/apps/shopify-api/docs/reference/auth/refreshToken.md
@@ -1,0 +1,41 @@
+# shopify.auth.refreshToken
+
+Refreshes an access token for a given session using a refresh token. This is used to obtain a new access token when the current one has expired (or is about to expire).
+
+## Examples
+
+### Node.js
+
+```ts
+const response = await shopify.auth.refreshToken({
+  shop: 'my-shop.myshopify.com',
+  refreshToken: 'refresh-token-from-session',
+});
+
+const {session} = response;
+// Use the new session with updated access token and (potentially) new refresh token
+```
+
+## Parameters
+
+### shop
+
+`string` | :exclamation: required
+
+A Shopify domain name in the form `{exampleshop}.myshopify.com`.
+
+### refreshToken
+
+`string` | :exclamation: required
+
+The refresh token stored in the session.
+
+## Return
+
+`Promise<{session: Session}>`
+
+Returns a promise resolving to an object containing the new [`Session`](../../../lib/session/session.ts) with the refreshed access token.
+
+[Back to shopify.auth](./README.md)
+
+

--- a/packages/apps/shopify-api/docs/reference/auth/tokenExchange.md
+++ b/packages/apps/shopify-api/docs/reference/auth/tokenExchange.md
@@ -22,6 +22,7 @@ app.get('/auth', async (req, res) => {
     sessionToken,
     shop,
     requestedTokenType: RequestedTokenType.OfflineAccessToken, // or RequestedTokenType.OnlineAccessToken
+    expiring: true, // Optional, defaults to false
   });
 });
 
@@ -75,6 +76,12 @@ A Shopify domain name in the form `{exampleshop}.myshopify.com`.
 
 - `RequestedTokenType.OnlineAccessToken` - Learn more about [online tokens](https://shopify.dev/docs/apps/auth/access-token-types/online.md)
 - `RequestedTokenType.OfflineAccessToken` - Learn more about [offline tokens](https://shopify.dev/docs/apps/auth/access-token-types/offline.md)
+
+### expiring
+
+`boolean` | optional
+
+Whether the requested access token should be expiring. If `true`, the response will include an expiring access token and a refresh token. Defaults to `false`.
 
 ## Return
 

--- a/packages/apps/shopify-app-react-router/docs/upcoming_changes.md
+++ b/packages/apps/shopify-app-react-router/docs/upcoming_changes.md
@@ -9,6 +9,7 @@ You can use it as a guide for migrating your app, and ensuring you're ready for 
 ## Table of contents
 
 - [Use new authentication strategy for embedded apps](#use-new-authentication-strategy-for-embedded-apps)
+- [Enable expiring offline access tokens](#enable-expiring-offline-access-tokens)
 
 ## Use new authentication strategy for embedded apps
 
@@ -22,3 +23,29 @@ This package will automatically use token exchange, but that only works if [Shop
 Before updating this package in your app, please ensure you've enabled managed installation.
 
 For more details on how this works, please see the [new embedded authorization strategy](../README.md#new-embedded-authorization-strategy) section in the README.
+
+## Enable expiring offline access tokens
+
+> [!NOTE]
+> The `expiringOfflineAccessTokens` future flag enables this behaviour.
+> If you've already enabled the flag, you don't need to follow these instructions.
+
+Shopify is moving towards expiring offline access tokens for better security. Traditionally, offline access tokens did not expire, but now they can have a limited lifetime and require refreshing.
+
+To enable this feature in your app:
+
+1.  **Update your database schema**: Ensure your Session table includes `refreshToken` and `refreshTokenExpires` columns.
+2.  **Enable the configuration**: Set `expiringOfflineAccessTokens: true` in your `shopifyApp` `future` configuration.
+
+```ts
+const shopify = shopifyApp({
+  // ...
+  future: {
+    expiringOfflineAccessTokens: true,
+  },
+});
+```
+
+When enabled, the package will automatically handle token refreshing when necessary during authentication.
+
+Learn more about [Expiring Access Tokens](../../../shopify-api/docs/guides/oauth.md#expiring-access-tokens).

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -42,6 +42,10 @@ export const createTokenExchangeStrategy: AuthStrategyFactory<any> = <
     requestedTokenType: RequestedTokenType;
   }): Promise<{session: Session}> {
     try {
+      console.log(
+        'config.future.expiringOfflineAccessTokens',
+        config.future.expiringOfflineAccessTokens,
+      );
       return await api.auth.tokenExchange({
         sessionToken,
         shop,


### PR DESCRIPTION
# Add support for expiring offline access tokens

### WHY are these changes introduced?

This PR adds support for expiring offline access tokens, which is part of Shopify's move toward more secure token management.

### WHAT is this pull request doing?

- Adds `refreshToken` and `refreshTokenExpires` fields to the Prisma session storage schema
- Implements new auth methods for token management:
    - `shopify.auth.migrateToExpiringToken` - Converts non-expiring tokens to expiring ones
    - `shopify.auth.refreshToken` - Refreshes expired access tokens
- Updates documentation with migration guidance and usage examples
- Adds `expiring` parameter to the token exchange method
- Updates session storage documentation to include the new fields

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)