### PR TITLE
Add Cluade skills for broken dependabot PR's for major upgrades

### DIFF
--- a/.claude/commands/dependabot/fix-broken-major-upgrade.md
+++ b/.claude/commands/dependabot/fix-broken-major-upgrade.md
@@ -2,7 +2,7 @@
 description: Process a major Dependabot PR: research breaking changes, apply fixes, validate CI
 argument-hint: [pr-url]
 model: opus
-allowed-tools: Task, AskUserQuestion, Read, Edit, Write, Glob, Grep, Bash(git *), Bash(gh *), Bash(pnpm *), Bash(npx *), Bash(ls *), Bash(cat *), Bash(timeout *), Bash(node *), Bash(wc *), WebFetch, WebSearch
+allowed-tools: Task, AskUserQuestion, Read, Edit, Write, Glob, Grep, Bash(git *), Bash(gh *), Bash(pnpm *), Bash(npx *), Bash(ls *), Bash(timeout *), Bash(node *), Bash(wc *), WebFetch, WebSearch
 ---
 
 # Dependency Upgrade Workflow
@@ -103,7 +103,7 @@ After the Planner completes, check the plan for merge conflicts.
    - List all conflicted files
    - Open each conflicted file and resolve the conflict markers by understanding both sides:
      - For **dependency version conflicts** (package.json): keep the Dependabot version bump while incorporating any unrelated changes from main
-     - For **lock files** (pnpm-lock.yaml, yarn.lock): after resolving package.json, delete the lock file and run `pnpm install` to regenerate it
+     - For **lock files** (pnpm-lock.yaml): after resolving package.json, delete the lock file and run `pnpm install` to regenerate it
      - For **source code conflicts**: merge both sides logically, preserving the intent of both the Dependabot change and the main branch changes
      - For **changeset or config conflicts**: incorporate changes from both sides
    - Stage all resolved files with `git add`

--- a/.claude/commands/dependabot/list-broken-major-upgrades.md
+++ b/.claude/commands/dependabot/list-broken-major-upgrades.md
@@ -1,6 +1,6 @@
 ---
 description: List open Dependabot PRs with major version bumps where CI is failing
-model: opus
+model: sonnet
 allowed-tools: Bash(gh *)
 ---
 


### PR DESCRIPTION
### WHY are these changes introduced?

Dependabot PR's for major upgrades often stay un merged for a long time. We don't want that

### WHAT is this pull request doing?

Add 2 skills:

1. `/dependabot:list-broken-major-upgrade` for getting a list of dependabot PR's for major changes that have broken CI
2. `/dependabot:fix-broken-major-upgrade [PR_URL]` for fixing a dependabot PR for major a changes that has broken CI

The fix skill has 3 stages.  The planner:

- Rebases the branch if needed.
- Looks at the PR, upgrade guides, chanelog, release notes and broken CI step logs
- Decides what the consumer impact is.
- Creates a plan

The implementor

- Fixes the PR
- Runs build, lint & test steps locally & iterates on failures
- Pushes the changes & waits for CI.  Iterates on failures.

The QA Reviewer:

- Checks changes match the plan
- Checks for consumer facing breaking changes, regressions, completness & code quality
- Presents a summary of the changes to the user

## Type of change

N/A (Internal tool only):

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

N/A (Internal tool only):

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
