### PR TITLE
Fix generated import extensions to use .js for TypeScript compatibility

### DIFF
--- a/.changeset/fix-codegen-import-extension.md
+++ b/.changeset/fix-codegen-import-extension.md
@@ -1,0 +1,5 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+Fixed TypeScript compilation error (ts5097) for users without `allowImportingTsExtensions` by using `.js` extensions for generated import paths. The `.js` extension works across all TypeScript module resolution strategies.

--- a/packages/api-clients/api-codegen-preset/src/preset.ts
+++ b/packages/api-clients/api-codegen-preset/src/preset.ts
@@ -3,7 +3,6 @@ import {preset as hydrogenPreset} from '@shopify/graphql-codegen';
 
 import {type ShopifyApiPresetConfig} from './types';
 import {apiConfigs} from './helpers/api-configs';
-import {getOutputFiles} from './helpers/get-output-files';
 
 export const preset: Types.OutputPreset<ShopifyApiPresetConfig> = {
   buildGeneratesSection: (options) => {
@@ -11,11 +10,8 @@ export const preset: Types.OutputPreset<ShopifyApiPresetConfig> = {
 
     const {interfaceExtension, module, presetConfigs} = apiConfigs[apiType];
 
-    // Determine if the output file is a declaration file
-    const isDts = options.baseOutputDir.endsWith('.d.ts');
-
-    // Get the correct filename with extension (.d.ts or .ts)
-    const {typesFile} = getOutputFiles(apiType, isDts);
+    // Use .js extension for import paths - TypeScript resolves these to .ts/.d.ts files
+    const typesFile = `${apiConfigs[apiType].typesFile}.js`;
 
     return hydrogenPreset.buildGeneratesSection({
       ...options,

--- a/packages/api-clients/api-codegen-preset/src/tests/preset.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/preset.test.ts
@@ -34,7 +34,7 @@ describe('Preset', () => {
 
     // Imports Admin API
     expect(generatedCode).toMatch(
-      `import type * as AdminTypes from './admin.types.d.ts';`,
+      `import type * as AdminTypes from './admin.types.js';`,
     );
 
     // Uses Pick<...>
@@ -59,7 +59,7 @@ describe('Preset', () => {
       .toBe(`/* eslint-disable eslint-comments/disable-enable-pair */
 /* eslint-disable eslint-comments/no-unlimited-disable */
 /* eslint-disable */
-import type * as AdminTypes from './admin.types.d.ts';
+import type * as AdminTypes from './admin.types.js';
 
 export type TestQueryQueryVariables = AdminTypes.Exact<{ [key: string]: never; }>;
 
@@ -100,11 +100,11 @@ declare module '@shopify/admin-api-client' {
     )!.content;
 
     expect(generatedCode).toMatch(
-      "import type * as AdminTypes from './admin.types.d.ts';",
+      "import type * as AdminTypes from './admin.types.js';",
     );
   });
 
-  it('imports regular files when using .ts targets', async () => {
+  it('imports .js extension for all output targets', async () => {
     const {result} = await executeCodegen(
       getCodegenOptions('operations.ts', 'out.ts'),
     );
@@ -116,7 +116,7 @@ declare module '@shopify/admin-api-client' {
     )!.content;
 
     expect(generatedCode).toMatch(
-      "import * as AdminTypes from './admin.types.ts';",
+      "import * as AdminTypes from './admin.types.js';",
     );
   });
 });


### PR DESCRIPTION
PR #2889 introduced .ts/.d.ts import extensions which broke compilation for users without allowImportingTsExtensions enabled in their tsconfig

Uses .js extensions which TypeScript resolves to .ts/.d.ts files during compilation, working across all module resolution strategies without requiring special tsconfig options

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #0000 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
