### PR TITLE
fix(api-codegen-preset): generate string instead of any for custom scalars

### DIFF
--- a/.changeset/fix-codegen-scalar-types.md
+++ b/.changeset/fix-codegen-scalar-types.md
@@ -1,0 +1,12 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+Fix custom GraphQL scalars generating as `any` in codegen output
+
+Shopify API custom scalars (e.g. `DateTime`, `Money`, `URL`, `HTML`) now
+correctly generate as `string` in codegen output instead of `any`. The `JSON`
+scalar generates as `unknown`. This applies automatically to all current and
+future Shopify API scalars without requiring manual configuration.
+
+Fixes https://github.com/Shopify/shopify-app-js/issues/1154

--- a/packages/api-clients/api-codegen-preset/src/api-types.ts
+++ b/packages/api-clients/api-codegen-preset/src/api-types.ts
@@ -38,11 +38,11 @@ export const shopifyApiTypes = ({
     [`${outputDir}/${typesFile}`]: {
       schema: schemaFileExists ? schemaFile : schema,
       plugins: ['typescript'],
-      ...(enumsAsConst !== undefined && {
-        config: {
-          enumsAsConst,
-        },
-      }),
+      config: {
+        defaultScalarType: 'string',
+        scalars: {JSON: 'unknown'},
+        ...(enumsAsConst !== undefined && {enumsAsConst}),
+      },
     },
     [`${outputDir}/${queryTypesFile}`]: {
       schema: schemaFileExists ? schemaFile : schema,

--- a/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-project.test.ts
@@ -140,6 +140,8 @@ describe('shopifyApiProject', () => {
             schema: expect.anything(),
             plugins: ['typescript'],
             config: {
+              defaultScalarType: 'string',
+              scalars: {JSON: 'unknown'},
               enumsAsConst: true,
             },
           }),
@@ -165,13 +167,15 @@ describe('shopifyApiProject', () => {
             schema: expect.anything(),
             plugins: ['typescript'],
             config: {
+              defaultScalarType: 'string',
+              scalars: {JSON: 'unknown'},
               enumsAsConst: false,
             },
           }),
         );
       });
 
-      it('does not include config when enumsAsConst is not provided', () => {
+      it('uses default scalar config when enumsAsConst is not provided', () => {
         // GIVEN
         const config: ShopifyApiProjectOptions = {
           apiType,
@@ -184,13 +188,16 @@ describe('shopifyApiProject', () => {
         // THEN
         expect(
           projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
-        ).toEqual({
-          schema: expect.anything(),
-          plugins: ['typescript'],
-        });
+        ).toEqual(
+          expect.objectContaining({
+            schema: expect.anything(),
+            plugins: ['typescript'],
+            config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
+          }),
+        );
         expect(
           projectConfig.extensions.codegen.generates[`./${type}.types.d.ts`],
-        ).not.toHaveProperty('config');
+        ).not.toHaveProperty('config.enumsAsConst');
       });
     },
   );

--- a/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
+++ b/packages/api-clients/api-codegen-preset/src/tests/api-types.test.ts
@@ -41,6 +41,7 @@ describe('shopifyApiTypes', () => {
           [`./testDir/${type}.types.d.ts`]: {
             schema: expectedSchema,
             plugins: ['typescript'],
+            config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
           },
           [`./testDir/${type}.generated.d.ts`]: {
             schema: expectedSchema,
@@ -73,6 +74,7 @@ describe('shopifyApiTypes', () => {
           [`./testDir/${type}.types.d.ts`]: {
             schema: `./testDir/${type}-2024-10.schema.json`,
             plugins: ['typescript'],
+            config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
           },
           [`./testDir/${type}.generated.d.ts`]: {
             schema: `./testDir/${type}-2024-10.schema.json`,
@@ -102,6 +104,7 @@ describe('shopifyApiTypes', () => {
           [`./${type}.types.d.ts`]: {
             schema: expectedSchema,
             plugins: ['typescript'],
+            config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
           },
           [`./${type}.generated.d.ts`]: {
             schema: expectedSchema,
@@ -131,6 +134,7 @@ describe('shopifyApiTypes', () => {
           [`./${type}.types.ts`]: {
             schema: `./${type}.schema.json`,
             plugins: ['typescript'],
+            config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
           },
           [`./${type}.generated.ts`]: {
             schema: `./${type}.schema.json`,
@@ -161,6 +165,8 @@ describe('shopifyApiTypes', () => {
             schema: `./${type}.schema.json`,
             plugins: ['typescript'],
             config: {
+              defaultScalarType: 'string',
+              scalars: {JSON: 'unknown'},
               enumsAsConst: true,
             },
           }),
@@ -187,13 +193,15 @@ describe('shopifyApiTypes', () => {
             schema: `./${type}.schema.json`,
             plugins: ['typescript'],
             config: {
+              defaultScalarType: 'string',
+              scalars: {JSON: 'unknown'},
               enumsAsConst: false,
             },
           }),
         );
       });
 
-      it('excludes config when enumsAsConst is not provided', () => {
+      it('uses default scalar config when enumsAsConst is not provided', () => {
         // GIVEN
         const config: ShopifyApiProjectOptions = {
           apiType,
@@ -210,10 +218,10 @@ describe('shopifyApiTypes', () => {
         expect(projectConfig[`./${type}.types.d.ts`]).toEqual({
           schema: `./${type}.schema.json`,
           plugins: ['typescript'],
-          // No config property expected
+          config: {defaultScalarType: 'string', scalars: {JSON: 'unknown'}},
         });
         expect(projectConfig[`./${type}.types.d.ts`]).not.toHaveProperty(
-          'config',
+          'config.enumsAsConst',
         );
       });
     },


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1154

When using `shopifyApiProject()` or `shopifyApiTypes()`, all Shopify-specific custom scalars (`DateTime`, `Money`, `URL`, `HTML`, `FormattedString`, `Decimal`, `UnsignedInt64`, etc.) were typed as `any` in the generated output. This is because the `@graphql-codegen/typescript` plugin defaults unknown scalars to `any` when no `scalars` config is provided, and the preset never configured one.

### WHAT is this pull request doing?

Adds two config keys to the `typescript` codegen plugin invocation in `shopifyApiTypes()`:

- `defaultScalarType: 'string'` — all custom scalars (current and future) now generate as `string`, which is the correct runtime type for virtually all Shopify API scalars (`DateTime`, `Money`, `URL`, `HTML`, etc.)
- `scalars: {JSON: 'unknown'}` — overrides the one exception; the `JSON` scalar generates as `unknown` rather than `string`

Because `defaultScalarType` is used rather than a hardcoded list, any new scalars Shopify adds to the API in future versions are handled automatically without code changes.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)