### PR TITLE
update gen docs and add public falgs, output copy to shopify dev repo

### DIFF
--- a/packages/shopify-app-remix/docs/generated/generated_docs_data_v2.json
+++ b/packages/shopify-app-remix/docs/generated/generated_docs_data_v2.json
@@ -1,0 +1,2812 @@
+{
+  "AuthenticateWebhook": {
+    "src/server/authenticate/webhooks/types.ts": {
+      "filePath": "src/server/authenticate/webhooks/types.ts",
+      "name": "AuthenticateWebhook",
+      "description": "Verifies requests coming from Shopify webhooks.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/authenticate/webhooks/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/webhooks/types.ts",
+        "description": "",
+        "name": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>",
+        "value": "Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>"
+      },
+      "value": "(\n  request: Request,\n) => Promise<\n  WebhookContext<Topics> | WebhookContextWithSession<Topics, Resources>\n>"
+    }
+  },
+  "WebhookContext": {
+    "src/server/authenticate/webhooks/types.ts": {
+      "filePath": "src/server/authenticate/webhooks/types.ts",
+      "name": "WebhookContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "undefined",
+          "description": ""
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "string",
+          "description": "The API version used for the webhook.",
+          "examples": [
+            {
+              "title": "Webhook API version",
+              "description": "Get the API version used for webhook request.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { apiVersion } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "payload",
+          "value": "JSONValue",
+          "description": "The payload from the webhook request.",
+          "examples": [
+            {
+              "title": "Webhook payload",
+              "description": "Get the request's POST payload.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { payload } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "undefined",
+          "description": ""
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": "The shop where the webhook was triggered.",
+          "examples": [
+            {
+              "title": "Webhook shop",
+              "description": "Get the shop that triggered a webhook.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { shop } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "topic",
+          "value": "Topics",
+          "description": "The topic of the webhook.",
+          "examples": [
+            {
+              "title": "Webhook topic",
+              "description": "Get the event topic for the webhook.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { topic } = await authenticate.webhook(request);\n\n  switch (topic) {\n    case \"APP_UNINSTALLED\":\n      // Do something when the app is uninstalled.\n      break;\n  }\n\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "webhookId",
+          "value": "string",
+          "description": "A unique ID for the webhook. Useful to keep track of which events your app has already processed.",
+          "examples": [
+            {
+              "title": "Webhook ID",
+              "description": "Get the webhook ID.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { webhookId } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface WebhookContext<Topics = string | number | symbol>\n  extends Context<Topics> {\n  session: undefined;\n  admin: undefined;\n}"
+    }
+  },
+  "JSONValue": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "JSONValue",
+      "value": "string | number | boolean | null | JSONObject | JSONArray",
+      "description": ""
+    }
+  },
+  "JSONObject": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "JSONObject",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "name": "[x: string]",
+          "value": "JSONValue"
+        }
+      ],
+      "value": "interface JSONObject {\n  [x: string]: JSONValue;\n}"
+    }
+  },
+  "JSONArray": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "JSONArray",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "__@iterator@410",
+          "value": "() => IterableIterator<JSONValue>",
+          "description": "Iterator"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "__@unscopables@412",
+          "value": "() => { copyWithin: boolean; entries: boolean; fill: boolean; find: boolean; findIndex: boolean; keys: boolean; values: boolean; }",
+          "description": "Returns an object whose properties have the value 'true'\r\nwhen they will be absent when used in a 'with' statement."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "at",
+          "value": "(index: number) => JSONValue",
+          "description": ""
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "concat",
+          "value": "{ (...items: ConcatArray<JSONValue>[]): JSONValue[]; (...items: (JSONValue | ConcatArray<JSONValue>)[]): JSONValue[]; }",
+          "description": "Combines two or more arrays.\r\nThis method returns a new array without modifying any existing arrays."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "copyWithin",
+          "value": "(target: number, start: number, end?: number) => JSONArray",
+          "description": "Returns the this object after copying a section of the array identified by start and end\r\nto the same array starting at position target"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "entries",
+          "value": "() => IterableIterator<[number, JSONValue]>",
+          "description": "Returns an iterable of key, value pairs for every entry in the array"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "every",
+          "value": "{ <S extends JSONValue>(predicate: (value: JSONValue, index: number, array: JSONValue[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: JSONValue, index: number, array: JSONValue[]) => unknown, thisArg?: any): boolean; }",
+          "description": "Determines whether all the members of an array satisfy the specified test."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "fill",
+          "value": "(value: JSONValue, start?: number, end?: number) => JSONArray",
+          "description": "Changes all array elements from `start` to `end` index to a static `value` and returns the modified array"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "filter",
+          "value": "{ <S extends JSONValue>(predicate: (value: JSONValue, index: number, array: JSONValue[]) => value is S, thisArg?: any): S[]; (predicate: (value: JSONValue, index: number, array: JSONValue[]) => unknown, thisArg?: any): JSONValue[]; }",
+          "description": "Returns the elements of an array that meet the condition specified in a callback function."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "find",
+          "value": "{ <S extends JSONValue>(predicate: (this: void, value: JSONValue, index: number, obj: JSONValue[]) => value is S, thisArg?: any): S; (predicate: (value: JSONValue, index: number, obj: JSONValue[]) => unknown, thisArg?: any): JSONValue; }",
+          "description": "Returns the value of the first element in the array where predicate is true, and undefined\r\notherwise."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "findIndex",
+          "value": "(predicate: (value: JSONValue, index: number, obj: JSONValue[]) => unknown, thisArg?: any) => number",
+          "description": "Returns the index of the first element in the array where predicate is true, and -1\r\notherwise."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "flat",
+          "value": "<A, D extends number = 1>(this: A, depth?: D) => FlatArray<A, D>[]",
+          "description": "Returns a new array with all sub-array elements concatenated into it recursively up to the\r\nspecified depth."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "flatMap",
+          "value": "<U, This = undefined>(callback: (this: This, value: JSONValue, index: number, array: JSONValue[]) => U | readonly U[], thisArg?: This) => U[]",
+          "description": "Calls a defined callback function on each element of an array. Then, flattens the result into\r\na new array.\r\nThis is identical to a map followed by flat with depth 1."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "forEach",
+          "value": "(callbackfn: (value: JSONValue, index: number, array: JSONValue[]) => void, thisArg?: any) => void",
+          "description": "Performs the specified action for each element in an array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "includes",
+          "value": "(searchElement: JSONValue, fromIndex?: number) => boolean",
+          "description": "Determines whether an array includes a certain element, returning true or false as appropriate."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "indexOf",
+          "value": "(searchElement: JSONValue, fromIndex?: number) => number",
+          "description": "Returns the index of the first occurrence of a value in an array, or -1 if it is not present."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "join",
+          "value": "(separator?: string) => string",
+          "description": "Adds all the elements of an array into a string, separated by the specified separator string."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "keys",
+          "value": "() => IterableIterator<number>",
+          "description": "Returns an iterable of keys in the array"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "lastIndexOf",
+          "value": "(searchElement: JSONValue, fromIndex?: number) => number",
+          "description": "Returns the index of the last occurrence of a specified value in an array, or -1 if it is not present."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "length",
+          "value": "number",
+          "description": "Gets or sets the length of the array. This is a number one higher than the highest index in the array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "map",
+          "value": "<U>(callbackfn: (value: JSONValue, index: number, array: JSONValue[]) => U, thisArg?: any) => U[]",
+          "description": "Calls a defined callback function on each element of an array, and returns an array that contains the results."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "pop",
+          "value": "() => JSONValue",
+          "description": "Removes the last element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "push",
+          "value": "(...items: JSONValue[]) => number",
+          "description": "Appends new elements to the end of an array, and returns the new length of the array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "reduce",
+          "value": "{ (callbackfn: (previousValue: JSONValue, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => JSONValue): JSONValue; (callbackfn: (previousValue: JSONValue, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => JSONValue, initialValue: JSONValue): JSONValue; <U>(callbackfn: (previousValue: U, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => U, initialValue: U): U; }",
+          "description": "Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "reduceRight",
+          "value": "{ (callbackfn: (previousValue: JSONValue, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => JSONValue): JSONValue; (callbackfn: (previousValue: JSONValue, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => JSONValue, initialValue: JSONValue): JSONValue; <U>(callbackfn: (previousValue: U, currentValue: JSONValue, currentIndex: number, array: JSONValue[]) => U, initialValue: U): U; }",
+          "description": "Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "reverse",
+          "value": "() => JSONValue[]",
+          "description": "Reverses the elements in an array in place.\r\nThis method mutates the array and returns a reference to the same array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "shift",
+          "value": "() => JSONValue",
+          "description": "Removes the first element from an array and returns it.\r\nIf the array is empty, undefined is returned and the array is not modified."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "slice",
+          "value": "(start?: number, end?: number) => JSONValue[]",
+          "description": "Returns a copy of a section of an array.\r\nFor both start and end, a negative index can be used to indicate an offset from the end of the array.\r\nFor example, -2 refers to the second to last element of the array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "some",
+          "value": "(predicate: (value: JSONValue, index: number, array: JSONValue[]) => unknown, thisArg?: any) => boolean",
+          "description": "Determines whether the specified callback function returns true for any element of an array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "sort",
+          "value": "(compareFn?: (a: JSONValue, b: JSONValue) => number) => JSONArray",
+          "description": "Sorts an array in place.\r\nThis method mutates the array and returns a reference to the same array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "splice",
+          "value": "{ (start: number, deleteCount?: number): JSONValue[]; (start: number, deleteCount: number, ...items: JSONValue[]): JSONValue[]; }",
+          "description": "Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "toLocaleString",
+          "value": "() => string",
+          "description": "Returns a string representation of an array. The elements are converted to string using their toLocaleString methods."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "toString",
+          "value": "() => string",
+          "description": "Returns a string representation of an array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "unshift",
+          "value": "(...items: JSONValue[]) => number",
+          "description": "Inserts new elements at the start of an array, and returns the new length of the array."
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "MethodSignature",
+          "name": "values",
+          "value": "() => IterableIterator<JSONValue>",
+          "description": "Returns an iterable of values in the array"
+        }
+      ],
+      "value": "interface JSONArray extends Array<JSONValue> {}"
+    }
+  },
+  "WebhookContextWithSession": {
+    "src/server/authenticate/webhooks/types.ts": {
+      "filePath": "src/server/authenticate/webhooks/types.ts",
+      "name": "WebhookContextWithSession",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "{ rest: RestClient & Resources; graphql: GraphqlClient; }",
+          "description": "An admin context for the webhook.\n\nReturned only if there is a session for the shop."
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "string",
+          "description": "The API version used for the webhook.",
+          "examples": [
+            {
+              "title": "Webhook API version",
+              "description": "Get the API version used for webhook request.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { apiVersion } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "payload",
+          "value": "JSONValue",
+          "description": "The payload from the webhook request.",
+          "examples": [
+            {
+              "title": "Webhook payload",
+              "description": "Get the request's POST payload.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { payload } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "A session with an offline token for the shop.\n\nReturned only if there is a session for the shop."
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "string",
+          "description": "The shop where the webhook was triggered.",
+          "examples": [
+            {
+              "title": "Webhook shop",
+              "description": "Get the shop that triggered a webhook.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { shop } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "topic",
+          "value": "Topics",
+          "description": "The topic of the webhook.",
+          "examples": [
+            {
+              "title": "Webhook topic",
+              "description": "Get the event topic for the webhook.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { topic } = await authenticate.webhook(request);\n\n  switch (topic) {\n    case \"APP_UNINSTALLED\":\n      // Do something when the app is uninstalled.\n      break;\n  }\n\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "webhookId",
+          "value": "string",
+          "description": "A unique ID for the webhook. Useful to keep track of which events your app has already processed.",
+          "examples": [
+            {
+              "title": "Webhook ID",
+              "description": "Get the webhook ID.",
+              "tabs": [
+                {
+                  "code": "import { ActionFunction } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const action: ActionFunction = async ({ request }) => {\n  const { webhookId } = await authenticate.webhook(request);\n  return new Response();\n};",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface WebhookContextWithSession<\n  Topics = string | number | symbol,\n  Resources extends ShopifyRestResources = any,\n> extends Context<Topics> {\n  /**\n   * A session with an offline token for the shop.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  session: Session;\n  /**\n   * An admin context for the webhook.\n   *\n   * Returned only if there is a session for the shop.\n   */\n  admin: {\n    /** A REST client. */\n    rest: InstanceType<Shopify['clients']['Rest']> & Resources;\n    /** A GraphQL client. */\n    graphql: InstanceType<Shopify['clients']['Graphql']>;\n  };\n}"
+    }
+  },
+  "AuthenticateCheckout": {
+    "src/server/authenticate/public/checkout/types.ts": {
+      "filePath": "src/server/authenticate/public/checkout/types.ts",
+      "name": "AuthenticateCheckout",
+      "description": "Authenticates requests coming from Shopify checkout extensions.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/authenticate/public/checkout/types.ts"
+        },
+        {
+          "name": "options",
+          "description": "",
+          "value": "AuthenticateCheckoutOptions",
+          "isOptional": true,
+          "filePath": "src/server/authenticate/public/checkout/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/public/checkout/types.ts",
+        "description": "",
+        "name": "Promise<CheckoutContext>",
+        "value": "Promise<CheckoutContext>"
+      },
+      "value": "(\n  request: Request,\n  options?: AuthenticateCheckoutOptions,\n) => Promise<CheckoutContext>"
+    }
+  },
+  "AuthenticateCheckoutOptions": {
+    "src/server/authenticate/public/checkout/types.ts": {
+      "filePath": "src/server/authenticate/public/checkout/types.ts",
+      "name": "AuthenticateCheckoutOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/checkout/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "corsHeaders",
+          "value": "string[]",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AuthenticateCheckoutOptions {\n  corsHeaders?: string[];\n}"
+    }
+  },
+  "CheckoutContext": {
+    "src/server/authenticate/public/checkout/types.ts": {
+      "filePath": "src/server/authenticate/public/checkout/types.ts",
+      "name": "CheckoutContext",
+      "description": "Authenticated Context for a checkout request",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/checkout/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cors",
+          "value": "EnsureCORSFunction",
+          "description": "A function that ensures the CORS headers are set correctly for the response.",
+          "examples": [
+            {
+              "title": "Setting CORS headers for a public request",
+              "description": "Use the `cors` helper to ensure your app can respond to checkout extension requests.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { sessionToken, cors } = await authenticate.public.checkout(\n    request,\n    { corsHeaders: [\"X-My-Custom-Header\"] }\n  );\n  const data = await getMyAppData({shop: sessionToken.dest});\n  return cors(json(data));\n};",
+                  "title": "app/routes/public/my-route.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/checkout/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionToken",
+          "value": "JwtPayload",
+          "description": "The decoded and validated session token for the request\n\nRefer to the OAuth docs for the [session token payload](https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload).",
+          "examples": [
+            {
+              "title": "Using the decoded session token",
+              "description": "Get store-specific data using the `sessionToken` object.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { sessionToken } = await authenticate.public.checkout(\n    request\n  );\n  return json(await getMyAppData({shop: sessionToken.dest}));\n};",
+                  "title": "app/routes/public/my-route.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface CheckoutContext {\n  /**\n   * The decoded and validated session token for the request\n   *\n   * Refer to the OAuth docs for the [session token payload](https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload).\n   *\n   * @example\n   * <caption>Using the decoded session token.</caption>\n   * <description>Get store-specific data using the `sessionToken` object.</description>\n   * ```ts\n   * // app/routes/public/my-route.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { sessionToken } = await authenticate.public.checkout(\n   *     request\n   *   );\n   *   return json(await getMyAppData({shop: sessionToken.dest}));\n   * };\n   * ```\n   */\n  sessionToken: JwtPayload;\n\n  /**\n   * A function that ensures the CORS headers are set correctly for the response.\n   *\n   * @example\n   * <caption>Setting CORS headers for a public request.</caption>\n   * <description>Use the `cors` helper to ensure your app can respond to checkout extension requests.</description>\n   * ```ts\n   * // app/routes/public/my-route.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { sessionToken, cors } = await authenticate.public.checkout(\n   *     request,\n   *     { corsHeaders: [\"X-My-Custom-Header\"] }\n   *   );\n   *   const data = await getMyAppData({shop: sessionToken.dest});\n   *   return cors(json(data));\n   * };\n   * ```\n   */\n  cors: EnsureCORSFunction;\n}"
+    }
+  },
+  "EnsureCORSFunction": {
+    "src/server/authenticate/helpers/ensure-cors-headers.ts": {
+      "filePath": "src/server/authenticate/helpers/ensure-cors-headers.ts",
+      "name": "EnsureCORSFunction",
+      "description": "",
+      "members": [],
+      "value": "export interface EnsureCORSFunction {\n  (response: Response): Response;\n}"
+    }
+  },
+  "AdminApiContext": {
+    "src/server/clients/admin/types.ts": {
+      "filePath": "src/server/clients/admin/types.ts",
+      "name": "AdminApiContext",
+      "description": "Provides utilities that apps can use to make requests to the Admin API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/server/clients/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "graphql",
+          "value": "GraphQLClient",
+          "description": "Methods for interacting with the Shopify Admin GraphQL API\n\n\n\n\n\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Querying the GraphQL API",
+              "description": "Use `admin.graphql` to make query / mutation requests.",
+              "tabs": [
+                {
+                  "code": "import { ActionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionArgs) {\n  const { admin } = await authenticate.admin(request);\n\n  const response = await admin.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/clients/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "rest",
+          "value": "RestClientWithResources<Resources>",
+          "description": "Methods for interacting with the Shopify Admin REST API\n\nThere are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Using REST resources",
+              "description": "Getting the number of orders in a store using REST resources.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  return json(admin.rest.resources.Order.count({ session }));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            },
+            {
+              "title": "Performing a GET request to the REST API",
+              "description": "Use `admin.rest.<method>` to make custom requests to the API.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { admin, session } = await authenticate.admin(request);\n  const response = await admin.rest.get({ path: \"/customers/count.json\" });\n  const customers = await response.json();\n  return json({ customers });\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AdminApiContext<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> {\n  /**\n   * Methods for interacting with the Shopify Admin REST API\n   *\n   * There are methods for interacting with individual REST resources. You can also make `GET`, `POST`, `PUT` and `DELETE` requests should the REST resources not meet your needs.\n   *\n   * {@link https://shopify.dev/docs/api/admin-rest}\n   *\n   * @example\n   * <caption>Using REST resources.</caption>\n   * <description>Getting the number of orders in a store using REST resources.</description>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-07\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   return json(admin.rest.resources.Order.count({ session }));\n   * };\n   * ```\n   *\n   * @example\n   * <caption>Performing a GET request to the REST API.</caption>\n   * <description>Use `admin.rest.<method>` to make custom requests to the API.</description>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { admin, session } = await authenticate.admin(request);\n   *   const response = await admin.rest.get({ path: \"/customers/count.json\" });\n   *   const customers = await response.json();\n   *   return json({ customers });\n   * };\n   * ```\n   */\n  rest: RestClientWithResources<Resources>;\n\n  /**\n   * Methods for interacting with the Shopify Admin GraphQL API\n   *\n   * {@link https://shopify.dev/docs/api/admin-graphql}\n   * {@link https://github.com/Shopify/shopify-api-js/blob/main/docs/reference/clients/Graphql.md}\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `admin.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * import { ActionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionArgs) {\n   *   const { admin } = await authenticate.admin(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  graphql: GraphQLClient;\n}"
+    }
+  },
+  "GraphQLClient": {
+    "src/server/clients/types.ts": {
+      "filePath": "src/server/clients/types.ts",
+      "name": "GraphQLClient",
+      "description": "",
+      "params": [
+        {
+          "name": "query",
+          "description": "",
+          "value": "string",
+          "filePath": "src/server/clients/types.ts"
+        },
+        {
+          "name": "options",
+          "description": "",
+          "value": "GraphQLQueryOptions",
+          "isOptional": true,
+          "filePath": "src/server/clients/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/clients/types.ts",
+        "description": "",
+        "name": "Promise<Response>",
+        "value": "Promise<Response>"
+      },
+      "value": "(\n  query: string,\n  options?: GraphQLQueryOptions,\n) => Promise<Response>"
+    }
+  },
+  "GraphQLQueryOptions": {
+    "src/server/clients/types.ts": {
+      "filePath": "src/server/clients/types.ts",
+      "name": "GraphQLQueryOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/clients/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/clients/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "headers",
+          "value": "{ [key: string]: any; }",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/clients/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "tries",
+          "value": "number",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/clients/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "variables",
+          "value": "QueryVariables",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface GraphQLQueryOptions {\n  variables?: QueryVariables;\n  apiVersion?: ApiVersion;\n  headers?: {[key: string]: any};\n  tries?: number;\n}"
+    }
+  },
+  "QueryVariables": {
+    "src/server/clients/types.ts": {
+      "filePath": "src/server/clients/types.ts",
+      "name": "QueryVariables",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/clients/types.ts",
+          "name": "[key: string]",
+          "value": "any"
+        }
+      ],
+      "value": "interface QueryVariables {\n  [key: string]: any;\n}"
+    }
+  },
+  "RestClientWithResources": {
+    "src/server/clients/admin/rest.ts": {
+      "filePath": "src/server/clients/admin/rest.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RestClientWithResources",
+      "value": "RemixRestClient & {resources: Resources}",
+      "description": ""
+    }
+  },
+  "RemixRestClient": {
+    "src/server/clients/admin/rest.ts": {
+      "filePath": "src/server/clients/admin/rest.ts",
+      "name": "RemixRestClient",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/clients/admin/rest.ts",
+          "syntaxKind": "PropertyDeclaration",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        },
+        {
+          "filePath": "src/server/clients/admin/rest.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "get",
+          "value": "(params: GetRequestParams) => Promise<Response>",
+          "description": "Performs a GET request on the given path."
+        },
+        {
+          "filePath": "src/server/clients/admin/rest.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "post",
+          "value": "(params: PostRequestParams) => Promise<Response>",
+          "description": "Performs a POST request on the given path."
+        },
+        {
+          "filePath": "src/server/clients/admin/rest.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "put",
+          "value": "(params: PostRequestParams) => Promise<Response>",
+          "description": "Performs a PUT request on the given path."
+        },
+        {
+          "filePath": "src/server/clients/admin/rest.ts",
+          "syntaxKind": "MethodDeclaration",
+          "name": "delete",
+          "value": "(params: GetRequestParams) => Promise<Response>",
+          "description": "Performs a DELETE request on the given path."
+        }
+      ],
+      "value": "class RemixRestClient {\n  public session: Session;\n  private params: AdminClientOptions['params'];\n  private handleClientError: AdminClientOptions['handleClientError'];\n\n  constructor({params, session, handleClientError}: AdminClientOptions) {\n    this.params = params;\n    this.handleClientError = handleClientError;\n    this.session = session;\n  }\n\n  /**\n   * Performs a GET request on the given path.\n   */\n  public async get(params: GetRequestParams) {\n    return this.makeRequest({\n      method: 'GET' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a POST request on the given path.\n   */\n  public async post(params: PostRequestParams) {\n    return this.makeRequest({\n      method: 'POST' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a PUT request on the given path.\n   */\n  public async put(params: PutRequestParams) {\n    return this.makeRequest({\n      method: 'PUT' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  /**\n   * Performs a DELETE request on the given path.\n   */\n  public async delete(params: DeleteRequestParams) {\n    return this.makeRequest({\n      method: 'DELETE' as RequestParams['method'],\n      ...params,\n    });\n  }\n\n  protected async makeRequest(params: RequestParams): Promise<Response> {\n    const originalClient = new this.params.api.clients.Rest({\n      session: this.session,\n    });\n    const originalRequest = Reflect.get(originalClient, 'request');\n\n    try {\n      const apiResponse = await originalRequest.call(originalClient, params);\n\n      // We use a separate client for REST requests and REST resources because we want to override the API library\n      // client class to return a Response object instead.\n      return new Response(JSON.stringify(apiResponse.body), {\n        headers: apiResponse.headers,\n      });\n    } catch (error) {\n      if (this.handleClientError) {\n        throw await this.handleClientError({\n          error,\n          session: this.session,\n          params: this.params,\n        });\n      } else throw new Error(error);\n    }\n  }\n}"
+    }
+  },
+  "StorefrontContext": {
+    "src/server/clients/storefront/types.ts": {
+      "filePath": "src/server/clients/storefront/types.ts",
+      "name": "StorefrontContext",
+      "description": "Provides utilities that apps can use to make requests to the Storefront API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/server/clients/storefront/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "graphql",
+          "value": "GraphQLClient",
+          "description": "Method for interacting with the Shopify Storefront GraphQL API\n\nIf you're getting incorrect type hints in the Shopify template, follow [these instructions](https://github.com/Shopify/shopify-app-template-remix/tree/main#incorrect-graphql-hints).\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Querying the GraphQL API",
+              "description": "Use `storefront.graphql` to make query / mutation requests.",
+              "tabs": [
+                {
+                  "code": "import { ActionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionArgs) {\n  const { storefront } = await authenticate.storefront(request);\n\n  const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface StorefrontContext {\n  /**\n   * Method for interacting with the Shopify Storefront GraphQL API\n   *\n   * If you're getting incorrect type hints in the Shopify template, follow [these instructions](https://github.com/Shopify/shopify-app-template-remix/tree/main#incorrect-graphql-hints).\n   *\n   * {@link https://shopify.dev/docs/api/storefront}\n   *\n   * @example\n   * <caption>Querying the GraphQL API.</caption>\n   * <description>Use `storefront.graphql` to make query / mutation requests.</description>\n   * ```ts\n   * import { ActionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionArgs) {\n   *   const { storefront } = await authenticate.storefront(request);\n   *\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  graphql: GraphQLClient;\n}"
+    }
+  },
+  "AuthenticateAppProxy": {
+    "src/server/authenticate/public/appProxy/types.ts": {
+      "filePath": "src/server/authenticate/public/appProxy/types.ts",
+      "name": "AuthenticateAppProxy",
+      "description": "Authenticates requests coming to the app from Shopify app proxies.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/authenticate/public/appProxy/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/public/appProxy/types.ts",
+        "description": "",
+        "name": "Promise<AppProxyContext | AppProxyContextWithSession>",
+        "value": "Promise<AppProxyContext | AppProxyContextWithSession>"
+      },
+      "value": "(\n  request: Request,\n) => Promise<AppProxyContext | AppProxyContextWithSession>"
+    }
+  },
+  "AppProxyContext": {
+    "src/server/authenticate/public/appProxy/types.ts": {
+      "filePath": "src/server/authenticate/public/appProxy/types.ts",
+      "name": "AppProxyContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "undefined",
+          "description": "No session is available for the shop that made this request. Therefore no methods for interacting with the GraphQL / REST Admin APIs are available."
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "liquid",
+          "value": "LiquidResponseFunction",
+          "description": "A utility for creating a Liquid Response.",
+          "examples": [
+            {
+              "title": "Rendering liquid content",
+              "description": "Use the `liquid` helper to render a `Response` with Liquid content.",
+              "tabs": [
+                {
+                  "code": "import {authenticate} from \"~/shopify.server\"\n\nexport async function loader({ request }) {\n  const {liquid} = authenticate.public.appProxy(request);\n\n  return liquid(\"Hello {{shop.name}}\")\n}",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "undefined",
+          "description": "No session is available for the shop that made this request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice."
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefront",
+          "value": "undefined",
+          "description": "No session is available for the shop that made this request. Therefore no method for interacting with the Storefront API is available."
+        }
+      ],
+      "value": "export interface AppProxyContext extends Context {\n  /**\n   * No session is available for the shop that made this request.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   */\n  session: undefined;\n\n  /**\n   * No session is available for the shop that made this request.\n   * Therefore no methods for interacting with the GraphQL / REST Admin APIs are available.\n   */\n  admin: undefined;\n\n  /**\n   * No session is available for the shop that made this request.\n   * Therefore no method for interacting with the Storefront API is available.\n   */\n  storefront: undefined;\n}"
+    }
+  },
+  "LiquidResponseFunction": {
+    "src/server/authenticate/public/appProxy/types.ts": {
+      "filePath": "src/server/authenticate/public/appProxy/types.ts",
+      "name": "LiquidResponseFunction",
+      "description": "",
+      "params": [
+        {
+          "name": "body",
+          "description": "",
+          "value": "string",
+          "filePath": "src/server/authenticate/public/appProxy/types.ts"
+        },
+        {
+          "name": "initAndOptions",
+          "description": "",
+          "value": "number | (ResponseInit & Options)",
+          "isOptional": true,
+          "filePath": "src/server/authenticate/public/appProxy/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/public/appProxy/types.ts",
+        "description": "",
+        "name": "Response",
+        "value": "Response"
+      },
+      "value": "(\n  body: string,\n  initAndOptions?: number | (ResponseInit & Options),\n) => Response"
+    }
+  },
+  "Options": {
+    "src/server/authenticate/public/appProxy/types.ts": {
+      "filePath": "src/server/authenticate/public/appProxy/types.ts",
+      "name": "Options",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "layout",
+          "value": "boolean",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "interface Options {\n  layout?: boolean;\n}"
+    }
+  },
+  "AppProxyContextWithSession": {
+    "src/server/authenticate/public/appProxy/types.ts": {
+      "filePath": "src/server/authenticate/public/appProxy/types.ts",
+      "name": "AppProxyContextWithSession",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AdminApiContext<Resources>",
+          "description": "Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request.",
+          "examples": [
+            {
+              "title": "Interacting with the Admin API",
+              "description": "Use the `admin` object to interact with the REST or GraphQL APIs.",
+              "tabs": [
+                {
+                  "code": "import { json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionArgs) {\n  const { admin } = await authenticate.public.appProxy(request);\n\n  const response = await admin.graphql(\n    `#graphql\n    mutation populateProduct($input: ProductInput!) {\n      productCreate(input: $input) {\n        product {\n          id\n        }\n      }\n    }`,\n    { variables: { input: { title: \"Product Name\" } } }\n  );\n\n  const productData = await response.json();\n  return json({ data: productData.data });\n}",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "liquid",
+          "value": "LiquidResponseFunction",
+          "description": "A utility for creating a Liquid Response.",
+          "examples": [
+            {
+              "title": "Rendering liquid content",
+              "description": "Use the `liquid` helper to render a `Response` with Liquid content.",
+              "tabs": [
+                {
+                  "code": "import {authenticate} from \"~/shopify.server\"\n\nexport async function loader({ request }) {\n  const {liquid} = authenticate.public.appProxy(request);\n\n  return liquid(\"Hello {{shop.name}}\")\n}",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The session for the shop that made the request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nUse this to get shop or user-specific data.",
+          "examples": [
+            {
+              "title": "Using the session object",
+              "description": "Get your app's data using an offline session for the shop that made the request.",
+              "tabs": [
+                {
+                  "code": "import { json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppModelData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }) => {\n  const { session } = await authenticate.public.appProxy(request);\n  return json(await getMyAppModelData({shop: session.shop));\n};",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/appProxy/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefront",
+          "value": "StorefrontContext",
+          "description": "Method for interacting with the Shopify Storefront Graphql API for the store that made the request.",
+          "examples": [
+            {
+              "title": "Interacting with the Storefront API",
+              "description": "Use the `storefront` object to interact with the GraphQL API.",
+              "tabs": [
+                {
+                  "code": "import { json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport async function action({ request }: ActionArgs) {\n  const { admin } = await authenticate.public.appProxy(request);\n\n  const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n\n  return json(await response.json());\n}",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AppProxyContextWithSession<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends Context {\n  /**\n   * The session for the shop that made the request.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * Use this to get shop or user-specific data.\n   *\n   * @example\n   * <caption>Using the session object.</caption>\n   * <description>Get your app's data using an offline session for the shop that made the request.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppModelData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }) => {\n   *   const { session } = await authenticate.public.appProxy(request);\n   *   return json(await getMyAppModelData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Admin API.</caption>\n   * <description>Use the `admin` object to interact with the REST or GraphQL APIs.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionArgs) {\n   *   const { admin } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await admin.graphql(\n   *     `#graphql\n   *     mutation populateProduct($input: ProductInput!) {\n   *       productCreate(input: $input) {\n   *         product {\n   *           id\n   *         }\n   *       }\n   *     }`,\n   *     { variables: { input: { title: \"Product Name\" } } }\n   *   );\n   *\n   *   const productData = await response.json();\n   *   return json({ data: productData.data });\n   * }\n   * ```\n   */\n  admin: AdminApiContext<Resources>;\n\n  /**\n   * Method for interacting with the Shopify Storefront Graphql API for the store that made the request.\n   *\n   * @example\n   * <caption>Interacting with the Storefront API.</caption>\n   * <description>Use the `storefront` object to interact with the GraphQL API.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export async function action({ request }: ActionArgs) {\n   *   const { admin } = await authenticate.public.appProxy(request);\n   *\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   */\n  storefront: StorefrontContext;\n}"
+    }
+  },
+  "BillingContext": {
+    "src/server/authenticate/admin/billing/types.ts": {
+      "filePath": "src/server/authenticate/admin/billing/types.ts",
+      "name": "BillingContext",
+      "description": "Provides utilities that apps can use to request billing for the app using the Admin API.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cancel",
+          "value": "(options: CancelBillingOptions) => Promise<AppSubscription>",
+          "description": "Cancels an ongoing subscription, given its ID.",
+          "examples": [
+            {
+              "title": "Cancelling a subscription",
+              "description": "Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const billingCheck = await billing.require({\n    plans: [MONTHLY_PLAN],\n    onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n  });\n\n  const subscription = billingCheck.appSubscriptions[0];\n  const cancelledSubscription = await billing.cancel({\n    subscriptionId: subscription.id,\n    isTest: true,\n    prorate: true,\n   });\n\n  // App logic\n};",
+                  "title": "/app/routes/cancel-subscription.ts"
+                },
+                {
+                  "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "request",
+          "value": "(options: RequestBillingOptions<Config>) => Promise<never>",
+          "description": "Requests payment for the plan.",
+          "examples": [
+            {
+              "title": "Using a custom return URL",
+              "description": "Change where the merchant is returned to after approving the purchase using the `returnUrl` option.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { billing } = await authenticate.admin(request);\n  await billing.require({\n    plans: [MONTHLY_PLAN],\n    onFailure: async () => billing.request({\n      plan: MONTHLY_PLAN,\n      isTest: true,\n      returnUrl: '/billing-complete',\n    }),\n  });\n\n  // App logic\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                },
+                {
+                  "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "require",
+          "value": "(options: RequireBillingOptions<Config>) => Promise<BillingCheckResponseObject>",
+          "description": "Checks if the shop has an active payment for any plan defined in the `billing` config option.",
+          "examples": [
+            {
+              "title": "Requesting billing right away",
+              "description": "Call `billing.request` in the `onFailure` callback to immediately request payment.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { billing } = await authenticate.admin(request);\n  await billing.require({\n    plans: [MONTHLY_PLAN],\n    isTest: true,\n    onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n  });\n\n  // App logic\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                },
+                {
+                  "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                }
+              ]
+            },
+            {
+              "title": "Using a plan selection page",
+              "description": "Redirect to a different page in the `onFailure` callback, where the merchant can select a billing plan.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, redirect } from \"@remix-run/node\";\nimport { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { billing } = await authenticate.admin(request);\n  const billingCheck = await billing.require({\n    plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n    isTest: true,\n    onFailure: () => redirect('/select-plan'),\n  });\n\n  const subscription = billingCheck.appSubscriptions[0];\n  console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n\n  // App logic\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                },
+                {
+                  "code": "import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n\nexport const MONTHLY_PLAN = 'Monthly subscription';\nexport const ANNUAL_PLAN = 'Annual subscription';\n\nconst shopify = shopifyApp({\n  // ...etc\n  billing: {\n    [MONTHLY_PLAN]: {\n      amount: 5,\n      currencyCode: 'USD',\n      interval: BillingInterval.Every30Days,\n    },\n    [ANNUAL_PLAN]: {\n      amount: 50,\n      currencyCode: 'USD',\n      interval: BillingInterval.Annual,\n    },\n  }\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface BillingContext<Config extends AppConfigArg> {\n  /**\n   * Checks if the shop has an active payment for any plan defined in the `billing` config option.\n   *\n   * @returns A promise that resolves to an object containing the active purchases for the shop.\n   *\n   * @example\n   * <caption>Requesting billing right away.</caption>\n   * <description>Call `billing.request` in the `onFailure` callback to immediately request payment.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     isTest: true,\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   *\n   * @example\n   * <caption>Using a plan selection page.</caption>\n   * <description>Redirect to a different page in the `onFailure` callback, where the merchant can select a billing plan.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs, redirect } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN, ANNUAL_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN, ANNUAL_PLAN],\n   *     isTest: true,\n   *     onFailure: () => redirect('/select-plan'),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   console.log(`Shop is on ${subscription.name} (id ${subscription.id})`);\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  require: (\n    options: RequireBillingOptions<Config>,\n  ) => Promise<BillingCheckResponseObject>;\n\n  /**\n   * Requests payment for the plan.\n   *\n   * @returns Redirects to the confirmation URL for the payment.\n   *\n   * @example\n   * <caption>Using a custom return URL.</caption>\n   * <description>Change where the merchant is returned to after approving the purchase using the `returnUrl` option.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({\n   *       plan: MONTHLY_PLAN,\n   *       isTest: true,\n   *       returnUrl: '/billing-complete',\n   *     }),\n   *   });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  request: (options: RequestBillingOptions<Config>) => Promise<never>;\n\n  /**\n   * Cancels an ongoing subscription, given its ID.\n   *\n   * @returns The cancelled subscription.\n   *\n   * @example\n   * <caption>Cancelling a subscription.</caption>\n   * <description>Use the `billing.cancel` function to cancel an active subscription with the id returned from `billing.require`.</description>\n   * ```ts\n   * // /app/routes/cancel-subscription.ts\n   * import { LoaderArgs } from \"@remix-run/node\";\n   * import { authenticate, MONTHLY_PLAN } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { billing } = await authenticate.admin(request);\n   *   const billingCheck = await billing.require({\n   *     plans: [MONTHLY_PLAN],\n   *     onFailure: async () => billing.request({ plan: MONTHLY_PLAN }),\n   *   });\n   *\n   *   const subscription = billingCheck.appSubscriptions[0];\n   *   const cancelledSubscription = await billing.cancel({\n   *     subscriptionId: subscription.id,\n   *     isTest: true,\n   *     prorate: true,\n   *    });\n   *\n   *   // App logic\n   * };\n   * ```\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp, BillingInterval } from \"@shopify/shopify-app-remix/server\";\n   *\n   * export const MONTHLY_PLAN = 'Monthly subscription';\n   * export const ANNUAL_PLAN = 'Annual subscription';\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   billing: {\n   *     [MONTHLY_PLAN]: {\n   *       amount: 5,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Every30Days,\n   *     },\n   *     [ANNUAL_PLAN]: {\n   *       amount: 50,\n   *       currencyCode: 'USD',\n   *       interval: BillingInterval.Annual,\n   *     },\n   *   }\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   */\n  cancel: (options: CancelBillingOptions) => Promise<AppSubscription>;\n}"
+    }
+  },
+  "CancelBillingOptions": {
+    "src/server/authenticate/admin/billing/types.ts": {
+      "filePath": "src/server/authenticate/admin/billing/types.ts",
+      "name": "CancelBillingOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": "",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "prorate",
+          "value": "boolean",
+          "description": "Whether to prorate the cancellation.\n\n\n\n\n",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "subscriptionId",
+          "value": "string",
+          "description": "The ID of the subscription to cancel."
+        }
+      ],
+      "value": "export interface CancelBillingOptions {\n  /**\n   * The ID of the subscription to cancel.\n   */\n  subscriptionId: string;\n  /**\n   * Whether to prorate the cancellation.\n   *\n   * {@link https://shopify.dev/docs/apps/billing/subscriptions/cancel-recurring-charges}\n   */\n  prorate?: boolean;\n  isTest?: boolean;\n}"
+    }
+  },
+  "RequestBillingOptions": {
+    "src/server/authenticate/admin/billing/types.ts": {
+      "filePath": "src/server/authenticate/admin/billing/types.ts",
+      "name": "RequestBillingOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "amount",
+          "value": "number",
+          "description": "Amount to charge for this plan."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "currencyCode",
+          "value": "string",
+          "description": "Currency code for this plan."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "interval",
+          "value": "BillingInterval.OneTime",
+          "description": "Interval for this plan.\n\nMust be set to `OneTime`."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": "Whether this is a test purchase.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "lineItems",
+          "value": "({ interval?: BillingInterval.Every30Days | BillingInterval.Annual; discount?: { durationLimitInIntervals?: number; value?: { amount?: number; percentage?: never; } | { amount?: never; percentage?: number; }; }; amount?: number; currencyCode?: string; } | { interval?: BillingInterval.Usage; amount?: number; terms?: string; currencyCode?: string; })[]",
+          "description": "The line items for this plan."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plan",
+          "value": "keyof Config[\"billing\"]",
+          "description": "The plan to request. Must be one of the values defined in the `billing` config option."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "replacementBehavior",
+          "value": "BillingReplacementBehavior",
+          "description": "The replacement behavior to use for this plan.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "returnUrl",
+          "value": "string",
+          "description": "Override the return URL after the purchase is complete.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "trialDays",
+          "value": "number",
+          "description": "How many trial days to give before charging for this plan.",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface RequestBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingRequestParams, 'session' | 'plan' | 'returnObject'> {\n  /**\n   * The plan to request. Must be one of the values defined in the `billing` config option.\n   */\n  plan: keyof Config['billing'];\n}"
+    }
+  },
+  "RequireBillingOptions": {
+    "src/server/authenticate/admin/billing/types.ts": {
+      "filePath": "src/server/authenticate/admin/billing/types.ts",
+      "name": "RequireBillingOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTest",
+          "value": "boolean",
+          "description": "Whether to include charges that were created on test mode. Test shops and demo shops cannot be charged.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "onFailure",
+          "value": "(error: any) => Promise<Response>",
+          "description": "How to handle the request if the shop doesn't have an active payment for any plan."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/billing/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "plans",
+          "value": "(keyof Config[\"billing\"])[]",
+          "description": "The plans to check for. Must be one of the values defined in the `billing` config option."
+        }
+      ],
+      "value": "export interface RequireBillingOptions<Config extends AppConfigArg>\n  extends Omit<BillingCheckParams, 'session' | 'plans' | 'returnObject'> {\n  /**\n   * The plans to check for. Must be one of the values defined in the `billing` config option.\n   */\n  plans: (keyof Config['billing'])[];\n  /**\n   * How to handle the request if the shop doesn't have an active payment for any plan.\n   */\n  onFailure: (error: any) => Promise<Response>;\n}"
+    }
+  },
+  "AuthenticateAdmin": {
+    "src/server/authenticate/admin/types.ts": {
+      "filePath": "src/server/authenticate/admin/types.ts",
+      "name": "AuthenticateAdmin",
+      "description": "Authenticates requests coming from the Shopify admin.\n\nThe shape of the returned object changes depending on the `isEmbeddedApp` config.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/authenticate/admin/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/admin/types.ts",
+        "description": "",
+        "name": "Promise<AdminContext<Config, Resources>>",
+        "value": "Promise<AdminContext<Config, Resources>>"
+      },
+      "value": "(request: Request) => Promise<AdminContext<Config, Resources>>"
+    }
+  },
+  "AdminContext": {
+    "src/server/authenticate/admin/types.ts": {
+      "filePath": "src/server/authenticate/admin/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AdminContext",
+      "value": "Config['isEmbeddedApp'] extends false\n  ? NonEmbeddedAdminContext<Config, Resources>\n  : EmbeddedAdminContext<Config, Resources>",
+      "description": ""
+    }
+  },
+  "NonEmbeddedAdminContext": {
+    "src/server/authenticate/admin/types.ts": {
+      "filePath": "src/server/authenticate/admin/types.ts",
+      "name": "NonEmbeddedAdminContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AdminApiContext<Resources>",
+          "description": "Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "BillingContext<Config>",
+          "description": "Billing methods for this store, based on the plans defined in the `billing` config option.\n\n\n\n\n"
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cors",
+          "value": "EnsureCORSFunction",
+          "description": "A function that ensures the CORS headers are set correctly for the response.",
+          "examples": [
+            {
+              "title": "Setting CORS headers for a admin request",
+              "description": "Use the `cors` helper to ensure your app can respond to requests from admin extensions.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session, cors } = await authenticate.admin(request);\n  return cors(json(await getMyAppData({user: session.onlineAccessInfo!.id})));\n};",
+                  "title": "/app/routes/admin/my-route.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The session for the user who made the request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nUse this to get shop or user-specific data.",
+          "examples": [
+            {
+              "title": "Using offline sessions",
+              "description": "Get your app's shop-specific data using an offline session.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            },
+            {
+              "title": "Using online sessions",
+              "description": "Get your app's user-specific data using an online session.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({user: session.onlineAccessInfo!.id}));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface NonEmbeddedAdminContext<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends AdminContextInternal<Config, Resources> {}"
+    }
+  },
+  "EmbeddedAdminContext": {
+    "src/server/authenticate/admin/types.ts": {
+      "filePath": "src/server/authenticate/admin/types.ts",
+      "name": "EmbeddedAdminContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AdminApiContext<Resources>",
+          "description": "Methods for interacting with the GraphQL / REST Admin APIs for the store that made the request."
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "BillingContext<Config>",
+          "description": "Billing methods for this store, based on the plans defined in the `billing` config option.\n\n\n\n\n"
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "cors",
+          "value": "EnsureCORSFunction",
+          "description": "A function that ensures the CORS headers are set correctly for the response.",
+          "examples": [
+            {
+              "title": "Setting CORS headers for a admin request",
+              "description": "Use the `cors` helper to ensure your app can respond to requests from admin extensions.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session, cors } = await authenticate.admin(request);\n  return cors(json(await getMyAppData({user: session.onlineAccessInfo!.id})));\n};",
+                  "title": "/app/routes/admin/my-route.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "redirect",
+          "value": "RedirectFunction",
+          "description": "A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded apps.\n\nReturned only if `isEmbeddedApp` is `true`.",
+          "examples": [
+            {
+              "title": "Redirecting to an app route",
+              "description": "Use the `redirect` helper to safely redirect between pages.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session, redirect } = await authenticate.admin(request);\n  return redirect(\"/\");\n};",
+                  "title": "/app/routes/admin/my-route.ts"
+                }
+              ]
+            },
+            {
+              "title": "Redirecting outside of Shopify admin",
+              "description": "Pass in a `target` option of `_top` or `_parent` to go to an external URL.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session, redirect } = await authenticate.admin(request);\n  return redirect(\"/\", { target: '_parent' });\n};",
+                  "title": "/app/routes/admin/my-route.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The session for the user who made the request.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nUse this to get shop or user-specific data.",
+          "examples": [
+            {
+              "title": "Using offline sessions",
+              "description": "Get your app's shop-specific data using an offline session.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            },
+            {
+              "title": "Using online sessions",
+              "description": "Get your app's user-specific data using an online session.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { session } = await authenticate.admin(request);\n  return json(await getMyAppData({user: session.onlineAccessInfo!.id}));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionToken",
+          "value": "JwtPayload",
+          "description": "The decoded and validated session token for the request.\n\nReturned only if `isEmbeddedApp` is `true`.\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Using the decoded session token",
+              "description": "Get user-specific data using the `sessionToken` object.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  useOnlineTokens: true,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { sessionToken } = await authenticate.public.checkout(\n    request\n  );\n  return json(await getMyAppData({user: sessionToken.sub}));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface EmbeddedAdminContext<\n  Config extends AppConfigArg,\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n> extends AdminContextInternal<Config, Resources> {\n  /**\n   * The decoded and validated session token for the request.\n   *\n   * Returned only if `isEmbeddedApp` is `true`.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/session-tokens#payload}\n   *\n   * @example\n   * <caption>Using the decoded session token.</caption>\n   * <description>Get user-specific data using the `sessionToken` object.</description>\n   * ```ts\n   * // shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   useOnlineTokens: true,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { sessionToken } = await authenticate.public.checkout(\n   *     request\n   *   );\n   *   return json(await getMyAppData({user: sessionToken.sub}));\n   * };\n   * ```\n   */\n  sessionToken: JwtPayload;\n\n  /**\n   * A function that redirects the user to a new page, ensuring that the appropriate parameters are set for embedded\n   * apps.\n   *\n   * Returned only if `isEmbeddedApp` is `true`.\n   *\n   * @example\n   * <caption>Redirecting to an app route.</caption>\n   * <description>Use the `redirect` helper to safely redirect between pages.</description>\n   * ```ts\n   * // /app/routes/admin/my-route.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { session, redirect } = await authenticate.admin(request);\n   *   return redirect(\"/\");\n   * };\n   * ```\n   *\n   * @example\n   * <caption>Redirecting outside of Shopify admin.</caption>\n   * <description>Pass in a `target` option of `_top` or `_parent` to go to an external URL.</description>\n   * ```ts\n   * // /app/routes/admin/my-route.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { session, redirect } = await authenticate.admin(request);\n   *   return redirect(\"/\", { target: '_parent' });\n   * };\n   * ```\n   */\n  redirect: RedirectFunction;\n}"
+    }
+  },
+  "RedirectFunction": {
+    "src/server/authenticate/admin/helpers/redirect.ts": {
+      "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
+      "name": "RedirectFunction",
+      "description": "",
+      "params": [
+        {
+          "name": "url",
+          "description": "",
+          "value": "string",
+          "filePath": "src/server/authenticate/admin/helpers/redirect.ts"
+        },
+        {
+          "name": "init",
+          "description": "",
+          "value": "RedirectInit",
+          "isOptional": true,
+          "filePath": "src/server/authenticate/admin/helpers/redirect.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
+        "description": "",
+        "name": "TypedResponse<never>",
+        "value": "TypedResponse<never>"
+      },
+      "value": "(\n  url: string,\n  init?: RedirectInit,\n) => TypedResponse<never>"
+    }
+  },
+  "RedirectInit": {
+    "src/server/authenticate/admin/helpers/redirect.ts": {
+      "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RedirectInit",
+      "value": "number | (ResponseInit & {target?: RedirectTarget})",
+      "description": ""
+    }
+  },
+  "RedirectTarget": {
+    "src/server/authenticate/admin/helpers/redirect.ts": {
+      "filePath": "src/server/authenticate/admin/helpers/redirect.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RedirectTarget",
+      "value": "'_self' | '_parent' | '_top'",
+      "description": ""
+    }
+  },
+  "GetUnauthenticatedAdminContext": {
+    "src/server/unauthenticated/admin/types.ts": {
+      "filePath": "src/server/unauthenticated/admin/types.ts",
+      "name": "GetUnauthenticatedAdminContext",
+      "description": "Creates an unauthenticated Admin context.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "shop",
+          "description": "",
+          "value": "string",
+          "filePath": "src/server/unauthenticated/admin/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/unauthenticated/admin/types.ts",
+        "description": "",
+        "name": "Promise<UnauthenticatedAdminContext<Resources>>",
+        "value": "Promise<UnauthenticatedAdminContext<Resources>>"
+      },
+      "value": "(shop: string) => Promise<UnauthenticatedAdminContext<Resources>>"
+    }
+  },
+  "UnauthenticatedAdminContext": {
+    "src/server/unauthenticated/admin/types.ts": {
+      "filePath": "src/server/unauthenticated/admin/types.ts",
+      "name": "UnauthenticatedAdminContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/unauthenticated/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AdminApiContext<Resources>",
+          "description": "Methods for interacting with the GraphQL / REST Admin APIs for the given store."
+        },
+        {
+          "filePath": "src/server/unauthenticated/admin/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The session for the given shop.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nThis will always be an offline session. You can use to get shop-specific data.",
+          "examples": [
+            {
+              "title": "Using the offline session",
+              "description": "Get your app's shop-specific data using the returned offline `session` object.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { unauthenticated } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const shop = getShopFromExternalRequest(request);\n  const { session } = await unauthenticated.admin(shop);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                  "title": "/app/routes/**\\/*.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface UnauthenticatedAdminContext<\n  Resources extends ShopifyRestResources,\n> {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use to get shop-specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // /app/routes/**\\/*.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.admin(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Methods for interacting with the GraphQL / REST Admin APIs for the given store.\n   */\n  admin: AdminApiContext<Resources>;\n}"
+    }
+  },
+  "GetUnauthenticatedStorefrontContext": {
+    "src/server/unauthenticated/storefront/types.ts": {
+      "filePath": "src/server/unauthenticated/storefront/types.ts",
+      "name": "GetUnauthenticatedStorefrontContext",
+      "description": "Creates an unauthenticated Storefront context.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "shop",
+          "description": "",
+          "value": "string",
+          "filePath": "src/server/unauthenticated/storefront/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/unauthenticated/storefront/types.ts",
+        "description": "",
+        "name": "Promise<UnauthenticatedStorefrontContext>",
+        "value": "Promise<UnauthenticatedStorefrontContext>"
+      },
+      "value": "(\n  shop: string,\n) => Promise<UnauthenticatedStorefrontContext>"
+    }
+  },
+  "UnauthenticatedStorefrontContext": {
+    "src/server/unauthenticated/storefront/types.ts": {
+      "filePath": "src/server/unauthenticated/storefront/types.ts",
+      "name": "UnauthenticatedStorefrontContext",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/unauthenticated/storefront/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The session for the given shop.\n\nThis comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n\nThis will always be an offline session. You can use this to get shop specific data.",
+          "examples": [
+            {
+              "title": "Using the offline session",
+              "description": "Get your app's shop-specific data using the returned offline `session` object.",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { unauthenticated } from \"../shopify.server\";\nimport { getMyAppData } from \"~/db/model.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const shop = getShopFromExternalRequest(request);\n  const { session } = await unauthenticated.storefront(shop);\n  return json(await getMyAppData({shop: session.shop));\n};",
+                  "title": "app/routes/**\\/.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/unauthenticated/storefront/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefront",
+          "value": "StorefrontContext",
+          "description": "Method for interacting with the Shopify GraphQL Storefront API for the given store."
+        }
+      ],
+      "value": "export interface UnauthenticatedStorefrontContext {\n  /**\n   * The session for the given shop.\n   *\n   * This comes from the session storage which `shopifyApp` uses to store sessions in your database of choice.\n   *\n   * This will always be an offline session. You can use this to get shop specific data.\n   *\n   * @example\n   * <caption>Using the offline session.</caption>\n   * <description>Get your app's shop-specific data using the returned offline `session` object.</description>\n   * ```ts\n   * // app/routes/**\\/.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { unauthenticated } from \"../shopify.server\";\n   * import { getMyAppData } from \"~/db/model.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const shop = getShopFromExternalRequest(request);\n   *   const { session } = await unauthenticated.storefront(shop);\n   *   return json(await getMyAppData({shop: session.shop));\n   * };\n   * ```\n   */\n  session: Session;\n\n  /**\n   * Method for interacting with the Shopify GraphQL Storefront API for the given store.\n   */\n  storefront: StorefrontContext;\n}"
+    }
+  },
+  "ShopifyAppGeneratedType": {
+    "src/server/shopify-app.ts": {
+      "filePath": "src/server/shopify-app.ts",
+      "name": "ShopifyAppGeneratedType",
+      "description": "Creates an object your app will use to interact with Shopify.",
+      "isPublicDocs": true,
+      "params": [
+        {
+          "name": "appConfig",
+          "description": "Configuration options for your Shopify app, such as the scopes your app needs.",
+          "value": "Config extends AppConfigArg<Resources, Storage>",
+          "filePath": "src/server/shopify-app.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/shopify-app.ts",
+        "description": "`ShopifyApp` An object constructed using your appConfig.  It has methods for interacting with Shopify.",
+        "name": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>",
+        "value": "ShopifyApp<Config extends AppConfigArg<Resources, Storage>>"
+      },
+      "value": "export function shopifyApp<\n  Config extends AppConfigArg<Resources, Storage>,\n  Resources extends ShopifyRestResources,\n  Storage extends SessionStorage,\n>(appConfig: Config): ShopifyApp<Config> {\n  const api = deriveApi<Resources>(appConfig);\n  const config = deriveConfig<Storage>(appConfig, api.config);\n  const logger = overrideLogger(api.logger);\n\n  if (appConfig.webhooks) {\n    api.webhooks.addHandlers(appConfig.webhooks);\n  }\n\n  const params: BasicParams = {api, config, logger};\n  const oauth = new AuthStrategy<Config, Resources>(params);\n\n  const shopify:\n    | AdminApp<Config>\n    | AppStoreApp<Config>\n    | SingleMerchantApp<Config> = {\n    sessionStorage: config.sessionStorage,\n    addDocumentResponseHeaders: addDocumentResponseHeadersFactory(params),\n    registerWebhooks: registerWebhooksFactory(params),\n    authenticate: {\n      admin: oauth.authenticateAdmin.bind(oauth),\n      public: authenticatePublicFactory<Resources>(params),\n      webhook: authenticateWebhookFactory<\n        Resources,\n        keyof Config['webhooks'] | MandatoryTopics\n      >(params),\n    },\n    unauthenticated: {\n      admin: unauthenticatedAdminContextFactory(params),\n      storefront: unauthenticatedStorefrontContextFactory(params),\n    },\n  };\n\n  if (\n    isAppStoreApp(shopify, appConfig) ||\n    isSingleMerchantApp(shopify, appConfig)\n  ) {\n    shopify.login = loginFactory(params);\n  }\n\n  return shopify as ShopifyApp<Config>;\n}",
+      "examples": [
+        {
+          "title": "The minimum viable configuration",
+          "description": "",
+          "tabs": [
+            {
+              "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  apiKey: process.env.SHOPIFY_API_KEY!,\n  apiSecretKey: process.env.SHOPIFY_API_SECRET!,\n  scopes: process.env.SCOPES?.split(\",\")!,\n  appUrl: process.env.SHOPIFY_APP_URL!,\n});\nexport default shopify;",
+              "title": "Example"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "AppConfigArg": {
+    "src/server/config-types.ts": {
+      "filePath": "src/server/config-types.ts",
+      "name": "AppConfigArg",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "_logDisabledFutureFlags",
+          "value": "boolean",
+          "description": "Whether to log disabled future flags at startup.",
+          "isOptional": true,
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "adminApiAccessToken",
+          "value": "string",
+          "description": "An app-wide API access token.\n\nOnly applies to custom apps.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiKey",
+          "value": "string",
+          "description": "The API key for your app.\n\nAlso known as Client ID in your Partner Dashboard.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiSecretKey",
+          "value": "string",
+          "description": "The API secret key for your app.\n\nAlso known as Client Secret in your Partner Dashboard."
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "apiVersion",
+          "value": "ApiVersion",
+          "description": "What version of Shopify's Admin API's would you like to use.\n\n\n\n\n",
+          "isOptional": true,
+          "defaultValue": "`LATEST_API_VERSION` from `@shopify/shopify-app-remix`",
+          "examples": [
+            {
+              "title": "Using the latest API Version (Recommended)",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  apiVersion: LATEST_API_VERSION,\n});",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appUrl",
+          "value": "string",
+          "description": "The URL your app is running on.\n\nThe `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL."
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "authPathPrefix",
+          "value": "string",
+          "description": "A path that Shopify can reserve for auth related endpoints.\n\nThis must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.",
+          "isOptional": true,
+          "defaultValue": "`\"/auth\"`",
+          "examples": [
+            {
+              "title": "Using the latest API Version (Recommended)",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n  apiVersion: LATEST_API_VERSION,\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;\n\n// /app/routes/auth/$.jsx\nimport { LoaderArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  await authenticate.admin(request);\n\n  return null\n}",
+                  "title": "/app/shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "billing",
+          "value": "BillingConfig",
+          "description": "Billing configurations for the app.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "customShopDomains",
+          "value": "(string | RegExp)[]",
+          "description": "Override values for Shopify shop domains.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "distribution",
+          "value": "AppDistribution",
+          "description": "How your app is distributed. Default is `AppDistribution.AppStore`.\n\n\n\n\n",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "future",
+          "value": "Future",
+          "description": "Future flags to include for this app.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "hooks",
+          "value": "HooksConfig",
+          "description": "Functions to call at key places during your apps lifecycle.\n\nThese functions are called in the context of the request that triggered them.  This means you can access the session.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Seeding your database custom data when a merchant installs your app",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { seedStoreData } from \"~/db/seeds\"\n\nconst shopify = shopifyApp({\n  hooks: {\n    afterAuth: async ({ session }) => {\n      seedStoreData({session})\n    }\n  },\n  // ...etc\n});",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isEmbeddedApp",
+          "value": "boolean",
+          "description": "Does your app render embedded inside the Shopify Admin or on its own.\n\nUnless you have very specific needs, this should be true.",
+          "isOptional": true,
+          "defaultValue": "`true`"
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "isTesting",
+          "value": "boolean",
+          "description": "Whether the app is initialised for local testing.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "logger",
+          "value": "{ log?: LogFunction; level?: LogSeverity; httpRequests?: boolean; timestamps?: boolean; }",
+          "description": "Customization options for Shopify logs.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "privateAppStorefrontAccessToken",
+          "value": "string",
+          "description": "An app-wide API access token for the storefront API.\n\nOnly applies to custom apps.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "restResources",
+          "value": "Resources",
+          "description": "REST resources to access the Admin API.\n\nYou can import these from `@shopify/shopify-api/rest/admin/*`.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "scopes",
+          "value": "string[] | AuthScopes",
+          "description": "The scopes your app needs to access the API. Not required if using Shopify managed installation.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionStorage",
+          "value": "Storage",
+          "description": "An adaptor for storing sessions in your database of choice.\n\nShopify provides multiple session storage adaptors and you can create your own.\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Storing sessions with Prisma",
+              "description": "Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n\nimport prisma from \"~/db.server\";\n\nconst shopify = shopifyApp({\n  // ... etc\n  sessionStorage: new PrismaSessionStorage(prisma),\n});\nexport default shopify;",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "useOnlineTokens",
+          "value": "boolean",
+          "description": "Whether your app use online or offline tokens.\n\nIf your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n\n\n\n\n",
+          "isOptional": true,
+          "defaultValue": "`false`"
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "userAgentPrefix",
+          "value": "string",
+          "description": "The user agent prefix to use for API requests.",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "webhooks",
+          "value": "WebhookConfig",
+          "description": "The config for the webhook topics your app would like to subscribe to.\n\n\n\n\n\n\n\nThis can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Registering for a webhook when a merchant uninstalls your app",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  webhooks: {\n    APP_UNINSTALLED: {\n      deliveryMethod: DeliveryMethod.Http,\n       callbackUrl: \"/webhooks\",\n    },\n  },\n  hooks: {\n    afterAuth: async ({ session }) => {\n      shopify.registerWebhooks({ session });\n    }\n  },\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;\n\n// /app/routes/webhooks.jsx\nimport { ActionArgs } from \"@remix-run/node\";\n\nimport { authenticate } from \"../shopify.server\";\nimport db from \"../db.server\";\n\nexport const action = async ({ request }: ActionArgs) => {\n  const { topic, shop } = await authenticate.webhook(request);\n\n  switch (topic) {\n    case \"APP_UNINSTALLED\":\n      await db.session.deleteMany({ where: { shop } });\n      break;\n    case \"CUSTOMERS_DATA_REQUEST\":\n    case \"CUSTOMERS_REDACT\":\n    case \"SHOP_REDACT\":\n    default:\n      throw new Response(\"Unhandled webhook topic\", { status: 404 });\n  }\n  throw new Response();\n};",
+                  "title": "/app/shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface AppConfigArg<\n  Resources extends ShopifyRestResources = ShopifyRestResources,\n  Storage extends SessionStorage = SessionStorage,\n> extends Omit<\n    ApiConfigArg<Resources>,\n    | 'hostName'\n    | 'hostScheme'\n    | 'isEmbeddedApp'\n    | 'apiVersion'\n    | 'isCustomStoreApp'\n  > {\n  /**\n   * The URL your app is running on.\n   *\n   * The `@shopify/cli` provides this URL as `process.env.SHOPIFY_APP_URL`.  For development this is probably a tunnel URL that points to your local machine.  If this is a production app, this is your production URL.\n   */\n  appUrl: string;\n\n  /**\n   * An adaptor for storing sessions in your database of choice.\n   *\n   * Shopify provides multiple session storage adaptors and you can create your own.\n   *\n   * {@link https://github.com/Shopify/shopify-app-js/blob/main/README.md#session-storage-options}\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Add the `@shopify/shopify-app-session-storage-prisma` package to use the Prisma session storage.</description>\n   * ```ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   *\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ... etc\n   *   sessionStorage: new PrismaSessionStorage(prisma),\n   * });\n   * export default shopify;\n   * ```\n   */\n  sessionStorage: Storage;\n\n  /**\n   * Whether your app use online or offline tokens.\n   *\n   * If your app uses online tokens, then both online and offline tokens will be saved to your database.  This ensures your app can perform background jobs.\n   *\n   * {@link https://shopify.dev/docs/apps/auth/oauth/access-modes}\n   *\n   * @defaultValue `false`\n   */\n  useOnlineTokens?: boolean;\n\n  /**\n   * The config for the webhook topics your app would like to subscribe to.\n   *\n   * {@link https://shopify.dev/docs/apps/webhooks}\n   *\n   * This can be in used in conjunction with the afterAuth hook to register webhook topics when a user installs your app.  Or you can use this function in other processes such as background jobs.\n   *\n   * @example\n   * <caption>Registering for a webhook when a merchant uninstalls your app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/webhooks.jsx\n   * import { ActionArgs } from \"@remix-run/node\";\n   *\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionArgs) => {\n   *   const { topic, shop } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       await db.session.deleteMany({ where: { shop } });\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhooks?: WebhookConfig;\n\n  /**\n   * Functions to call at key places during your apps lifecycle.\n   *\n   * These functions are called in the context of the request that triggered them.  This means you can access the session.\n   *\n   * @example\n   * <caption>Seeding your database custom data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  hooks?: HooksConfig;\n\n  /**\n   * Does your app render embedded inside the Shopify Admin or on its own.\n   *\n   * Unless you have very specific needs, this should be true.\n   *\n   * @defaultValue `true`\n   */\n  isEmbeddedApp?: boolean;\n\n  /**\n   * How your app is distributed. Default is `AppDistribution.AppStore`.\n   *\n   * {@link https://shopify.dev/docs/apps/distribution}\n   */\n  distribution?: AppDistribution;\n\n  /**\n   * What version of Shopify's Admin API's would you like to use.\n   *\n   * {@link https://shopify.dev/docs/api/}\n   *\n   * @defaultValue `LATEST_API_VERSION` from `@shopify/shopify-app-remix`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * ```\n   */\n  apiVersion?: ApiVersion;\n\n  /**\n   * A path that Shopify can reserve for auth related endpoints.\n   *\n   * This must match a $ route in your Remix app.  That route must export a loader function that calls `shopify.authenticate.admin(request)`.\n   *\n   * @default `\"/auth\"`\n   *\n   * @example\n   * <caption>Using the latest API Version (Recommended)</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   *   apiVersion: LATEST_API_VERSION,\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   *\n   * // /app/routes/auth/$.jsx\n   * import { LoaderArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   await authenticate.admin(request);\n   *\n   *   return null\n   * }\n   * ```\n   */\n  authPathPrefix?: string;\n}"
+    }
+  },
+  "AppDistribution": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "AppDistribution",
+      "value": "export enum AppDistribution {\n  AppStore = 'app_store',\n  SingleMerchant = 'single_merchant',\n  ShopifyAdmin = 'shopify_admin',\n}",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "name": "AppStore",
+          "value": "app_store"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "name": "SingleMerchant",
+          "value": "single_merchant"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "name": "ShopifyAdmin",
+          "value": "shopify_admin"
+        }
+      ]
+    }
+  },
+  "HooksConfig": {
+    "src/server/config-types.ts": {
+      "filePath": "src/server/config-types.ts",
+      "name": "HooksConfig",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "afterAuth",
+          "value": "(options: AfterAuthOptions<ShopifyRestResources>) => void | Promise<void>",
+          "description": "A function to call after a merchant installs your app",
+          "isOptional": true,
+          "examples": [
+            {
+              "title": "Registering webhooks and seeding data when a merchant installs your app",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { seedStoreData } from \"~/db/seeds\"\n\nconst shopify = shopifyApp({\n  hooks: {\n    afterAuth: async ({ session }) => {\n      shopify.registerWebhooks({ session });\n      seedStoreData({session})\n    }\n  },\n  webhooks: {\n    APP_UNINSTALLED: {\n      deliveryMethod: DeliveryMethod.Http,\n       callbackUrl: \"/webhooks\",\n    },\n  },\n  // ...etc\n});",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "interface HooksConfig {\n  /**\n   * A function to call after a merchant installs your app\n   *\n   * @param context - An object with context about the request that triggered the hook.\n   * @param context.session - The session of the merchant that installed your app. This is the output of sessionStorage.loadSession in case people want to load their own.\n   * @param context.admin - An object with access to the Shopify Admin API's.\n   *\n   * @example\n   * <caption>Registering webhooks and seeding data when a merchant installs your app.</caption>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { seedStoreData } from \"~/db/seeds\"\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *       seedStoreData({session})\n   *     }\n   *   },\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  afterAuth?: (options: AfterAuthOptions) => void | Promise<void>;\n}"
+    }
+  },
+  "AfterAuthOptions": {
+    "src/server/config-types.ts": {
+      "filePath": "src/server/config-types.ts",
+      "name": "AfterAuthOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AdminApiContext<R>",
+          "description": ""
+        },
+        {
+          "filePath": "src/server/config-types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": ""
+        }
+      ],
+      "value": "export interface AfterAuthOptions<\n  R extends ShopifyRestResources = ShopifyRestResources,\n> {\n  session: Session;\n  admin: AdminApiContext<R>;\n}"
+    }
+  },
+  "WebhookConfig": {
+    "src/server/config-types.ts": {
+      "filePath": "src/server/config-types.ts",
+      "name": "WebhookConfig",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/config-types.ts",
+          "name": "[key: string]",
+          "value": "WebhookHandler | WebhookHandler[]"
+        }
+      ],
+      "value": "export interface WebhookConfig {\n  [key: string]: WebhookHandler | WebhookHandler[];\n}"
+    }
+  },
+  "ShopifyApp": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "ShopifyApp",
+      "value": "Config['distribution'] extends AppDistribution.ShopifyAdmin\n    ? AdminApp<Config>\n    : Config['distribution'] extends AppDistribution.SingleMerchant\n    ? SingleMerchantApp<Config>\n    : Config['distribution'] extends AppDistribution.AppStore\n    ? AppStoreApp<Config>\n    : AppStoreApp<Config>",
+      "description": "An object your app can use to interact with Shopify.\n\nBy default, the app's distribution is `AppStore`."
+    }
+  },
+  "AdminApp": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AdminApp",
+      "value": "ShopifyAppBase<Config>",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "addDocumentResponseHeaders",
+          "value": "AddDocumentResponseHeaders",
+          "description": "Adds the required Content Security Policy headers for Shopify apps to the given Headers object.\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Return headers on all requests",
+              "description": "Add headers to all HTML requests by calling `shopify.addDocumentResponseHeaders` in `entry.server.tsx`.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const addDocumentResponseheaders = shopify.addDocumentResponseheaders;",
+                  "title": "~/shopify.server.ts"
+                },
+                {
+                  "code": "import { addDocumentResponseHeaders } from \"~/shopify.server\";\n\nexport default function handleRequest(\n  request: Request,\n  responseStatusCode: number,\n  responseHeaders: Headers,\n  remixContext: EntryContext\n) {\n  const markup = renderToString(\n    <RemixServer context={remixContext} url={request.url} />\n  );\n\n  responseHeaders.set(\"Content-Type\", \"text/html\");\n  addDocumentResponseHeaders(request, responseHeaders);\n\n  return new Response(\"<!DOCTYPE html>\" + markup, {\n    status: responseStatusCode,\n    headers: responseHeaders,\n  });\n}",
+                  "title": "entry.server.tsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "authenticate",
+          "value": "Authenticate<Config>",
+          "description": "Ways to authenticate requests from different surfaces across Shopify.",
+          "examples": [
+            {
+              "title": "Authenticate Shopify requests",
+              "description": "Use the functions in `authenticate` to validate requests coming from Shopify.",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const {admin, session, sessionToken, billing} = shopify.authenticate.admin(request);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "registerWebhooks",
+          "value": "RegisterWebhooks",
+          "description": "Register webhook topics for a store using the given session. Most likely you want to use this in combination with the afterAuth hook.",
+          "examples": [
+            {
+              "title": "Registering webhooks",
+              "description": "Trigger the registration after a merchant installs your app using the `afterAuth` hook.",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  hooks: {\n    afterAuth: async ({ session }) => {\n      shopify.registerWebhooks({ session });\n    }\n  },\n  webhooks: {\n    APP_UNINSTALLED: {\n      deliveryMethod: DeliveryMethod.Http,\n       callbackUrl: \"/webhooks\",\n    },\n  },\n  // ...etc\n});",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionStorage",
+          "value": "SessionStorageType<Config>",
+          "description": "The `SessionStorage` instance you passed in as a config option.",
+          "examples": [
+            {
+              "title": "Storing sessions with Prisma",
+              "description": "Import the `@shopify/shopify-app-session-storage-prisma` package to store sessions in your Prisma database.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\nimport prisma from \"~/db.server\";\n\nconst shopify = shopifyApp({\n  sesssionStorage: new PrismaSessionStorage(prisma),\n  // ...etc\n})\n\n// shopify.sessionStorage is an instance of PrismaSessionStorage",
+                  "title": "/app/shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "unauthenticated",
+          "value": "Unauthenticated<RestResourcesType<Config>>",
+          "description": "Ways to get Contexts from requests that do not originate from Shopify.",
+          "examples": [
+            {
+              "title": "Using unauthenticated contexts",
+              "description": "Create contexts for requests that don't come from Shopify.",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticateExternal } from \"~/helpers/authenticate\"\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const shop = await authenticateExternal(request)\n  const {admin} = await shopify.unauthenticated.admin(shop);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "AddDocumentResponseHeaders": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "AddDocumentResponseHeaders",
+      "description": "",
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/types.ts"
+        },
+        {
+          "name": "headers",
+          "description": "",
+          "value": "Headers",
+          "filePath": "src/server/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/types.ts",
+        "description": "",
+        "name": "void",
+        "value": "void"
+      },
+      "value": "(request: Request, headers: Headers) => void"
+    }
+  },
+  "Authenticate": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "Authenticate",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "AuthenticateAdmin<Config, RestResourcesType<Config>>",
+          "description": "Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n\nExamples of when to use this are requests from your app's UI, or requests from admin extensions.\n\nIf there is no session for the Request, this will redirect the merchant to correct auth flows.",
+          "examples": [
+            {
+              "title": "Authenticating a request for an embedded app",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const {admin, session, sessionToken, billing} = authenticate.admin(request);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "public",
+          "value": "AuthenticatePublic",
+          "description": "Authenticate a public request and get back a session token.",
+          "examples": [
+            {
+              "title": "Authenticating a request from a checkout extension",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../../shopify.server\";\nimport { getWidgets } from \"~/db/widgets\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const {sessionToken} = authenticate.public.checkout(request);\n\n  return json(await getWidgets(sessionToken));\n}",
+                  "title": "/app/routes/api/checkout.jsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "webhook",
+          "value": "AuthenticateWebhook<\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >",
+          "description": "Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request",
+          "examples": [
+            {
+              "title": "Authenticating a webhook request",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  webhooks: {\n   APP_UNINSTALLED: {\n      deliveryMethod: DeliveryMethod.Http,\n      callbackUrl: \"/webhooks\",\n    },\n  },\n  hooks: {\n    afterAuth: async ({ session }) => {\n      shopify.registerWebhooks({ session });\n    },\n  },\n  // ...etc\n});\nexport default shopify;\nexport const authenticate = shopify.authenticate;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { ActionArgs } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\nimport db from \"../db.server\";\n\nexport const action = async ({ request }: ActionArgs) => {\n  const { topic, shop, session } = await authenticate.webhook(request);\n\n  switch (topic) {\n    case \"APP_UNINSTALLED\":\n      if (session) {\n        await db.session.deleteMany({ where: { shop } });\n      }\n      break;\n    case \"CUSTOMERS_DATA_REQUEST\":\n    case \"CUSTOMERS_REDACT\":\n    case \"SHOP_REDACT\":\n    default:\n      throw new Response(\"Unhandled webhook topic\", { status: 404 });\n  }\n\n  throw new Response();\n};",
+                  "title": "/app/routes/webhooks.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "interface Authenticate<Config extends AppConfigArg> {\n  /**\n   * Authenticate an admin Request and get back an authenticated admin context.  Use the authenticated admin context to interact with Shopify.\n   *\n   * Examples of when to use this are requests from your app's UI, or requests from admin extensions.\n   *\n   * If there is no session for the Request, this will redirect the merchant to correct auth flows.\n   *\n   * @example\n   * <caption>Authenticating a request for an embedded app.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const {admin, session, sessionToken, billing} = authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  admin: AuthenticateAdmin<Config, RestResourcesType<Config>>;\n\n  /**\n   * Authenticate a public request and get back a session token.\n   *\n   * @example\n   * <caption>Authenticating a request from a checkout extension</caption>\n   *\n   * ```ts\n   * // /app/routes/api/checkout.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../../shopify.server\";\n   * import { getWidgets } from \"~/db/widgets\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const {sessionToken} = authenticate.public.checkout(request);\n   *\n   *   return json(await getWidgets(sessionToken));\n   * }\n   * ```\n   */\n  public: AuthenticatePublic;\n\n  /**\n   * Authenticate a Shopify webhook request, get back an authenticated admin context and details on the webhook request\n   *\n   * @example\n   * <caption>Authenticating a webhook request</caption>\n   *\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   webhooks: {\n   *    APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *       callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const authenticate = shopify.authenticate;\n   * ```\n   * ```ts\n   * // /app/routes/webhooks.ts\n   * import { ActionArgs } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   * import db from \"../db.server\";\n   *\n   * export const action = async ({ request }: ActionArgs) => {\n   *   const { topic, shop, session } = await authenticate.webhook(request);\n   *\n   *   switch (topic) {\n   *     case \"APP_UNINSTALLED\":\n   *       if (session) {\n   *         await db.session.deleteMany({ where: { shop } });\n   *       }\n   *       break;\n   *     case \"CUSTOMERS_DATA_REQUEST\":\n   *     case \"CUSTOMERS_REDACT\":\n   *     case \"SHOP_REDACT\":\n   *     default:\n   *       throw new Response(\"Unhandled webhook topic\", { status: 404 });\n   *   }\n   *\n   *   throw new Response();\n   * };\n   * ```\n   */\n  webhook: AuthenticateWebhook<\n    RestResourcesType<Config>,\n    keyof Config['webhooks'] | MandatoryTopics\n  >;\n}"
+    }
+  },
+  "RestResourcesType": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "RestResourcesType",
+      "value": "Config['restResources'] extends ShopifyRestResources\n    ? Config['restResources']\n    : ShopifyRestResources",
+      "description": ""
+    }
+  },
+  "AuthenticatePublic": {
+    "src/server/authenticate/public/types.ts": {
+      "filePath": "src/server/authenticate/public/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AuthenticatePublic",
+      "value": "AuthenticateCheckout & AuthenticatePublicObject",
+      "description": "Methods for authenticating Requests from Shopify's public surfaces\n\nTo maintain backwards compatability this is a function and an object.\n\nDo not use `authenticate.public()`. Use `authenticate.public.checkout()` instead. `authenticate.public()` will be removed in v2.\n\nMethods are:\n\n- `authenticate.public.checkout()` for authenticating requests from checkout extensions\n- `authenticate.public.appProxy()` for authenticating requests from app proxies"
+    }
+  },
+  "AuthenticatePublicObject": {
+    "src/server/authenticate/public/types.ts": {
+      "filePath": "src/server/authenticate/public/types.ts",
+      "name": "AuthenticatePublicObject",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/public/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "appProxy",
+          "value": "AuthenticateAppProxy",
+          "description": "Authenticate a request from an app proxy",
+          "examples": [
+            {
+              "title": "Authenticating an app proxy request",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  await authenticate.public.appProxy(\n    request,\n  );\n\n  const {searchParams} = new URL(request.url);\n  const shop = searchParams.get(\"shop\");\n  const customerId = searchParams.get(\"logged_in_customer_id\")\n\n  return json({my: \"data\", shop, customerId});\n};",
+                  "title": "/app/routes/public/widgets.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/authenticate/public/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "checkout",
+          "value": "AuthenticateCheckout",
+          "description": "Authenticate a request from a checkout extension",
+          "examples": [
+            {
+              "title": "Authenticating a checkout extension request",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticate } from \"../shopify.server\";\n\nexport const loader = async ({ request }: LoaderArgs) => {\n  const { sessionToken, cors } = await authenticate.public.checkout(\n    request,\n  );\n  return cors(json({my: \"data\", shop: sessionToken.dest}));\n};",
+                  "title": "/app/routes/public/widgets.ts"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "interface AuthenticatePublicObject {\n  /**\n   * Authenticate a request from a checkout extension\n   *\n   * @example\n   * <caption>Authenticating a checkout extension request</caption>\n   * ```ts\n   * // /app/routes/public/widgets.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   const { sessionToken, cors } = await authenticate.public.checkout(\n   *     request,\n   *   );\n   *   return cors(json({my: \"data\", shop: sessionToken.dest}));\n   * };\n   * ```\n   */\n  checkout: AuthenticateCheckout;\n\n  /**\n   * Authenticate a request from an app proxy\n   *\n   * @example\n   * <caption>Authenticating an app proxy request</caption>\n   * ```ts\n   * // /app/routes/public/widgets.ts\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticate } from \"../shopify.server\";\n   *\n   * export const loader = async ({ request }: LoaderArgs) => {\n   *   await authenticate.public.appProxy(\n   *     request,\n   *   );\n   *\n   *   const {searchParams} = new URL(request.url);\n   *   const shop = searchParams.get(\"shop\");\n   *   const customerId = searchParams.get(\"logged_in_customer_id\")\n   *\n   *   return json({my: \"data\", shop, customerId});\n   * };\n   * ```\n   */\n  appProxy: AuthenticateAppProxy;\n}"
+    }
+  },
+  "MandatoryTopics": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "MandatoryTopics",
+      "value": "'CUSTOMERS_DATA_REQUEST' | 'CUSTOMERS_REDACT' | 'SHOP_REDACT'",
+      "description": ""
+    }
+  },
+  "RegisterWebhooks": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "RegisterWebhooks",
+      "description": "",
+      "params": [
+        {
+          "name": "options",
+          "description": "",
+          "value": "RegisterWebhooksOptions",
+          "filePath": "src/server/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/types.ts",
+        "description": "",
+        "name": "Promise<RegisterReturn>",
+        "value": "Promise<RegisterReturn>"
+      },
+      "value": "(\n  options: RegisterWebhooksOptions,\n) => Promise<RegisterReturn>"
+    }
+  },
+  "RegisterWebhooksOptions": {
+    "src/server/authenticate/webhooks/types.ts": {
+      "filePath": "src/server/authenticate/webhooks/types.ts",
+      "name": "RegisterWebhooksOptions",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/authenticate/webhooks/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "session",
+          "value": "Session",
+          "description": "The Shopify session used to register webhooks using the Admin API."
+        }
+      ],
+      "value": "export interface RegisterWebhooksOptions {\n  /**\n   * The Shopify session used to register webhooks using the Admin API.\n   */\n  session: Session;\n}"
+    }
+  },
+  "SessionStorageType": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SessionStorageType",
+      "value": "Config['sessionStorage'] extends SessionStorage\n    ? Config['sessionStorage']\n    : SessionStorage",
+      "description": ""
+    }
+  },
+  "Unauthenticated": {
+    "src/server/unauthenticated/types.ts": {
+      "filePath": "src/server/unauthenticated/types.ts",
+      "name": "Unauthenticated",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/unauthenticated/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "admin",
+          "value": "GetUnauthenticatedAdminContext<Resources>",
+          "description": "Get an admin context by passing a shop\n\n**Warning** This should only be used for Requests that do not originate from Shopify. You must do your own authentication before using this method. This method throws an error if there is no session for the shop.",
+          "examples": [
+            {
+              "title": "Responding to a request not controlled by Shopify",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticateExternal } from \"~/helpers/authenticate\"\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const shop = await authenticateExternal(request)\n  const {admin} = await shopify.unauthenticated.admin(shop);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/unauthenticated/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "storefront",
+          "value": "GetUnauthenticatedStorefrontContext",
+          "description": "Get a storefront context by passing a shop\n\n**Warning** This should only be used for Requests that do not originate from Shopify. You must do your own authentication before using this method. This method throws an error if there is no session for the shop.",
+          "examples": [
+            {
+              "title": "Responding to a request not controlled by Shopify",
+              "description": "",
+              "tabs": [
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticateExternal } from \"~/helpers/authenticate\"\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const shop = await authenticateExternal(request)\n  const {storefront} = await shopify.unauthenticated.storefront(shop);\n  const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n\n  return json(await response.json());\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface Unauthenticated<Resources extends ShopifyRestResources> {\n  /**\n   * Get an admin context by passing a shop\n   *\n   * **Warning** This should only be used for Requests that do not originate from Shopify.\n   * You must do your own authentication before using this method.\n   * This method throws an error if there is no session for the shop.\n   *\n   * @example\n   * <caption>Responding to a request not controlled by Shopify.</caption>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticateExternal } from \"~/helpers/authenticate\"\n   * import shopify from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const shop = await authenticateExternal(request)\n   *   const {admin} = await shopify.unauthenticated.admin(shop);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  admin: GetUnauthenticatedAdminContext<Resources>;\n\n  /**\n   * Get a storefront context by passing a shop\n   *\n   * **Warning** This should only be used for Requests that do not originate from Shopify.\n   * You must do your own authentication before using this method.\n   * This method throws an error if there is no session for the shop.\n   *\n   * @example\n   * <caption>Responding to a request not controlled by Shopify</caption>\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticateExternal } from \"~/helpers/authenticate\"\n   * import shopify from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const shop = await authenticateExternal(request)\n   *   const {storefront} = await shopify.unauthenticated.storefront(shop);\n   *   const response = await storefront.graphql(`{blogs(first: 10) { edges { node { id } } } }`);\n   *\n   *   return json(await response.json());\n   * }\n   * ```\n   */\n  storefront: GetUnauthenticatedStorefrontContext;\n}"
+    }
+  },
+  "SingleMerchantApp": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "SingleMerchantApp",
+      "value": "ShopifyAppBase<Config> & ShopifyAppLogin",
+      "description": ""
+    }
+  },
+  "ShopifyAppBase": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "ShopifyAppBase",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "addDocumentResponseHeaders",
+          "value": "AddDocumentResponseHeaders",
+          "description": "Adds the required Content Security Policy headers for Shopify apps to the given Headers object.\n\n\n\n\n",
+          "examples": [
+            {
+              "title": "Return headers on all requests",
+              "description": "Add headers to all HTML requests by calling `shopify.addDocumentResponseHeaders` in `entry.server.tsx`.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;\nexport const addDocumentResponseheaders = shopify.addDocumentResponseheaders;",
+                  "title": "~/shopify.server.ts"
+                },
+                {
+                  "code": "import { addDocumentResponseHeaders } from \"~/shopify.server\";\n\nexport default function handleRequest(\n  request: Request,\n  responseStatusCode: number,\n  responseHeaders: Headers,\n  remixContext: EntryContext\n) {\n  const markup = renderToString(\n    <RemixServer context={remixContext} url={request.url} />\n  );\n\n  responseHeaders.set(\"Content-Type\", \"text/html\");\n  addDocumentResponseHeaders(request, responseHeaders);\n\n  return new Response(\"<!DOCTYPE html>\" + markup, {\n    status: responseStatusCode,\n    headers: responseHeaders,\n  });\n}",
+                  "title": "entry.server.tsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "authenticate",
+          "value": "Authenticate<Config>",
+          "description": "Ways to authenticate requests from different surfaces across Shopify.",
+          "examples": [
+            {
+              "title": "Authenticate Shopify requests",
+              "description": "Use the functions in `authenticate` to validate requests coming from Shopify.",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const {admin, session, sessionToken, billing} = shopify.authenticate.admin(request);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "registerWebhooks",
+          "value": "RegisterWebhooks",
+          "description": "Register webhook topics for a store using the given session. Most likely you want to use this in combination with the afterAuth hook.",
+          "examples": [
+            {
+              "title": "Registering webhooks",
+              "description": "Trigger the registration after a merchant installs your app using the `afterAuth` hook.",
+              "tabs": [
+                {
+                  "code": "import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  hooks: {\n    afterAuth: async ({ session }) => {\n      shopify.registerWebhooks({ session });\n    }\n  },\n  webhooks: {\n    APP_UNINSTALLED: {\n      deliveryMethod: DeliveryMethod.Http,\n       callbackUrl: \"/webhooks\",\n    },\n  },\n  // ...etc\n});",
+                  "title": "Example"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "sessionStorage",
+          "value": "SessionStorageType<Config>",
+          "description": "The `SessionStorage` instance you passed in as a config option.",
+          "examples": [
+            {
+              "title": "Storing sessions with Prisma",
+              "description": "Import the `@shopify/shopify-app-session-storage-prisma` package to store sessions in your Prisma database.",
+              "tabs": [
+                {
+                  "code": "import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\nimport prisma from \"~/db.server\";\n\nconst shopify = shopifyApp({\n  sesssionStorage: new PrismaSessionStorage(prisma),\n  // ...etc\n})\n\n// shopify.sessionStorage is an instance of PrismaSessionStorage",
+                  "title": "/app/shopify.server.ts"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "unauthenticated",
+          "value": "Unauthenticated<RestResourcesType<Config>>",
+          "description": "Ways to get Contexts from requests that do not originate from Shopify.",
+          "examples": [
+            {
+              "title": "Using unauthenticated contexts",
+              "description": "Create contexts for requests that don't come from Shopify.",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\nimport { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n\nconst shopify = shopifyApp({\n  restResources,\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import { LoaderArgs, json } from \"@remix-run/node\";\nimport { authenticateExternal } from \"~/helpers/authenticate\"\nimport shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const shop = await authenticateExternal(request)\n  const {admin} = await shopify.unauthenticated.admin(shop);\n\n  return json(await admin.rest.resources.Product.count({ session }));\n}",
+                  "title": "/app/routes/**\\/*.jsx"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "export interface ShopifyAppBase<Config extends AppConfigArg> {\n  /**\n   * The `SessionStorage` instance you passed in as a config option.\n   *\n   * @example\n   * <caption>Storing sessions with Prisma.</caption>\n   * <description>Import the `@shopify/shopify-app-session-storage-prisma` package to store sessions in your Prisma database.</description>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { PrismaSessionStorage } from \"@shopify/shopify-app-session-storage-prisma\";\n   * import prisma from \"~/db.server\";\n   *\n   * const shopify = shopifyApp({\n   *   sesssionStorage: new PrismaSessionStorage(prisma),\n   *   // ...etc\n   * })\n   *\n   * // shopify.sessionStorage is an instance of PrismaSessionStorage\n   * ```\n   */\n  sessionStorage: SessionStorageType<Config>;\n\n  /**\n   * Adds the required Content Security Policy headers for Shopify apps to the given Headers object.\n   *\n   * {@link https://shopify.dev/docs/apps/store/security/iframe-protection}\n   *\n   * @example\n   * <caption>Return headers on all requests.</caption>\n   * <description>Add headers to all HTML requests by calling `shopify.addDocumentResponseHeaders` in `entry.server.tsx`.</description>\n   *\n   * ```\n   * // ~/shopify.server.ts\n   * import { shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   * });\n   * export default shopify;\n   * export const addDocumentResponseheaders = shopify.addDocumentResponseheaders;\n   * ```\n   *\n   * ```ts\n   * // entry.server.tsx\n   * import { addDocumentResponseHeaders } from \"~/shopify.server\";\n   *\n   * export default function handleRequest(\n   *   request: Request,\n   *   responseStatusCode: number,\n   *   responseHeaders: Headers,\n   *   remixContext: EntryContext\n   * ) {\n   *   const markup = renderToString(\n   *     <RemixServer context={remixContext} url={request.url} />\n   *   );\n   *\n   *   responseHeaders.set(\"Content-Type\", \"text/html\");\n   *   addDocumentResponseHeaders(request, responseHeaders);\n   *\n   *   return new Response(\"<!DOCTYPE html>\" + markup, {\n   *     status: responseStatusCode,\n   *     headers: responseHeaders,\n   *   });\n   * }\n   * ```\n   */\n  addDocumentResponseHeaders: AddDocumentResponseHeaders;\n\n  /**\n   * Register webhook topics for a store using the given session. Most likely you want to use this in combination with the afterAuth hook.\n   *\n   * @example\n   * <caption>Registering webhooks.</caption>\n   * <description>Trigger the registration after a merchant installs your app using the `afterAuth` hook.</description>\n   * ```ts\n   * import { DeliveryMethod, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   hooks: {\n   *     afterAuth: async ({ session }) => {\n   *       shopify.registerWebhooks({ session });\n   *     }\n   *   },\n   *   webhooks: {\n   *     APP_UNINSTALLED: {\n   *       deliveryMethod: DeliveryMethod.Http,\n   *        callbackUrl: \"/webhooks\",\n   *     },\n   *   },\n   *   // ...etc\n   * });\n   * ```\n   */\n  registerWebhooks: RegisterWebhooks;\n\n  /**\n   * Ways to authenticate requests from different surfaces across Shopify.\n   *\n   * @example\n   * <caption>Authenticate Shopify requests.</caption>\n   * <description>Use the functions in `authenticate` to validate requests coming from Shopify.</description>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import shopify from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const {admin, session, sessionToken, billing} = shopify.authenticate.admin(request);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  authenticate: Authenticate<Config>;\n\n  /**\n   * Ways to get Contexts from requests that do not originate from Shopify.\n   *\n   * @example\n   * <caption>Using unauthenticated contexts.</caption>\n   * <description>Create contexts for requests that don't come from Shopify.</description>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   * import { restResources } from \"@shopify/shopify-api/rest/admin/2023-04\";\n   *\n   * const shopify = shopifyApp({\n   *   restResources,\n   *   // ...etc\n   * });\n   * export default shopify;\n   * ```\n   * ```ts\n   * // /app/routes/**\\/*.jsx\n   * import { LoaderArgs, json } from \"@remix-run/node\";\n   * import { authenticateExternal } from \"~/helpers/authenticate\"\n   * import shopify from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const shop = await authenticateExternal(request)\n   *   const {admin} = await shopify.unauthenticated.admin(shop);\n   *\n   *   return json(await admin.rest.resources.Product.count({ session }));\n   * }\n   * ```\n   */\n  unauthenticated: Unauthenticated<RestResourcesType<Config>>;\n}"
+    }
+  },
+  "ShopifyAppLogin": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "ShopifyAppLogin",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "login",
+          "value": "Login",
+          "description": "Log a merchant in, and redirect them to the app root. Will redirect the merchant to authentication if a shop is present in the URL search parameters or form data.\n\nThis function won't be present when the `distribution` config option is set to `AppDistribution.ShopifyAdmin`, because Admin apps aren't allowed to show a login page.",
+          "examples": [
+            {
+              "title": "Creating a login page",
+              "description": "Use `shopify.login` to create a login form, in a route that can handle GET and POST requests.",
+              "tabs": [
+                {
+                  "code": "import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n\nconst shopify = shopifyApp({\n  // ...etc\n});\nexport default shopify;",
+                  "title": "/app/shopify.server.ts"
+                },
+                {
+                  "code": "import shopify from \"../../shopify.server\";\n\nexport async function loader({ request }: LoaderArgs) {\n  const errors = shopify.login(request);\n\n  return json(errors);\n}\n\nexport async function action({ request }: ActionArgs) {\n  const errors = shopify.login(request);\n\n  return json(errors);\n}\n\nexport default function Auth() {\n  const actionData = useActionData<typeof action>();\n  const [shop, setShop] = useState(\"\");\n\n  return (\n    <Page>\n      <Card>\n        <Form method=\"post\">\n          <FormLayout>\n            <Text variant=\"headingMd\" as=\"h2\">\n              Login\n            </Text>\n            <TextField\n              type=\"text\"\n              name=\"shop\"\n              label=\"Shop domain\"\n              helpText=\"e.g: my-shop-domain.myshopify.com\"\n              value={shop}\n              onChange={setShop}\n              autoComplete=\"on\"\n              error={actionData?.errors.shop}\n            />\n            <Button submit primary>\n              Submit\n            </Button>\n          </FormLayout>\n        </Form>\n      </Card>\n    </Page>\n  );\n}",
+                  "title": "/app/routes/auth/login.tsx"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "value": "interface ShopifyAppLogin {\n  /**\n   * Log a merchant in, and redirect them to the app root. Will redirect the merchant to authentication if a shop is\n   * present in the URL search parameters or form data.\n   *\n   * This function won't be present when the `distribution` config option is set to `AppDistribution.ShopifyAdmin`,\n   * because Admin apps aren't allowed to show a login page.\n   *\n   * @example\n   * <caption>Creating a login page.</caption>\n   * <description>Use `shopify.login` to create a login form, in a route that can handle GET and POST requests.</description>\n   * ```ts\n   * // /app/shopify.server.ts\n   * import { LATEST_API_VERSION, shopifyApp } from \"@shopify/shopify-app-remix/server\";\n   *\n   * const shopify = shopifyApp({\n   *   // ...etc\n   * });\n   * export default shopify;\n   * ```\n   * ```ts\n   * // /app/routes/auth/login.tsx\n   * import shopify from \"../../shopify.server\";\n   *\n   * export async function loader({ request }: LoaderArgs) {\n   *   const errors = shopify.login(request);\n   *\n   *   return json(errors);\n   * }\n   *\n   * export async function action({ request }: ActionArgs) {\n   *   const errors = shopify.login(request);\n   *\n   *   return json(errors);\n   * }\n   *\n   * export default function Auth() {\n   *   const actionData = useActionData<typeof action>();\n   *   const [shop, setShop] = useState(\"\");\n   *\n   *   return (\n   *     <Page>\n   *       <Card>\n   *         <Form method=\"post\">\n   *           <FormLayout>\n   *             <Text variant=\"headingMd\" as=\"h2\">\n   *               Login\n   *             </Text>\n   *             <TextField\n   *               type=\"text\"\n   *               name=\"shop\"\n   *               label=\"Shop domain\"\n   *               helpText=\"e.g: my-shop-domain.myshopify.com\"\n   *               value={shop}\n   *               onChange={setShop}\n   *               autoComplete=\"on\"\n   *               error={actionData?.errors.shop}\n   *             />\n   *             <Button submit primary>\n   *               Submit\n   *             </Button>\n   *           </FormLayout>\n   *         </Form>\n   *       </Card>\n   *     </Page>\n   *   );\n   * }\n   * ```\n   */\n  login: Login;\n}"
+    }
+  },
+  "Login": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "Login",
+      "description": "",
+      "params": [
+        {
+          "name": "request",
+          "description": "",
+          "value": "Request",
+          "filePath": "src/server/types.ts"
+        }
+      ],
+      "returns": {
+        "filePath": "src/server/types.ts",
+        "description": "",
+        "name": "Promise<LoginError | never>",
+        "value": "Promise<LoginError | never>"
+      },
+      "value": "(request: Request) => Promise<LoginError | never>"
+    }
+  },
+  "LoginError": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "name": "LoginError",
+      "description": "",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "syntaxKind": "PropertySignature",
+          "name": "shop",
+          "value": "LoginErrorType",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface LoginError {\n  shop?: LoginErrorType;\n}"
+    }
+  },
+  "LoginErrorType": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "EnumDeclaration",
+      "name": "LoginErrorType",
+      "value": "export enum LoginErrorType {\n  MissingShop = 'MISSING_SHOP',\n  InvalidShop = 'INVALID_SHOP',\n}",
+      "members": [
+        {
+          "filePath": "src/server/types.ts",
+          "name": "MissingShop",
+          "value": "MISSING_SHOP"
+        },
+        {
+          "filePath": "src/server/types.ts",
+          "name": "InvalidShop",
+          "value": "INVALID_SHOP"
+        }
+      ]
+    }
+  },
+  "AppStoreApp": {
+    "src/server/types.ts": {
+      "filePath": "src/server/types.ts",
+      "syntaxKind": "TypeAliasDeclaration",
+      "name": "AppStoreApp",
+      "value": "ShopifyAppBase<Config> & ShopifyAppLogin",
+      "description": ""
+    }
+  },
+  "AppProviderProps": {
+    "src/react/components/AppProvider/AppProvider.tsx": {
+      "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+      "name": "AppProviderProps",
+      "description": "Props for the `AppProvider` component.",
+      "isPublicDocs": true,
+      "members": [
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "__APP_BRIDGE_URL",
+          "value": "string",
+          "description": "Used internally by Shopify. You don't need to set this.",
+          "isOptional": true,
+          "isPrivate": true
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "apiKey",
+          "value": "string",
+          "description": "The API key for your Shopify app. This is the `Client ID` from the Partner Dashboard.\n\nWhen using the Shopify CLI, this is the `SHOPIFY_API_KEY` environment variable. If you're using the environment variable, then you need to pass it from the loader to the component."
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "children",
+          "value": "React.ReactNode",
+          "description": "Inner content of the application",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "features",
+          "value": "FeaturesConfig",
+          "description": "For toggling features",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "i18n",
+          "value": "TranslationDictionary | TranslationDictionary[]",
+          "description": "The internationalization (i18n) configuration for your Polaris provider.\n\n\n\n\n",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "isEmbeddedApp",
+          "value": "boolean",
+          "description": "Whether the app is loaded inside the Shopify Admin. Default is `true`.\n\n\n\n\n",
+          "isOptional": true
+        },
+        {
+          "filePath": "src/react/components/AppProvider/AppProvider.tsx",
+          "syntaxKind": "PropertySignature",
+          "name": "theme",
+          "value": "ThemeName",
+          "description": "",
+          "isOptional": true
+        }
+      ],
+      "value": "export interface AppProviderProps\n  extends Omit<PolarisAppProviderProps, 'linkComponent' | 'i18n'> {\n  /**\n   * The API key for your Shopify app. This is the `Client ID` from the Partner Dashboard.\n   *\n   * When using the Shopify CLI, this is the `SHOPIFY_API_KEY` environment variable. If you're using the environment\n   * variable, then you need to pass it from the loader to the component.\n   */\n  apiKey: string;\n  /**\n   * Whether the app is loaded inside the Shopify Admin. Default is `true`.\n   *\n   * {@link https://shopify.dev/docs/apps/admin/embedded-app-home}\n   */\n  isEmbeddedApp?: boolean;\n  /**\n   * The internationalization (i18n) configuration for your Polaris provider.\n   *\n   * {@link https://polaris.shopify.com/components/utilities/app-provider}\n   */\n  i18n?: PolarisAppProviderProps['i18n'];\n  /**\n   * Used internally by Shopify. You don't need to set this.\n   * @private\n   */\n  __APP_BRIDGE_URL?: string;\n}"
+    }
+  }
+}


### PR DESCRIPTION
# gen-docs-remix-v1 (Remix v1)

Related ticket: https://github.com/shop/issues-learn/issues/1464

Shopify-dev top hatting PR: https://github.com/shop/world/pull/570575

  ## Summary
  - Add `@publicDocs` JSDoc tags to all top-level types in `@shopify/shopify-app-remix` v1
  - Upgrade `@shopify/generate-docs` to `^1.1.0` to enable v2 documentation pipeline
  - Add JSDoc descriptions matching existing v1 generated docs definitions
  - Update `build-docs.sh` to copy generated files to shopify-dev world repo

  ## Test plan
  - [ ] Run `pnpm build-docs` in `packages/shopify-app-remix`
  - [ ] Verify `generated_docs_data_v2.json` is created alongside existing files
  - [ ] Verify docs render correctly in shopify-dev preview for v1