### PR TITLE
Gen docs react router v0

### DIFF
--- a/packages/apps/shopify-app-react-router/docs/build-docs.sh
+++ b/packages/apps/shopify-app-react-router/docs/build-docs.sh
@@ -48,6 +48,7 @@ if [ -f "$V2_FILE" ] && [ -f "$V1_FILE" ]; then
   "
 fi
 
+
 # Copy generated docs to shopify-dev in the world repo if available
 MAJOR_VERSION=$(node -p "require('./package.json').version.split('.')[0]")
 WORLD_DEST="$HOME/world/trees/root/src/areas/platforms/shopify-dev/db/data/docs/templated_apis/shopify_app_react_router/v${MAJOR_VERSION}"


### PR DESCRIPTION
# gen-docs-react-router-v0 (React Router v0)

Related ticket: https://github.com/shop/issues-learn/issues/1464

Shopify-dev top hatting PR: https://github.com/shop/world/pull/570575

  ## Summary
  - Add `@publicDocs` JSDoc tags to all top-level types in `@shopify/shopify-app-react-router` v0
  - Upgrade `@shopify/generate-docs` to `^1.1.0` to enable v2 documentation pipeline
  - Add JSDoc descriptions matching existing v1 generated docs definitions
  - Update `build-docs.sh` to copy generated files to shopify-dev world repo

  ## Test plan
  - [ ] Run `pnpm build-docs` in `packages/apps/shopify-app-react-router`
  - [ ] Verify `generated_docs_data_v2.json` is created alongside existing files
  - [ ] Verify docs render correctly in shopify-dev preview for v0