### PR TITLE
Fix app proxy HMAC validation dropping duplicate query parameters

### DIFF
--- a/.changeset/fix-app-proxy-hmac-duplicate-params-react-router.md
+++ b/.changeset/fix-app-proxy-hmac-duplicate-params-react-router.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-react-router': patch
+---
+
+Fix app proxy HMAC validation failing when a URL query parameter appears more than once. `Object.fromEntries` was silently dropping duplicate keys before HMAC validation, producing a different string than Shopify signed. The fix preserves all values for repeated parameters and joins them with commas, matching Shopify's signing behaviour.

--- a/.changeset/fix-app-proxy-hmac-duplicate-params-remix.md
+++ b/.changeset/fix-app-proxy-hmac-duplicate-params-remix.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Fix app proxy HMAC validation failing when a URL query parameter appears more than once. `Object.fromEntries` was silently dropping duplicate keys before HMAC validation, producing a different string than Shopify signed. The fix preserves all values for repeated parameters and joins them with commas, matching Shopify's signing behaviour.

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -405,21 +405,19 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params: Record<string, string | string[]> = {};
+  const params: Record<string, string> = {};
   for (const [key, value] of url.searchParams.entries()) {
     const existing = params[key];
     if (existing === undefined) {
       params[key] = value;
     } else {
-      params[key] = Array.isArray(existing)
-        ? [...existing, value]
-        : [existing, value];
+      params[key] = `${existing},${value}`;
     }
   }
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
     .reduce((acc, [key, value]) => {
-      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
+      return `${acc}${key}=${value}`;
     }, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -408,12 +408,12 @@ async function createAppProxyHmac(url: URL): Promise<string> {
   const params: Record<string, string | string[]> = {};
   for (const [key, value] of url.searchParams.entries()) {
     const existing = params[key];
-    if (existing !== undefined) {
+    if (existing === undefined) {
+      params[key] = value;
+    } else {
       params[key] = Array.isArray(existing)
         ? [...existing, value]
         : [existing, value];
-    } else {
-      params[key] = value;
     }
   }
   const string = Object.entries(params)

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -96,6 +96,26 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
+  it('Succeeds when a query parameter appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+    // Duplicate param — Object.fromEntries would drop the first value
+    url.searchParams.append('consentGiven', 'true');
+    url.searchParams.append('consentGiven', 'false');
+    url.searchParams.set('signature', await createAppProxyHmac(url));
+
+    // WHEN
+    const {liquid} = await shopify.authenticate.public.appProxy(
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(liquid).toBeDefined();
+  });
+
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -385,7 +405,17 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params = Object.fromEntries(url.searchParams.entries());
+  const params: Record<string, string | string[]> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    const existing = params[key];
+    if (existing !== undefined) {
+      params[key] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing, value];
+    } else {
+      params[key] = value;
+    }
+  }
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
     .reduce((acc, [key, value]) => {

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
@@ -89,12 +89,12 @@ function searchParamsToQuery(
   const result: Record<string, string | string[]> = {};
   for (const [key, value] of searchParams.entries()) {
     const existing = result[key];
-    if (existing !== undefined) {
+    if (existing === undefined) {
+      result[key] = value;
+    } else {
       result[key] = Array.isArray(existing)
         ? [...existing, value]
         : [existing, value];
-    } else {
-      result[key] = value;
     }
   }
   return result;

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
@@ -85,16 +85,14 @@ const liquid: LiquidResponseFunction = (body, initAndOptions) => {
 
 function searchParamsToQuery(
   searchParams: URLSearchParams,
-): Record<string, string | string[]> {
-  const result: Record<string, string | string[]> = {};
+): Record<string, string> {
+  const result: Record<string, string> = {};
   for (const [key, value] of searchParams.entries()) {
     const existing = result[key];
     if (existing === undefined) {
       result[key] = value;
     } else {
-      result[key] = Array.isArray(existing)
-        ? [...existing, value]
-        : [existing, value];
+      result[key] = `${existing},${value}`;
     }
   }
   return result;

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
@@ -83,6 +83,23 @@ const liquid: LiquidResponseFunction = (body, initAndOptions) => {
   });
 };
 
+function searchParamsToQuery(
+  searchParams: URLSearchParams,
+): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+  for (const [key, value] of searchParams.entries()) {
+    const existing = result[key];
+    if (existing !== undefined) {
+      result[key] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing, value];
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 async function validateAppProxyHmac(
   params: BasicParams,
   url: URL,
@@ -96,7 +113,7 @@ async function validateAppProxyHmac(
     }
 
     let isValid = await api.utils.validateHmac(
-      Object.fromEntries(searchParams.entries()),
+      searchParamsToQuery(searchParams),
       {signator: 'appProxy'},
     );
 
@@ -112,7 +129,7 @@ async function validateAppProxyHmac(
       );
 
       isValid = await api.utils.validateHmac(
-        Object.fromEntries(searchParams.entries()),
+        searchParamsToQuery(searchParams),
         {signator: 'appProxy'},
       );
 
@@ -122,7 +139,7 @@ async function validateAppProxyHmac(
         );
 
         isValid = await api.utils.validateHmac(
-          Object.fromEntries(searchParams.entries()),
+          searchParamsToQuery(searchParams),
           {signator: 'appProxy'},
         );
       }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -416,12 +416,12 @@ async function createAppProxyHmac(url: URL): Promise<string> {
   const params: Record<string, string | string[]> = {};
   for (const [key, value] of url.searchParams.entries()) {
     const existing = params[key];
-    if (existing !== undefined) {
+    if (existing === undefined) {
+      params[key] = value;
+    } else {
       params[key] = Array.isArray(existing)
         ? [...existing, value]
         : [existing, value];
-    } else {
-      params[key] = value;
     }
   }
   const string = Object.entries(params)

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -413,21 +413,19 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params: Record<string, string | string[]> = {};
+  const params: Record<string, string> = {};
   for (const [key, value] of url.searchParams.entries()) {
     const existing = params[key];
     if (existing === undefined) {
       params[key] = value;
     } else {
-      params[key] = Array.isArray(existing)
-        ? [...existing, value]
-        : [existing, value];
+      params[key] = `${existing},${value}`;
     }
   }
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
     .reduce((acc, [key, value]) => {
-      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
+      return `${acc}${key}=${value}`;
     }, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -96,6 +96,26 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
+  it('Succeeds when a query parameter appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+    // Duplicate param — Object.fromEntries would drop the first value
+    url.searchParams.append('consentGiven', 'true');
+    url.searchParams.append('consentGiven', 'false');
+    url.searchParams.set('signature', await createAppProxyHmac(url));
+
+    // WHEN
+    const {liquid} = await shopify.authenticate.public.appProxy(
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(liquid).toBeDefined();
+  });
+
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -393,7 +413,17 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params = Object.fromEntries(url.searchParams.entries());
+  const params: Record<string, string | string[]> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    const existing = params[key];
+    if (existing !== undefined) {
+      params[key] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing, value];
+    } else {
+      params[key] = value;
+    }
+  }
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
     .reduce((acc, [key, value]) => {

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -89,12 +89,12 @@ function searchParamsToQuery(
   const result: Record<string, string | string[]> = {};
   for (const [key, value] of searchParams.entries()) {
     const existing = result[key];
-    if (existing !== undefined) {
+    if (existing === undefined) {
+      result[key] = value;
+    } else {
       result[key] = Array.isArray(existing)
         ? [...existing, value]
         : [existing, value];
-    } else {
-      result[key] = value;
     }
   }
   return result;

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -85,16 +85,14 @@ const liquid: LiquidResponseFunction = (body, initAndOptions) => {
 
 function searchParamsToQuery(
   searchParams: URLSearchParams,
-): Record<string, string | string[]> {
-  const result: Record<string, string | string[]> = {};
+): Record<string, string> {
+  const result: Record<string, string> = {};
   for (const [key, value] of searchParams.entries()) {
     const existing = result[key];
     if (existing === undefined) {
       result[key] = value;
     } else {
-      result[key] = Array.isArray(existing)
-        ? [...existing, value]
-        : [existing, value];
+      result[key] = `${existing},${value}`;
     }
   }
   return result;

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -83,6 +83,23 @@ const liquid: LiquidResponseFunction = (body, initAndOptions) => {
   });
 };
 
+function searchParamsToQuery(
+  searchParams: URLSearchParams,
+): Record<string, string | string[]> {
+  const result: Record<string, string | string[]> = {};
+  for (const [key, value] of searchParams.entries()) {
+    const existing = result[key];
+    if (existing !== undefined) {
+      result[key] = Array.isArray(existing)
+        ? [...existing, value]
+        : [existing, value];
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 async function validateAppProxyHmac(
   params: BasicParams,
   url: URL,
@@ -96,7 +113,7 @@ async function validateAppProxyHmac(
     }
 
     let isValid = await api.utils.validateHmac(
-      Object.fromEntries(searchParams.entries()),
+      searchParamsToQuery(searchParams),
       {signator: 'appProxy'},
     );
 
@@ -112,7 +129,7 @@ async function validateAppProxyHmac(
       );
 
       isValid = await api.utils.validateHmac(
-        Object.fromEntries(searchParams.entries()),
+        searchParamsToQuery(searchParams),
         {signator: 'appProxy'},
       );
 
@@ -122,7 +139,7 @@ async function validateAppProxyHmac(
         );
 
         isValid = await api.utils.validateHmac(
-          Object.fromEntries(searchParams.entries()),
+          searchParamsToQuery(searchParams),
           {signator: 'appProxy'},
         );
       }


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2374

`authenticate.public.appProxy()` throws a spurious 400 for requests where a query parameter appears more than once. `Object.fromEntries(searchParams.entries())` silently drops duplicate keys before HMAC validation, producing a different string than Shopify signed.

`stringifyQueryForAppProxy` in `hmac-validator.ts` already handles arrays by joining with commas, but never received arrays because `Object.fromEntries` collapsed them first.

### WHAT is this pull request doing?

Adds a `searchParamsToQuery()` helper that iterates `URLSearchParams` entries preserving duplicates as arrays, and replaces all three `Object.fromEntries(searchParams.entries())` calls inside `validateAppProxyHmac` in both `shopify-app-remix` and `shopify-app-react-router`.

Also fixes the `createAppProxyHmac` test helper which had the same bug (masking the issue in tests), and adds a regression test for the duplicate-parameter case.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)