### PR TITLE
test: make refresh token tests run by default in batteryOfTests

### DIFF
--- a/.changeset/remove-refresh-token-test-param.md
+++ b/.changeset/remove-refresh-token-test-param.md
@@ -1,0 +1,19 @@
+---
+'@shopify/shopify-app-session-storage-test-utils': major
+---
+
+BREAKING: batteryOfTests now always tests refresh token functionality
+
+The optional `testRefreshTokens` parameter has been removed from `batteryOfTests`. Refresh token tests now run by default for all session storage adapters.
+
+**Migration:** Remove the third parameter from any `batteryOfTests` calls:
+
+```typescript
+// Before
+batteryOfTests(async () => storage, false, true);
+
+// After
+batteryOfTests(async () => storage);
+```
+
+All session storage adapters are now required to support refresh token storage.

--- a/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/battery-of-tests.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/battery-of-tests.ts
@@ -8,7 +8,6 @@ const testScopes = ['test_scope'];
 export function batteryOfTests(
   storageFactory: () => Promise<SessionStorage>,
   testUserInfo = false,
-  testRefreshTokens = false,
 ) {
   it('can store and delete all kinds of sessions', async () => {
     const sessionFactories = [
@@ -341,61 +340,59 @@ export function batteryOfTests(
     expect(session.equals(storedSession)).toBeTruthy();
   });
 
-  if (testRefreshTokens) {
-    it('can store and delete sessions with refresh tokens', async () => {
-      const storage = await storageFactory();
-      const sessionId = 'test_refresh_token_session';
+  it('can store and delete sessions with refresh tokens', async () => {
+    const storage = await storageFactory();
+    const sessionId = 'test_refresh_token_session';
 
-      // Test session with refresh token only
-      const sessionWithRefreshToken = new Session({
-        id: sessionId,
-        shop: 'shop',
-        state: 'state',
-        isOnline: false,
-        scope: testScopes.toString(),
-        accessToken: 'access_token_123',
-        refreshToken: 'refresh_token_456',
-      });
-
-      await expect(
-        storage.storeSession(sessionWithRefreshToken),
-      ).resolves.toBeTruthy();
-      let storedSession = await storage.loadSession(sessionId);
-      expect(sessionWithRefreshToken.equals(storedSession)).toBeTruthy();
-      expect(storedSession?.refreshToken).toBe('refresh_token_456');
-      expect(storedSession?.refreshTokenExpires).toBeUndefined();
-
-      // Test session with refresh token and expiry
-      const refreshTokenExpiryDate = new Date();
-      refreshTokenExpiryDate.setMilliseconds(0);
-      refreshTokenExpiryDate.setDate(refreshTokenExpiryDate.getDate() + 30);
-
-      const sessionWithRefreshTokenAndExpiry = new Session({
-        id: sessionId,
-        shop: 'shop',
-        state: 'state',
-        isOnline: false,
-        scope: testScopes.toString(),
-        accessToken: 'access_token_789',
-        refreshToken: 'refresh_token_abc',
-        refreshTokenExpires: refreshTokenExpiryDate,
-      });
-
-      await expect(
-        storage.storeSession(sessionWithRefreshTokenAndExpiry),
-      ).resolves.toBeTruthy();
-      storedSession = await storage.loadSession(sessionId);
-      expect(
-        sessionWithRefreshTokenAndExpiry.equals(storedSession),
-      ).toBeTruthy();
-      expect(storedSession?.refreshToken).toBe('refresh_token_abc');
-      expect(storedSession?.refreshTokenExpires).toEqual(
-        refreshTokenExpiryDate,
-      );
-
-      // Clean up
-      await expect(storage.deleteSession(sessionId)).resolves.toBeTruthy();
-      await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
+    // Test session with refresh token only
+    const sessionWithRefreshToken = new Session({
+      id: sessionId,
+      shop: 'shop',
+      state: 'state',
+      isOnline: false,
+      scope: testScopes.toString(),
+      accessToken: 'access_token_123',
+      refreshToken: 'refresh_token_456',
     });
-  }
+
+    await expect(
+      storage.storeSession(sessionWithRefreshToken),
+    ).resolves.toBeTruthy();
+    let storedSession = await storage.loadSession(sessionId);
+    expect(sessionWithRefreshToken.equals(storedSession)).toBeTruthy();
+    expect(storedSession?.refreshToken).toBe('refresh_token_456');
+    expect(storedSession?.refreshTokenExpires).toBeUndefined();
+
+    // Test session with refresh token and expiry
+    const refreshTokenExpiryDate = new Date();
+    refreshTokenExpiryDate.setMilliseconds(0);
+    refreshTokenExpiryDate.setDate(refreshTokenExpiryDate.getDate() + 30);
+
+    const sessionWithRefreshTokenAndExpiry = new Session({
+      id: sessionId,
+      shop: 'shop',
+      state: 'state',
+      isOnline: false,
+      scope: testScopes.toString(),
+      accessToken: 'access_token_789',
+      refreshToken: 'refresh_token_abc',
+      refreshTokenExpires: refreshTokenExpiryDate,
+    });
+
+    await expect(
+      storage.storeSession(sessionWithRefreshTokenAndExpiry),
+    ).resolves.toBeTruthy();
+    storedSession = await storage.loadSession(sessionId);
+    expect(
+      sessionWithRefreshTokenAndExpiry.equals(storedSession),
+    ).toBeTruthy();
+    expect(storedSession?.refreshToken).toBe('refresh_token_abc');
+    expect(storedSession?.refreshTokenExpires).toEqual(
+      refreshTokenExpiryDate,
+    );
+
+    // Clean up
+    await expect(storage.deleteSession(sessionId)).resolves.toBeTruthy();
+    await expect(storage.loadSession(sessionId)).resolves.toBeUndefined();
+  });
 }


### PR DESCRIPTION
## Summary

**BREAKING CHANGE:** Removes the optional `testRefreshTokens` parameter from `batteryOfTests` and makes refresh token tests run by default for all session storage adapters.

## Changes

- Removed `testRefreshTokens` parameter from `batteryOfTests` function signature
- Removed conditional wrapper around refresh token tests - they now always run
- Added new changeset with **major** version bump to reflect the breaking API change

## Why

After all storage adapters have been updated to support refresh tokens, the optional parameter is no longer needed. Making refresh token tests run by default ensures:

- All storage adapters consistently support refresh tokens
- No adapter can accidentally skip refresh token tests
- Simpler API - one less parameter to think about

## Migration

Remove the third parameter from any `batteryOfTests` calls:

```typescript
// Before
batteryOfTests(async () => storage, false, true);

// After
batteryOfTests(async () => storage);
```

## Test Plan

All existing tests should pass since no adapters are currently passing `true` for the third parameter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)