### PR TITLE
Fix missing forwardRef in AppProxyForm and AppProxyLink

### DIFF
--- a/.changeset/fix-appproxy-forwardref.md
+++ b/.changeset/fix-appproxy-forwardref.md
@@ -1,0 +1,9 @@
+---
+'@shopify/shopify-app-remix': patch
+'@shopify/shopify-app-react-router': patch
+---
+
+Forward refs in AppProxyForm and AppProxyLink components
+
+`AppProxyForm` and `AppProxyLink` now use `forwardRef`, allowing consumers to
+attach a ref to the underlying DOM element (e.g. `form.current.submit()`).

--- a/.changeset/fix-appproxy-react-router-forwardref.md
+++ b/.changeset/fix-appproxy-react-router-forwardref.md
@@ -1,0 +1,6 @@
+---
+'@shopify/shopify-app-react-router': patch
+---
+
+`AppProxyLink` now uses `forwardRef`, allowing consumers to attach a ref to the
+underlying `<a>` element (e.g. `anchor.current.focus()`).

--- a/.changeset/fix-appproxy-remix-forwardref.md
+++ b/.changeset/fix-appproxy-remix-forwardref.md
@@ -1,9 +1,6 @@
 ---
 '@shopify/shopify-app-remix': patch
-'@shopify/shopify-app-react-router': patch
 ---
-
-Forward refs in AppProxyForm and AppProxyLink components
 
 `AppProxyForm` and `AppProxyLink` now use `forwardRef`, allowing consumers to
 attach a ref to the underlying DOM element (e.g. `form.current.submit()`).

--- a/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/AppProxyLink.tsx
+++ b/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/AppProxyLink.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {forwardRef, useContext} from 'react';
 
 import {AppProxyProviderContext} from '../AppProxyProvider';
 
@@ -40,20 +40,22 @@ export interface AppProxyLinkProps extends React.DetailedHTMLProps<
  * ```
  * @publicDocs
  */
-export function AppProxyLink(props: AppProxyLinkProps) {
-  const context = useContext(AppProxyProviderContext);
+export const AppProxyLink = forwardRef<HTMLAnchorElement, AppProxyLinkProps>(
+  function AppProxyLink(props, ref) {
+    const context = useContext(AppProxyProviderContext);
 
-  if (!context) {
-    throw new Error(
-      'AppProxyLink must be used within an AppProxyProvider component',
+    if (!context) {
+      throw new Error(
+        'AppProxyLink must be used within an AppProxyProvider component',
+      );
+    }
+
+    const {children, href, ...otherProps} = props;
+
+    return (
+      <a href={context.formatUrl(href)} {...otherProps} ref={ref}>
+        {children}
+      </a>
     );
-  }
-
-  const {children, href, ...otherProps} = props;
-
-  return (
-    <a href={context.formatUrl(href)} {...otherProps}>
-      {children}
-    </a>
-  );
-}
+  },
+);

--- a/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
+++ b/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
@@ -1,3 +1,4 @@
+import {createRef} from 'react';
 import {mount} from '@shopify/react-testing';
 
 import '../../../__tests__/test-helper';
@@ -44,5 +45,20 @@ describe('<AppProxyLink />', () => {
       href: 'http://localhost/my-action/',
     });
     expect(component).toContainReactHtml('Hello world');
+  });
+
+  it('forwards ref to the underlying anchor element', () => {
+    // GIVEN
+    const ref = createRef<HTMLAnchorElement>();
+
+    // WHEN
+    mount(
+      <AppProxyProvider appUrl="http://my-app.example.io">
+        <AppProxyLink ref={ref} href="/my-action">Hello world</AppProxyLink>
+      </AppProxyProvider>,
+    );
+
+    // THEN
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
   });
 });

--- a/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
+++ b/packages/apps/shopify-app-react-router/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
@@ -54,7 +54,9 @@ describe('<AppProxyLink />', () => {
     // WHEN
     mount(
       <AppProxyProvider appUrl="http://my-app.example.io">
-        <AppProxyLink ref={ref} href="/my-action">Hello world</AppProxyLink>
+        <AppProxyLink ref={ref} href="/my-action">
+          Hello world
+        </AppProxyLink>
       </AppProxyProvider>,
     );
 

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/AppProxyForm.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/AppProxyForm.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {forwardRef, useContext} from 'react';
 import {Form, type FormProps} from '@remix-run/react';
 
 import {AppProxyProviderContext} from '../AppProxyProvider';
@@ -64,20 +64,22 @@ export interface AppProxyFormProps extends FormProps {
  * ```
  * @publicDocs
  */
