### PR TITLE
feat(remix): Add support for expiring offline access tokens

### DIFF
--- a/.changeset/lazy-kangaroos-dance.md
+++ b/.changeset/lazy-kangaroos-dance.md
@@ -1,0 +1,49 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+We are introducing support for expiring offline access tokens. This feature improves security by limiting the lifespan of offline access tokens and automatically refreshing them using refresh tokens.
+
+- **New Future Flag**: Added `expiringOfflineAccessTokens` (boolean) to the `future` configuration in `shopifyApp`. When enabled, the library will start using expiring offline tokens and automatically check if it is expired or nearing expiration. If expired/expiring, it attempts to refresh the access token using the stored refresh token. Defaults to `false` for backward compatibility.
+
+- **Automatic Token Refresh**: Integrated token refresh logic into authentication flows (`flow`, `fulfillmentService`, `appProxy`, `webhooks`) and unauthenticated contexts (`admin`, `storefront`). When a session is loaded and found to be expired (or expiring within 5 minutes), and the feature is enabled, the library transparently refreshes the token and persists the new session data. This behavior applies to both offline and online tokens.
+
+To enable expiring offline access tokens in your app, you must ensure your session storage can persist refresh tokens. For now, this will only work if you are using the Prisma Session Storage package. We're starting with Prisma since this is what the majority of our developers use. If you're using a different session storage adapter and would like support for expiring offline tokens, we'd love to hear from you! If you are using Prisma, follow these steps:
+
+1. Update your `@shopify/shopify-api` and `@shopify/shopify-app-session-storage-prisma` packages to the latest version.
+
+2. Update your Prisma schema to include the `refreshToken` and `refreshTokenExpires` fields in the `Session` model:
+
+```prisma
+model Session {
+  // ...
+  refreshToken        String?
+  refreshTokenExpires DateTime?
+}
+```
+
+3. Run a migration to update your database:
+
+```sh
+npx prisma migrate dev
+```
+
+4. Update the generated types to include the new fields:
+
+```sh
+npx prisma generate
+```
+
+5. Enable the future flag in your app configuration:
+
+```ts
+const shopify = shopifyApp({
+  // ... other config
+  future: {
+    expiringOfflineAccessTokens: true,
+  },
+});
+```
+
+When enabled, calls to `shopify.authenticate.admin`, `shopify.authenticate.flow`, etc., will automatically handle token refreshing for offline sessions.
+

