### PR TITLE
shopify-app-express: document environment variable defaults

### DIFF
--- a/packages/apps/shopify-app-express/README.md
+++ b/packages/apps/shopify-app-express/README.md
@@ -89,6 +89,42 @@ To load your app within the Shopify Admin app, you need to:
 1. Update your app's callback URL to `http://localhost:8080/api/auth/callback` in that same page
 1. Go to **Test your app** in Partners Dashboard and select your development store
 
+## Environment variables
+
+The following environment variables are automatically read as defaults when they are not explicitly provided in the `api` config object passed to `shopifyApp()`:
+
+| Variable           | Maps to config field       | Description                                                  |
+| ------------------ | -------------------------- | ------------------------------------------------------------ |
+| `SHOPIFY_API_KEY`  | `apiKey`                   | Your app's API key from the Partners Dashboard               |
+| `SHOPIFY_API_SECRET` | `apiSecretKey`           | Your app's API secret from the Partners Dashboard            |
+| `HOST`             | `hostScheme` / `hostName`  | Your app's public URL (e.g. `https://my-app.example.com`)   |
+| `SCOPES`           | `scopes`                   | Comma-separated list of OAuth scopes (e.g. `read_products,write_orders`) |
+
+For example, if you set these environment variables:
+
+```bash
+SHOPIFY_API_KEY=mykey
+SHOPIFY_API_SECRET=mysecret
+HOST=https://my-app.example.com
+SCOPES=read_products,write_orders
+```
+
+Then you can omit them from the config:
+
+```ts
+const shopify = shopifyApp({
+  auth: {
+    path: '/api/auth',
+    callbackPath: '/api/auth/callback',
+  },
+  webhooks: {
+    path: '/api/webhooks',
+  },
+});
+```
+
+Any values explicitly passed in the `api` config will take precedence over the environment variables.
+
 ## Next steps
 
 Now that your app is up and running, you can learn more about the `shopifyApp` object in [the reference docs](./docs/reference/shopifyApp.md).


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

`@shopify/shopify-app-express` automatically reads the following environment variables when they are not explicitly passed to `shopifyApp()`:

- `SHOPIFY_API_KEY`
- `SHOPIFY_API_SECRET`
- `HOST` (split into hostScheme and hostName)
- `SCOPES`                                                                                   
   
This behavior is implemented in [apiConfigWithDefaults()](https://github.com/Shopify/shopify-app-js/blob/03615954b3d68b2fb046f6465824fdcdd63a2522/packages/apps/shopify-app-express/src/index.ts#L112-L121) in the source, but is not mentioned anywhere in the README or docs.

see https://github.com/Shopify/shopify-app-js/issues/3110

### WHAT is this pull request doing?

Add a section to the `README` documenting the supported environment variables

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
