### PR TITLE
update gen docs and add public docs tags

### DIFF
--- a/packages/apps/shopify-app-remix/src/server/future/flags.ts
+++ b/packages/apps/shopify-app-remix/src/server/future/flags.ts
@@ -12,10 +12,10 @@ import {AppConfig} from '../config-types';
  */
 export interface FutureFlags {
   /**
-   * When enabled, embedded apps will fetch access tokens via [token exchange](https://shopify.dev/docs/apps/auth/get-access-tokens/token-exchange).
-   * This assumes the app has scopes declared for [Shopify managing installation](https://shopify.dev/docs/apps/auth/installation#shopify-managed-installation).
+   * When enabled, embedded apps will fetch access tokens via [token exchange](/docs/apps/auth/get-access-tokens/token-exchange).
+   * This assumes the app has scopes declared for [Shopify managing installation](/docs/apps/auth/installation#shopify-managed-installation).
    *
-   * Learn more about this [new embedded app auth strategy](https://shopify.dev/docs/api/shopify-app-remix#embedded-auth-strategy).
+   * Learn more about this [new embedded app auth strategy](/docs/api/shopify-app-remix#embedded-auth-strategy).
    *
    * @default false
    */
@@ -62,7 +62,7 @@ export function logDisabledFutureFlags(
     logFlag(
       'unstable_newEmbeddedAuthStrategy',
       'Enable this to use OAuth token exchange instead of auth code to generate API access tokens.' +
-        '\n  Your app must be using Shopify managed install: https://shopify.dev/docs/apps/auth/installation',
+        '\n  Your app must be using Shopify managed install: /docs/apps/auth/installation',
     );
   }
 }


### PR DESCRIPTION
# gen-docs-remix-v3 (Remix v3)

Related ticket: https://github.com/shop/issues-learn/issues/1464

Shopify-dev top hatting PR: https://github.com/shop/world/pull/570575


  ## Summary
  - Add `@publicDocs` JSDoc tags to all top-level types in `@shopify/shopify-app-remix` v3
  - Upgrade `@shopify/generate-docs` to `^1.1.0` to enable v2 documentation pipeline
  - Add JSDoc descriptions matching existing v1 generated docs definitions
  - Add `FutureFlags` description to match v1 docs
  - Fix `shopify.dev` links to use relative `/docs/` paths in `FutureFlags`
  - Update `build-docs.sh` to copy generated files to shopify-dev world repo and post-process v2 output to prefer local types
   over declaration-path types

  ## Test plan
  - [ ] Run `pnpm build-docs` in `packages/apps/shopify-app-remix`
  - [ ] Verify `generated_docs_data_v2.json` is created alongside existing files
  - [ ] Verify docs render correctly in shopify-dev preview for v3