--- a/packages/apps/shopify-app-remix/docs/upcoming_changes.md
+++ b/packages/apps/shopify-app-remix/docs/upcoming_changes.md
@@ -9,6 +9,7 @@ You can use it as a guide for migrating your app, and ensuring you're ready for 
 ## Table of contents
 
 - [Use new authentication strategy for embedded apps](#use-new-authentication-strategy-for-embedded-apps)
+- [Enable expiring offline access tokens](#enable-expiring-offline-access-tokens)
 
 ## Use new authentication strategy for embedded apps
 
@@ -22,3 +23,22 @@ This package will automatically use token exchange, but that only works if [Shop
 Before updating this package in your app, please ensure you've enabled managed installation.
 
 For more details on how this works, please see the [new embedded authorization strategy](../README.md#new-embedded-authorization-strategy) section in the README.
+
+## Enable expiring offline access tokens
+> [!NOTE]
+> The `expiringOfflineAccessTokens` future flag enables this behaviour.
+> If you've already enabled the flag, you don't need to follow these instructions.
+Shopify is moving towards expiring offline access tokens for better security. Traditionally, offline access tokens did not expire, but now they can have a limited lifetime and require refreshing.
+To enable this feature in your app:
+1.  **Update your database schema**: Ensure your Session table includes `refreshToken` and `refreshTokenExpires` columns.
+2.  **Enable the configuration**: Set `expiringOfflineAccessTokens: true` in your `shopifyApp` `future` configuration.
+```ts
+const shopify = shopifyApp({
+  // ...
+  future: {
+    expiringOfflineAccessTokens: true,
+  },
+});
+```
+When enabled, the package will automatically handle token refreshing when necessary during authentication.
+Learn more about [Expiring Access Tokens](../../../shopify-api/docs/guides/oauth.md#expiring-access-tokens).

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-token-refresh.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-token-refresh.ts
@@ -1,0 +1,188 @@
+import {Session} from '@shopify/shopify-api';
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
+import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+
+import {TestOverridesArg} from '../test-helpers/test-config';
+import {AppDistribution} from '../types';
+
+import {API_KEY, API_SECRET_KEY, TEST_SHOP} from './const';
+import {mockExternalRequest} from './request-mock';
+import {
+  setUpValidSession,
+  setupValidCustomAppSession,
+} from './setup-valid-session';
+
+export function expectTokenRefresh(
+  runAuth: (
+    sessionStorage: SessionStorage,
+    session: Session,
+    configOverrides?: TestOverridesArg,
+  ) => Promise<Session>,
+) {
+  describe('token refresh for expired offline sessions', () => {
+    it('does not refresh token when session is not expired', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const oneHourFromNow = new Date(Date.now() + 1000 * 3600);
+      const session = await setUpValidSession(sessionStorage, {
+        expires: oneHourFromNow,
+        refreshToken: 'test-refresh-token',
+      });
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session);
+
+      // THEN
+      expect(actualSession.accessToken).toBe(session.accessToken);
+      expect(actualSession.expires?.getTime()).toBe(oneHourFromNow.getTime());
+    });
+
+    it('refreshes token when session is expired and feature flag is enabled', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const oneSecondAgo = new Date(Date.now() - 1000);
+      const thirtyDaysFromNow = new Date(Date.now() + 1000 * 3600 * 24 * 30);
+
+      const session = await setUpValidSession(sessionStorage, {
+        expires: oneSecondAgo,
+        refreshToken: 'test-refresh-token',
+        refreshTokenExpires: thirtyDaysFromNow,
+      });
+
+      const refreshResponse = {
+        access_token: 'new-access-token',
+        scope: 'testScope',
+        expires_in: 3600,
+        refresh_token: 'new-refresh-token',
+        refresh_token_expires_in: 2592000,
+      };
+
+      await mockExternalRequest({
+        request: new Request(`https://${TEST_SHOP}/admin/oauth/access_token`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            client_id: API_KEY,
+            client_secret: API_SECRET_KEY,
+            refresh_token: 'test-refresh-token',
+            grant_type: 'refresh_token',
+          }),
+        }),
+        response: new Response(JSON.stringify(refreshResponse), {
+          status: 200,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      });
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session);
+
+      // THEN
+      expect(actualSession.accessToken).toBe('new-access-token');
+      expect(actualSession.refreshToken).toBe('new-refresh-token');
+      expect(actualSession.id).toBe(session.id);
+      expect(actualSession.shop).toBe(TEST_SHOP);
+      expect(actualSession.expires?.getTime()).toBeGreaterThan(Date.now());
+    });
+
+    it('refreshes token when session is within milliseconds of expiry', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const halfSecondFromNow = new Date(Date.now() + 500);
+      const thirtyDaysFromNow = new Date(Date.now() + 1000 * 3600 * 24 * 30);
+
+      const session = await setUpValidSession(sessionStorage, {
+        expires: halfSecondFromNow,
+        refreshToken: 'test-refresh-token',
+        refreshTokenExpires: thirtyDaysFromNow,
+      });
+
+      const refreshResponse = {
+        access_token: 'new-access-token-2',
+        scope: 'testScope',
+        expires_in: 3600,
+        refresh_token: 'new-refresh-token-2',
+        refresh_token_expires_in: 2592000,
+      };
+
+      await mockExternalRequest({
+        request: new Request(`https://${TEST_SHOP}/admin/oauth/access_token`, {
+          method: 'POST',
+          headers: {'Content-Type': 'application/json'},
+          body: JSON.stringify({
+            client_id: API_KEY,
+            client_secret: API_SECRET_KEY,
+            refresh_token: 'test-refresh-token',
+            grant_type: 'refresh_token',
+          }),
+        }),
+        response: new Response(JSON.stringify(refreshResponse), {
+          status: 200,
+          headers: {'Content-Type': 'application/json'},
+        }),
+      });
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session);
+
+      // THEN
+      expect(actualSession.accessToken).toBe('new-access-token-2');
+      expect(actualSession.refreshToken).toBe('new-refresh-token-2');
+    });
+
+    it('does not refresh token when session has no expiry', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const session = await setUpValidSession(sessionStorage, {
+        expires: undefined,
+        refreshToken: 'test-refresh-token',
+      });
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session);
+
+      // THEN
+      expect(actualSession.accessToken).toBe(session.accessToken);
+      expect(actualSession.expires).toBeUndefined();
+    });
+
+    it('does not refresh token when feature flag is disabled even if session is expired', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const oneSecondAgo = new Date(Date.now() - 1000);
+      const session = await setUpValidSession(sessionStorage, {
+        expires: oneSecondAgo,
+        refreshToken: 'test-refresh-token',
+      });
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session, {
+        future: {
+          expiringOfflineAccessTokens: false,
+        },
+      });
+
+      // THEN
+      expect(actualSession.accessToken).toBe(session.accessToken);
+      expect(actualSession.expires?.getTime()).toBe(oneSecondAgo.getTime());
+      expect(actualSession.refreshToken).toBe('test-refresh-token');
+    });
+
+    it('does not refresh token when distribution is ShopifyAdmin', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const session = setupValidCustomAppSession(TEST_SHOP);
+
+      // WHEN
+      const actualSession = await runAuth(sessionStorage, session, {
+        distribution: AppDistribution.ShopifyAdmin,
+      });
+
+      // THEN
+      expect(actualSession).toBeDefined();
+      expect(actualSession.shop).toBe(TEST_SHOP);
+      expect(actualSession.expires).toBeUndefined();
+      expect(actualSession.refreshToken).toBeUndefined();
+    });
+  });
+}

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/index.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/index.ts
@@ -18,3 +18,4 @@ export * from './setup-embedded-flow';
 export * from './setup-fetch-flow';
 export * from './mock-graphql-request';
 export * from './setup-non-embedded-flow';