-export function AppProxyForm(props: AppProxyFormProps) {
-  const context = useContext(AppProxyProviderContext);
+export const AppProxyForm = forwardRef<HTMLFormElement, AppProxyFormProps>(
+  function AppProxyForm(props, ref) {
+    const context = useContext(AppProxyProviderContext);
 
-  if (!context) {
-    throw new Error(
-      'AppProxyForm must be used within an AppProxyProvider component',
+    if (!context) {
+      throw new Error(
+        'AppProxyForm must be used within an AppProxyProvider component',
+      );
+    }
+
+    const {children, action, ...otherProps} = props;
+
+    return (
+      <Form action={context.formatUrl(action, false)} {...otherProps} ref={ref}>
+        {children}
+      </Form>
     );
-  }
-
-  const {children, action, ...otherProps} = props;
-
-  return (
-    <Form action={context.formatUrl(action, false)} {...otherProps}>
-      {children}
-    </Form>
-  );
-}
+  },
+);

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/__tests__/AppProxyForm.test.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/__tests__/AppProxyForm.test.tsx
@@ -61,7 +61,9 @@ describe('<AppProxyForm />', () => {
     function MyComponent() {
       return (
         <AppProxyProvider appUrl="http://my-app.example.io">
-          <AppProxyForm ref={ref} action="/my-action">Hello world</AppProxyForm>
+          <AppProxyForm ref={ref} action="/my-action">
+            Hello world
+          </AppProxyForm>
         </AppProxyProvider>
       );
     }

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/__tests__/AppProxyForm.test.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyForm/__tests__/AppProxyForm.test.tsx
@@ -1,3 +1,4 @@
+import {createRef} from 'react';
 import {mount} from '@shopify/react-testing';
 import {createRemixStub} from '@remix-run/testing';
 
@@ -51,5 +52,25 @@ describe('<AppProxyForm />', () => {
     // THEN
     expect(component).toContainReactComponent('form', {action: '/my-action/'});
     expect(component).toContainReactHtml('Hello world');
+  });
+
+  it('forwards ref to the underlying form element', () => {
+    // GIVEN
+    const ref = createRef<HTMLFormElement>();
+
+    function MyComponent() {
+      return (
+        <AppProxyProvider appUrl="http://my-app.example.io">
+          <AppProxyForm ref={ref} action="/my-action">Hello world</AppProxyForm>
+        </AppProxyProvider>
+      );
+    }
+
+    // WHEN
+    const RemixStub = createRemixStub([{path: '/', Component: MyComponent}]);
+    mount(<RemixStub />);
+
+    // THEN
+    expect(ref.current).toBeInstanceOf(HTMLFormElement);
   });
 });

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/AppProxyLink.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/AppProxyLink.tsx
@@ -1,4 +1,4 @@
-import {useContext} from 'react';
+import {forwardRef, useContext} from 'react';
 
 import {AppProxyProviderContext} from '../AppProxyProvider';
 
@@ -40,20 +40,22 @@ export interface AppProxyLinkProps extends React.DetailedHTMLProps<
  * ```
  * @publicDocs
  */
-export function AppProxyLink(props: AppProxyLinkProps) {
-  const context = useContext(AppProxyProviderContext);
+export const AppProxyLink = forwardRef<HTMLAnchorElement, AppProxyLinkProps>(
+  function AppProxyLink(props, ref) {
+    const context = useContext(AppProxyProviderContext);
 
-  if (!context) {
-    throw new Error(
-      'AppProxyLink must be used within an AppProxyProvider component',
+    if (!context) {
+      throw new Error(
+        'AppProxyLink must be used within an AppProxyProvider component',
+      );
+    }
+
+    const {children, href, ...otherProps} = props;
+
+    return (
+      <a href={context.formatUrl(href)} {...otherProps} ref={ref}>
+        {children}
+      </a>
     );
-  }
-
-  const {children, href, ...otherProps} = props;
-
-  return (
-    <a href={context.formatUrl(href)} {...otherProps}>
-      {children}
-    </a>
-  );
-}
+  },
+);

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
@@ -1,3 +1,4 @@
+import {createRef} from 'react';
 import {mount} from '@shopify/react-testing';
 
 import '../../../__tests__/test-helper';
@@ -44,5 +45,20 @@ describe('<AppProxyLink />', () => {
       href: 'http://localhost/my-action/',
     });
     expect(component).toContainReactHtml('Hello world');
+  });
+
+  it('forwards ref to the underlying anchor element', () => {
+    // GIVEN
+    const ref = createRef<HTMLAnchorElement>();
+
+    // WHEN
+    mount(
+      <AppProxyProvider appUrl="http://my-app.example.io">
+        <AppProxyLink ref={ref} href="/my-action">Hello world</AppProxyLink>
+      </AppProxyProvider>,
+    );
+
+    // THEN
+    expect(ref.current).toBeInstanceOf(HTMLAnchorElement);
   });
 });

--- a/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProxyLink/__tests__/AppProxyLink.test.tsx
@@ -54,7 +54,9 @@ describe('<AppProxyLink />', () => {
     // WHEN
     mount(
       <AppProxyProvider appUrl="http://my-app.example.io">
-        <AppProxyLink ref={ref} href="/my-action">Hello world</AppProxyLink>
+        <AppProxyLink ref={ref} href="/my-action">
+          Hello world
+        </AppProxyLink>
       </AppProxyProvider>,
     );
 


### PR DESCRIPTION
## Summary

Fixes #1605

`AppProxyForm` and `AppProxyLink` were plain function components with no ref forwarding, making it impossible for consumers to attach a ref to the underlying DOM element. This PR wraps all three affected components with `forwardRef`:

- `AppProxyForm` in `@shopify/shopify-app-remix` — forwards `ref` to the underlying Remix `<Form>` / `<form>` element
- `AppProxyLink` in `@shopify/shopify-app-remix` — forwards `ref` to the underlying `<a>` element
- `AppProxyLink` in `@shopify/shopify-app-react-router` — forwards `ref` to the underlying `<a>` element

Note: `RemixPolarisLink` already used `forwardRef` correctly and was not changed.

## Motivation

Without `forwardRef`, TypeScript raises:
```
Property 'ref' does not exist on type 'IntrinsicAttributes & AppProxyFormProps'
```
and consumers cannot do common DOM operations like `form.current.submit()` or `anchor.current.focus()`.

## Test plan

- [ ] Existing tests pass (`pnpm test` in `shopify-app-remix` and `shopify-app-react-router`)
- [ ] TypeScript accepts `ref` prop on `AppProxyForm` and `AppProxyLink` without errors
- [ ] `ref.current` correctly points to the underlying DOM element at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)