### PR TITLE
Fix: widen drizzle-orm peer dependency to include 0.45.x

### DIFF
--- a/.changeset/fix-drizzle-orm-peer-dep-045.md
+++ b/.changeset/fix-drizzle-orm-peer-dep-045.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-session-storage-drizzle": patch
+---
+
+Widen `drizzle-orm` peer dependency to include `^0.45.0`, fixing `ERESOLVE` errors for users on drizzle-orm 0.45.x

--- a/packages/apps/session-storage/shopify-app-session-storage-drizzle/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-drizzle/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@shopify/shopify-api": "^13.0.0",
     "@shopify/shopify-app-session-storage": "^5.0.0",
-    "drizzle-orm": "^0.44.7"
+    "drizzle-orm": "^0.44.7 || ^0.45.0"
   },
   "devDependencies": {
     "@libsql/client": "^0.17.2",


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #2963

Users on `drizzle-orm@0.45.x` get an `ERESOLVE` error when installing `@shopify/shopify-app-session-storage-drizzle` because the published peer dependency range `^0.44.7` resolves to `>=0.44.7 <0.45.0`, which excludes all `0.45.x` versions.

The package already runs its own tests against `drizzle-orm@0.45.x` via `devDependencies` (since [#2989](https://github.com/Shopify/shopify-app-js/pull/2989)) — the peer dependency range was simply never updated to match.

### WHAT is this pull request doing?

Widens the `peerDependencies` entry for `drizzle-orm` from `^0.44.7` to `^0.44.7 || ^0.45.0` in `@shopify/shopify-app-session-storage-drizzle`.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)