+export * from './expect-token-refresh';

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/test-config.ts
@@ -14,6 +14,7 @@ import {testConfig as testConfigImport} from '../test-helpers/test-config';
  */
 const TEST_FUTURE_FLAGS: Required<{[key in keyof FutureFlags]: true}> = {
   unstable_newEmbeddedAuthStrategy: true,
+  expiringOfflineAccessTokens: true,
 } as const;
 
 // Override the helper's future flags and logger settings for our purposes

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/auth-code-flow.ts
@@ -191,6 +191,7 @@ export class AuthCodeFlowStrategy<Config extends AppConfigArg>
     try {
       const {session, headers: responseHeaders} = await api.auth.callback({
         rawRequest: request,
+        expiring: config.future.expiringOfflineAccessTokens,
       });
 
       await config.sessionStorage!.storeSession(session);

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/strategies/token-exchange.ts
@@ -19,6 +19,7 @@ import type {
   ApiConfigWithFutureFlags,
   ApiFutureFlags,
 } from '../../../future/flags';
+import {WITHIN_MILLISECONDS_OF_EXPIRY} from '../../../helpers';
 
 import {AuthorizationStrategy, SessionContext, OnErrorOptions} from './types';
 
@@ -50,7 +51,10 @@ export class TokenExchangeStrategy<Config extends AppConfigArg>
 
     if (!sessionToken) throw new InvalidJwtError();
 
-    if (!session || !session.isActive(undefined)) {
+    if (
+      !session ||
+      !session.isActive(undefined, WITHIN_MILLISECONDS_OF_EXPIRY)
+    ) {
       logger.info('No valid session found', {shop});
       logger.info('Requesting offline access token', {shop});
       const {session: offlineSession} = await this.exchangeToken({
@@ -144,6 +148,7 @@ export class TokenExchangeStrategy<Config extends AppConfigArg>
         sessionToken,
         shop,
         requestedTokenType,
+        expiring: config.future.expiringOfflineAccessTokens,
       });
     } catch (error) {
       if (

--- a/packages/apps/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/flow/authenticate.ts
@@ -1,10 +1,11 @@
 import {adminClientFactory} from '../../clients/admin';
+import {ensureValidOfflineSession} from '../../helpers';
 import {BasicParams} from '../../types';
 
 import type {AuthenticateFlow, FlowContext} from './types';
 
 export function authenticateFlowFactory(params: BasicParams): AuthenticateFlow {
-  const {api, config, logger} = params;
+  const {api, logger} = params;
 
   return async function authenticate(request: Request): Promise<FlowContext> {
     logger.info('Authenticating flow request');
@@ -41,8 +42,10 @@ export function authenticateFlowFactory(params: BasicParams): AuthenticateFlow {
       shop: payload.shopify_domain,
     });
 
-    const sessionId = api.session.getOfflineId(payload.shopify_domain);
-    const session = await config.sessionStorage!.loadSession(sessionId);
+    const session = await ensureValidOfflineSession(
+      params,
+      payload.shopify_domain,
+    );
 
     if (!session) {
       logger.info('Flow request could not find session', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/__tests__/authenticate.test.ts
@@ -1,15 +1,18 @@
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+import {Session} from '@shopify/shopify-api';
 
 import {AppDistribution, shopifyApp} from '../../..';
 import {
   expectAdminApiClient,
+  expectTokenRefresh,
   getHmac,
   getThrownResponse,
   setUpValidSession,
   TEST_SHOP,
   testConfig,
 } from '../../../__test-helpers';
+import {TestOverridesArg} from '../../../test-helpers/test-config';
 
 const FULFILLMENT_URL =
   'https://example.myapp.io/authenticate/fulfillment_order_notification';
@@ -131,11 +134,47 @@ const MERCHANT_CUSTOM_APP_CONFIG = {
         return {admin, expectedSession, actualSession};
       });
     });
+
+    describe('token refresh for expired offline sessions', () => {
+      expectTokenRefresh(
+        async (
+          sessionStorage: SessionStorage,
+          session: Session,
+          configOverrides: TestOverridesArg,
+        ) => {
+          const shopify = shopifyApp(
+            testConfig({
+              sessionStorage,
+              ...configOverrides,
+            }) as any,
+          );
+
+          const body = {kind: 'FULFILLMENT_REQUEST'};
+          const bodyString = JSON.stringify(body);
+
+          const request = new Request(FULFILLMENT_URL, {
+            method: 'POST',
+            body: bodyString,
+            headers: {
+              'X-Shopify-Hmac-Sha256': getHmac(bodyString),
+              'X-Shopify-Shop-Domain': session.shop,
+            },
+          });
+
+          const {session: actualSession} =
+            await shopify.authenticate.fulfillmentService(request);
+
+          return actualSession;
+        },
+      );
+    });
   });
 });
 
 async function getValidRequest(sessionStorage: SessionStorage) {
-  const session = await setUpValidSession(sessionStorage, {isOnline: false});
+  const session = await setUpValidSession(sessionStorage, {
+    isOnline: false,
+  });
 
   const body = {kind: 'FULFILLMENT_REQUEST'};
   const bodyString = JSON.stringify(body);

--- a/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/fulfillment-service/authenticate.ts
@@ -2,7 +2,7 @@ import {ShopifyHeader} from '@shopify/shopify-api';
 
 import {adminClientFactory} from '../../clients/admin';
 import {BasicParams} from '../../types';
-import {createOrLoadOfflineSession} from '../helpers';
+import {ensureValidOfflineSession} from '../../helpers';
 
 import type {
   AuthenticateFulfillmentService,
@@ -57,7 +57,7 @@ export function authenticateFulfillmentServiceFactory(
       },
     );
 
-    const session = await createOrLoadOfflineSession(shop, params);
+    const session = await ensureValidOfflineSession(params, shop);
 
     if (!session) {
       logger.info('Fulfillment service request could not find session', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/index.ts
@@ -7,5 +7,4 @@ export * from './invalidate-access-token';
 export * from './reject-bot-request';
 export * from './respond-to-options-request';
 export * from './respond-to-invalid-session-token';
-export * from './create-or-load-offline-session';
 export * from './get-shop-from-request';

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -1,4 +1,6 @@
 import {createSHA256HMAC, HashFormat} from '@shopify/shopify-api/runtime';
+import {Session} from '@shopify/shopify-api';
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
 
 import {shopifyApp} from '../../../..';
 import {
@@ -7,10 +9,12 @@ import {
   TEST_SHOP,
   expectAdminApiClient,
   expectStorefrontApiClient,
+  expectTokenRefresh,
   getThrownResponse,
   setUpValidSession,
   testConfig,
 } from '../../../../__test-helpers';
+import {TestOverridesArg} from '../../../../test-helpers/test-config';
 
 describe('authenticating app proxy requests', () => {
   it('Throws a 400 response if there is no signature param', async () => {
@@ -346,6 +350,36 @@ describe('authenticating app proxy requests', () => {
 
       return {storefront, expectedSession, actualSession};
     });
+  });
+
+  describe('Valid requests with expired offline session', () => {
+    expectTokenRefresh(
+      async (
+        sessionStorage: SessionStorage,
+        session: Session,
+        configOverrides: TestOverridesArg,
+      ) => {
+        const shopify = shopifyApp(
+          testConfig({
+            sessionStorage,
+            ...configOverrides,
+          }) as any,
+        );
+
+        const url = new URL(APP_URL);
+        url.searchParams.set('shop', session.shop);
+        url.searchParams.set('timestamp', secondsInPast(1));
+        url.searchParams.set('signature', await createAppProxyHmac(url));
+        const request = new Request(url.toString());
+
+        const context = await shopify.authenticate.public.appProxy(request);
+
+        if (!context.session) {
+          throw new Error('No session returned from app proxy authentication');
+        }
+        return context.session;
+      },
+    );
   });
 });
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -1,4 +1,5 @@
 import {adminClientFactory, storefrontClientFactory} from '../../../clients';
+import {ensureValidOfflineSession} from '../../../helpers';
 import {BasicParams} from '../../../types';
 
 import {
@@ -11,7 +12,7 @@ import {
 export function authenticateAppProxyFactory(
   params: BasicParams,
 ): AuthenticateAppProxy {
-  const {api, config, logger} = params;
+  const {logger} = params;
 
   return async function authenticate(
     request: Request,
@@ -28,8 +29,7 @@ export function authenticateAppProxyFactory(
       });
     }
 
-    const sessionId = api.session.getOfflineId(shop);
-    const session = await config.sessionStorage!.loadSession(sessionId);
+    const session = await ensureValidOfflineSession(params, shop);
 
     if (!session) {
       logger.debug('Could not find offline session, returning empty context', {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
@@ -1,15 +1,18 @@
 import {Session} from '@shopify/shopify-api';
 import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
 
 import {shopifyApp} from '../../..';
 import {
   APP_URL,
   TEST_SHOP,
   expectAdminApiClient,
+  expectTokenRefresh,
   getHmac,
   getThrownResponse,
   testConfig,
 } from '../../../__test-helpers';
+import {TestOverridesArg} from '../../../test-helpers/test-config';
 
 interface WebhookHeaders {
   [key: string]: string;
@@ -165,6 +168,41 @@ describe('Webhook validation', () => {
 
     // THEN
     expect(response.status).toBe(405);
+  });
+
+  describe('Offline token expiration handling', () => {
+    expectTokenRefresh(
+      async (
+        sessionStorage: SessionStorage,
+        session: Session,
+        configOverrides: TestOverridesArg,
+      ) => {
+        const shopify = shopifyApp(
+          testConfig({
+            sessionStorage,
+            ...configOverrides,
+          }) as any,
+        );
+
+        const body = {some: 'data'};
+        const bodyString = JSON.stringify(body);
+
+        const request = new Request(`${APP_URL}/webhooks`, {
+          method: 'POST',
+          body: bodyString,
+          headers: webhookHeaders(bodyString),
+        });
+
+        const {session: actualSession} =
+          await shopify.authenticate.webhook(request);
+
+        if (!actualSession) {
+          throw new Error('No session returned from webhook authentication');
+        }
+
+        return actualSession;
+      },
+    );
   });
 });
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
@@ -3,7 +3,7 @@ import {WebhookValidationErrorReason} from '@shopify/shopify-api';
 import type {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients';
 import {handleClientErrorFactory} from '../admin/helpers';
-import {createOrLoadOfflineSession} from '../helpers';
+import {ensureValidOfflineSession} from '../../helpers';
 
 import type {
   AuthenticateWebhook,
@@ -49,7 +49,7 @@ export function authenticateWebhookFactory<Topics extends string>(
         throw new Response(undefined, {status: 400, statusText: 'Bad Request'});
       }
     }
-    const session = await createOrLoadOfflineSession(check.domain, params);
+    const session = await ensureValidOfflineSession(params, check.domain);
     const webhookContext: WebhookContextWithoutSession<Topics> = {
       apiVersion: check.apiVersion,
       shop: check.domain,

--- a/packages/apps/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/apps/shopify-app-remix/src/server/future/flags.ts
@@ -14,11 +14,20 @@ export interface FutureFlags {
    * @default false
    */
   unstable_newEmbeddedAuthStrategy?: boolean;
+  /**
+   * When enabled, the app will start using expiring offline access tokens and automatically refresh them when they are close to expiring.
+   *
+   * @default false
+   */
+  expiringOfflineAccessTokens?: boolean;
 }
 
 // When adding new flags, use this format:
 // apiFutureFlag: Future extends FutureFlags ? Future['remixFutureFlag'] : false;
-export interface ApiFutureFlags<_Future extends FutureFlagOptions> {
+export interface ApiFutureFlags<Future extends FutureFlagOptions> {
+  expiringOfflineAccessTokens: Future extends FutureFlags
+    ? Future['expiringOfflineAccessTokens']
+    : false;
   unstable_managedPricingSupport: true;
 }
 

--- a/packages/apps/shopify-app-remix/src/server/helpers/__tests__/ensure-offline-token-is-not-expired.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/__tests__/ensure-offline-token-is-not-expired.test.ts
@@ -1,0 +1,32 @@
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
+
+import {testConfig} from '../../__test-helpers';
+import {expectTokenRefresh} from '../../__test-helpers/expect-token-refresh';
+import {AppConfigArg} from '../../config-types';
+import {deriveApi} from '../../shopify-app';
+import {BasicParams} from '../../types';
+import {
+  ensureOfflineTokenIsNotExpired,
+  WITHIN_MILLISECONDS_OF_EXPIRY,
+} from '../ensure-offline-token-is-not-expired';
+import {FutureFlagOptions} from '../../future/flags';
+
+describe('ensureOfflineTokenIsNotExpired', () => {
+  it('uses 5 minutes for WITHIN_MILLISECONDS_OF_EXPIRY', async () => {
+    expect(WITHIN_MILLISECONDS_OF_EXPIRY).toBe(5 * 60 * 1000);
+  });
+  expectTokenRefresh(async (sessionStorage, session, configOverrides) => {
+    const config = testConfig({
+      sessionStorage,
+      ...configOverrides,
+    }) as AppConfigArg<SessionStorage, FutureFlagOptions>;
+    const api = deriveApi(config);
+    const params = {
+      api,
+      config,
+      logger: api.logger,
+    } as unknown as BasicParams;
+
+    return ensureOfflineTokenIsNotExpired(session, params, session.shop);
+  });
+});

--- a/packages/apps/shopify-app-remix/src/server/helpers/__tests__/ensure-valid-offline-session.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/__tests__/ensure-valid-offline-session.test.ts
@@ -1,0 +1,78 @@
+import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+import {SessionStorage} from '@shopify/shopify-app-session-storage';
+
+import {testConfig, TEST_SHOP} from '../../__test-helpers';
+import {expectTokenRefresh} from '../../__test-helpers/expect-token-refresh';
+import {deriveApi} from '../../shopify-app';
+import {AppDistribution, BasicParams} from '../../types';
+import {ensureValidOfflineSession} from '../ensure-valid-offline-session';
+import {AppConfigArg} from '../../config-types';
+import {FutureFlagOptions} from '../../future/flags';
+
+describe('ensureValidOfflineSession', () => {
+  let sessionStorage: MemorySessionStorage;
+  let params: BasicParams;
+  let mockRefreshToken: jest.Mock;
+
+  describe('when no session exists', () => {
+    beforeEach(() => {
+      sessionStorage = new MemorySessionStorage();
+      const config = testConfig({sessionStorage});
+
+      mockRefreshToken = jest.fn();
+
+      // Create api using deriveApi
+      const api = deriveApi(config);
+
+      // Create params with mocked api.auth.refreshToken
+      params = {
+        api: {
+          ...api,
+          auth: {
+            ...api.auth,
+            refreshToken: mockRefreshToken,
+          },
+        },
+        config,
+        logger: api.logger,
+      } as unknown as BasicParams;
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns undefined when session storage is empty', async () => {
+      // GIVEN
+      params.config.distribution = AppDistribution.AppStore;
+
+      // WHEN
+      const result = await ensureValidOfflineSession(params, TEST_SHOP);
+
+      // THEN
+      expect(result).toBeUndefined();
+      expect(mockRefreshToken).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when session exists', () => {
+    expectTokenRefresh(async (sessionStorage, session, configOverrides) => {
+      const config = testConfig({
+        sessionStorage,
+        ...configOverrides,
+      }) as AppConfigArg<SessionStorage, FutureFlagOptions>;
+      const api = deriveApi(config);
+      const params = {
+        api,
+        config,
+        logger: api.logger,
+      } as unknown as BasicParams;
+
+      const result = await ensureValidOfflineSession(params, session.shop);
+      if (!result) {
+        throw new Error('Session not found');
+      }
+      return result;
+    });
+  });
+});

--- a/packages/apps/shopify-app-remix/src/server/helpers/__tests__/refresh-token.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/__tests__/refresh-token.test.ts
@@ -1,0 +1,168 @@
+import {HttpResponseError, InvalidJwtError} from '@shopify/shopify-api';
+import {setUpValidSession as setUpValidSessionImport} from '@shopify/shopify-api/test-helpers';
+import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory';
+
+import {testConfig, TEST_SHOP} from '../../__test-helpers';
+import {deriveApi} from '../../shopify-app';
+import {BasicParams} from '../../types';
+import refreshToken from '../refresh-token';
+
+describe('refreshToken', () => {
+  let sessionStorage: MemorySessionStorage;
+  let params: BasicParams;
+  let mockRefreshToken: jest.Mock;
+
+  beforeEach(() => {
+    sessionStorage = new MemorySessionStorage();
+    const config = testConfig({sessionStorage});
+
+    mockRefreshToken = jest.fn();
+
+    // Create api using deriveApi
+    const api = deriveApi(config);
+
+    // Create params with mocked api.auth.refreshToken
+    params = {
+      api: {
+        ...api,
+        auth: {
+          ...api.auth,
+          refreshToken: mockRefreshToken,
+        },
+      },
+      config,
+      logger: api.logger,
+    } as unknown as BasicParams;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('refreshToken', () => {
+    it('successfully refreshes a token and returns a session', async () => {
+      // GIVEN
+      const refreshTokenValue = 'test-refresh-token';
+      const newSession = setUpValidSessionImport({
+        shop: TEST_SHOP,
+        expires: new Date(Date.now() + 86400000),
+        refreshToken: 'new-refresh-token',
+        isOnline: false,
+        accessToken: 'new-access-token',
+      });
+
+      mockRefreshToken.mockResolvedValue({session: newSession});
+
+      // WHEN
+      const result = await refreshToken(params, TEST_SHOP, refreshTokenValue);
+
+      // THEN
+      expect(result).toBeDefined();
+      expect(result.accessToken).toBe('new-access-token');
+      expect(result.refreshToken).toBe('new-refresh-token');
+      expect(mockRefreshToken).toHaveBeenCalledWith({
+        shop: TEST_SHOP,
+        refreshToken: refreshTokenValue,
+      });
+    });
+
+    describe('error handling', () => {
+      it('rethrows InvalidJwtError', async () => {
+        // GIVEN
+        const refreshTokenValue = 'invalid-jwt-refresh-token';
+        const jwtError = new InvalidJwtError('Invalid JWT token');
+
+        mockRefreshToken.mockRejectedValue(jwtError);
+
+        // WHEN & THEN
+        await expect(
+          refreshToken(params, TEST_SHOP, refreshTokenValue),
+        ).rejects.toThrow(InvalidJwtError);
+
+        expect(mockRefreshToken).toHaveBeenCalledWith({
+          shop: TEST_SHOP,
+          refreshToken: refreshTokenValue,
+        });
+      });
+
+      it('rethrows HttpResponseError with code 400 and error "invalid_subject_token"', async () => {
+        // GIVEN
+        const refreshTokenValue = 'invalid-subject-token';
+        const httpError = new HttpResponseError({
+          message: 'Invalid subject token',
+          code: 400,
+          statusText: 'Bad Request',
+          body: {error: 'invalid_subject_token'},
+        });
+
+        mockRefreshToken.mockRejectedValue(httpError);
+
+        // WHEN & THEN
+        await expect(
+          refreshToken(params, TEST_SHOP, refreshTokenValue),
+        ).rejects.toThrow(HttpResponseError);
+
+        const error = await refreshToken(
+          params,
+          TEST_SHOP,
+          refreshTokenValue,
+        ).catch((err) => err);
+
+        expect(error).toBeInstanceOf(HttpResponseError);
+        expect(error.response.code).toBe(400);
+        expect(error.response.body?.error).toBe('invalid_subject_token');
+      });
+
+      it('throws Response with status 500 for HttpResponseError with code 500', async () => {
+        // GIVEN
+        const refreshTokenValue = 'server-error-token';
+        const httpError = new HttpResponseError({
+          message: 'Internal Server Error',
+          code: 500,
+          statusText: 'Internal Server Error',
+          body: {error: 'server_error'},
+        });
+
+        mockRefreshToken.mockRejectedValue(httpError);
+
+        // WHEN & THEN
+        await expect(
+          refreshToken(params, TEST_SHOP, refreshTokenValue),
+        ).rejects.toBeInstanceOf(Response);
+
+        const error = await refreshToken(
+          params,
+          TEST_SHOP,
+          refreshTokenValue,
+        ).catch((err) => err);
+
+        expect(error).toBeInstanceOf(Response);
+        expect(error.status).toBe(500);
+        expect(error.statusText).toBe('Internal Server Error');
+      });
+
+      it('throws Response with status 500 for generic errors', async () => {
+        // GIVEN
+        const refreshTokenValue = 'generic-error-token';
+        const genericError = new Error('Something went wrong');
+
+        mockRefreshToken.mockRejectedValue(genericError);
+
+        // WHEN & THEN
+        await expect(
+          refreshToken(params, TEST_SHOP, refreshTokenValue),
+        ).rejects.toBeInstanceOf(Response);
+
+        const error = await refreshToken(
+          params,
+          TEST_SHOP,
+          refreshTokenValue,
+        ).catch((err) => err);
+
+        expect(error).toBeInstanceOf(Response);
+        expect(error.status).toBe(500);
+        expect(error.statusText).toBe('Internal Server Error');
+      });
+    });
+  });
+});

--- a/packages/apps/shopify-app-remix/src/server/helpers/create-or-load-offline-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/create-or-load-offline-session.ts
@@ -1,8 +1,8 @@
-import {AppDistribution, BasicParams} from '../../types';
+import {AppDistribution, BasicParams} from '../types';
 
 export async function createOrLoadOfflineSession(
-  shop: string,
   {api, config, logger}: BasicParams,
+  shop: string,
 ) {
   if (config.distribution === AppDistribution.ShopifyAdmin) {
     logger.debug('Creating custom app session from configured access token', {

--- a/packages/apps/shopify-app-remix/src/server/helpers/ensure-offline-token-is-not-expired.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/ensure-offline-token-is-not-expired.ts
@@ -1,0 +1,32 @@
+import {Session} from '@shopify/shopify-api';
+
+import {AppDistribution, BasicParams} from '../types';
+
+import refreshToken from './refresh-token';
+
+// 5 minutes
+export const WITHIN_MILLISECONDS_OF_EXPIRY = 5 * 60 * 1000;
+
+export async function ensureOfflineTokenIsNotExpired(
+  session: Session,
+  params: BasicParams,
+  shop: string,
+) {
+  const {config} = params;
+  if (
+    config.future?.expiringOfflineAccessTokens &&
+    session.isExpired(WITHIN_MILLISECONDS_OF_EXPIRY) &&
+    config.distribution !== AppDistribution.ShopifyAdmin &&
+    session.refreshToken
+  ) {
+    const offlineSession = await refreshToken(
+      params,
+      shop,
+      session.refreshToken,
+    );
+
+    await config.sessionStorage!.storeSession(offlineSession);
+    return offlineSession;
+  }
+  return session;
+}

--- a/packages/apps/shopify-app-remix/src/server/helpers/ensure-valid-offline-session.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/ensure-valid-offline-session.ts
@@ -1,0 +1,15 @@
+import {BasicParams} from '../types';
+
+import {createOrLoadOfflineSession} from './create-or-load-offline-session';
+import {ensureOfflineTokenIsNotExpired} from './ensure-offline-token-is-not-expired';
+
+export async function ensureValidOfflineSession(
+  params: BasicParams,
+  shop: string,
+) {
+  const session = await createOrLoadOfflineSession(params, shop);
+
+  if (!session) return undefined;
+
+  return ensureOfflineTokenIsNotExpired(session, params, shop);
+}

--- a/packages/apps/shopify-app-remix/src/server/helpers/index.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/index.ts
@@ -1,0 +1,4 @@
+export * from './ensure-valid-offline-session';
+export * from './ensure-offline-token-is-not-expired';
+export * from './create-or-load-offline-session';
+export * from './refresh-token';

--- a/packages/apps/shopify-app-remix/src/server/helpers/refresh-token.ts
+++ b/packages/apps/shopify-app-remix/src/server/helpers/refresh-token.ts
@@ -1,0 +1,35 @@
+import {
+  HttpResponseError,
+  InvalidJwtError,
+  Session,
+} from '@shopify/shopify-api';
+
+import {BasicParams} from '../types';
+
+export default async function refreshToken(
+  params: BasicParams,
+  shop: string,
+  refreshToken: string,
+): Promise<Session> {
+  const {api} = params;
+  try {
+    const {session} = await api.auth.refreshToken({
+      shop,
+      refreshToken,
+    });
+    return session;
+  } catch (error) {
+    if (
+      error instanceof InvalidJwtError ||
+      (error instanceof HttpResponseError &&
+        error.response.code === 400 &&
+        error.response.body?.error === 'invalid_subject_token')
+    ) {
+      throw error;
+    }
+    throw new Response(undefined, {
+      status: 500,
+      statusText: 'Internal Server Error',
+    });
+  }
+}

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/__tests__/factory.test.ts
@@ -1,6 +1,7 @@
 import {
   TEST_SHOP,
   expectAdminApiClient,
+  expectTokenRefresh,
   setUpValidSession,
   setupValidCustomAppSession,
   testConfig,
@@ -31,6 +32,20 @@ describe('unauthenticated admin context', () => {
       await shopify.unauthenticated.admin(TEST_SHOP);
 
     return {admin, expectedSession, actualSession};
+  });
+
+  expectTokenRefresh(async (sessionStorage, session, configOverrides) => {
+    const shopify = shopifyApp(
+      testConfig({
+        sessionStorage,
+        ...configOverrides,
+      }) as any,
+    );
+    await shopify.sessionStorage!.storeSession(session);
+
+    const {session: actualSession} =
+      await shopify.unauthenticated.admin(TEST_SHOP);
+    return actualSession;
   });
 });
 

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/admin/factory.ts
@@ -1,4 +1,4 @@
-import {createOrLoadOfflineSession} from '../../authenticate/helpers/create-or-load-offline-session';
+import {ensureValidOfflineSession} from '../../helpers';
 import {SessionNotFoundError} from '../../errors';
 import {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients/admin';
@@ -7,7 +7,7 @@ import {UnauthenticatedAdminContext} from './types';
 
 export function unauthenticatedAdminContextFactory(params: BasicParams) {
   return async (shop: string): Promise<UnauthenticatedAdminContext> => {
-    const session = await createOrLoadOfflineSession(shop, params);
+    const session = await ensureValidOfflineSession(params, shop);
 
     if (!session) {
       throw new SessionNotFoundError(

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/__tests__/factory.test.ts
@@ -4,6 +4,7 @@ import {
   setUpValidSession,
   testConfig,
   expectStorefrontApiClient,
+  expectTokenRefresh,
   setupValidCustomAppSession,
 } from '../../../__test-helpers';
 
@@ -27,6 +28,20 @@ describe('unauthenticated storefront context', () => {
       await shopify.unauthenticated.storefront(TEST_SHOP);
 
     return {storefront, expectedSession, actualSession};
+  });
+
+  expectTokenRefresh(async (sessionStorage, session, configOverrides) => {
+    const shopify = shopifyApp(
+      testConfig({
+        sessionStorage,
+        ...configOverrides,
+      }) as any,
+    );
+    await shopify.sessionStorage!.storeSession(session);
+
+    const {session: actualSession} =
+      await shopify.unauthenticated.storefront(TEST_SHOP);
+    return actualSession;
   });
 });
 

--- a/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
+++ b/packages/apps/shopify-app-remix/src/server/unauthenticated/storefront/factory.ts
@@ -1,7 +1,7 @@
-import {createOrLoadOfflineSession} from '../../authenticate/helpers/create-or-load-offline-session';
 import {SessionNotFoundError} from '../../errors';
 import {BasicParams} from '../../types';
 import {storefrontClientFactory} from '../../clients/storefront';
+import {ensureValidOfflineSession} from '../../helpers';
 
 import {
   UnauthenticatedStorefrontContext,
@@ -12,7 +12,7 @@ export function unauthenticatedStorefrontContextFactory(
   params: BasicParams,
 ): GetUnauthenticatedStorefrontContext {
   return async (shop: string): Promise<UnauthenticatedStorefrontContext> => {
-    const session = await createOrLoadOfflineSession(shop, params);
+    const session = await ensureValidOfflineSession(params, shop);
 
     if (!session) {
       throw new SessionNotFoundError(


### PR DESCRIPTION
### WHY are these changes introduced?

To enhance security by supporting expiring offline access tokens, which require refreshing after a limited lifetime instead of remaining valid indefinitely.

### WHAT is this pull request doing?

- Adds support for expiring offline access tokens via a new `expiringOfflineAccessTokens` future flag
- Implements automatic token refreshing when tokens are expired or close to expiring
- Creates helper functions to manage offline session tokens and their refresh lifecycle
- Updates documentation with instructions for enabling this feature
- Adds comprehensive test coverage for the new token refresh functionality

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)