### PR TITLE
Fix server crash on 5xx errors in validateAuthenticatedSession

### DIFF
--- a/.changeset/fix-validate-session-503-crash.md
+++ b/.changeset/fix-validate-session-503-crash.md
@@ -1,0 +1,7 @@
+---
+"@shopify/shopify-app-express": patch
+---
+
+Fix server crash when Shopify returns 5xx errors during session token validation.
+
+`validateAuthenticatedSession` now catches non-401 HTTP errors thrown by `hasValidAccessToken` (e.g. 503 Service Unavailable) and treats them as an invalid session, redirecting to re-authentication instead of crashing the server with an unhandled promise rejection.

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -225,6 +225,22 @@ describe('validateAuthenticatedSession', () => {
 
       expect((response.error as any).text).toBe('Storage error');
     });
+
+    it('redirects to auth if Shopify returns a 503 during token validation', async () => {
+      mockShopifyResponse({errors: 'Service Unavailable'}, {status: 503});
+
+      const response = await request(app)
+        .get('/test/shop?shop=my-shop.myshopify.io')
+        .set({Authorization: `Bearer ${validJWT}`})
+        .expect(403);
+
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize'],
+      ).toBe('1');
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize-url'],
+      ).toBe(`/api/auth?shop=my-shop.myshopify.io`);
+    });
   });
 
   describe('for non-embedded apps', () => {

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -71,7 +71,18 @@ export function validateAuthenticatedSession({
             shop: session.shop,
           });
 
-          if (await hasValidAccessToken(api, session)) {
+          let hasValidToken: boolean;
+          try {
+            hasValidToken = await hasValidAccessToken(api, session);
+          } catch (error) {
+            config.logger.error(
+              `Could not check if session was valid: ${error}`,
+              {shop: session.shop},
+            );
+            hasValidToken = false;
+          }
+
+          if (hasValidToken) {
             config.logger.debug('Request session has a valid access token', {
               shop: session.shop,
             });


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1860

When Shopify returns a non-401 HTTP error (e.g. 503 Service Unavailable) during session token validation, `hasValidAccessToken` re-throws the error. In `validateAuthenticatedSession`, this call was unguarded — the error escaped the async Express middleware as an unhandled promise rejection, crashing the server.

This is a recurring issue: it was also reported in #427 (2023, closed stale without a fix).

### WHAT is this pull request doing?

Wraps the `await hasValidAccessToken(api, session)` call in `validateAuthenticatedSession` with a try/catch. On any non-401 error, it logs the error and returns `false`, treating the session as invalid and redirecting to re-authentication — the same defensive pattern already used by `sessionHasValidAccessToken` in `ensureInstalledOnShop`.

**Before:** transient Shopify 5xx errors crash the server with an unhandled promise rejection.

**After:** transient errors are caught, logged, and the user is redirected to re-authenticate instead.

Also adds a test for the 503 case, which was previously uncovered.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)