### PR TITLE
fix(ci): switch release workflows to Node 24 to fix broken npm self-upgrade

### DIFF
--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: 'pnpm'
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/main-release.yml
+++ b/.github/workflows/main-release.yml
@@ -28,9 +28,6 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install npm 11.x for OIDC support
-        run: npm install -g npm@^11.5.1
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: 'pnpm'
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install dependencies

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -28,9 +28,6 @@ jobs:
           node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install npm 11.x for OIDC support
-        run: npm install -g npm@^11.5.1
-
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Fixes the release workflow which has been **broken since April 1, 2026** by:

1. Upgrading from Node 22 to Node 24, which ships with npm 11.11.0 natively — providing the npm 11.5.1+ required for OIDC trusted publishing without any self-upgrade
2. Removing the `npm install -g npm@^11.5.1` self-upgrade step (which can't run on the broken npm bundled with Node 22.22.2)

## The problem

The release workflow fails at the "Install npm 11.x for OIDC support" step:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

**Root cause:** On April 1, the GitHub Actions runner image updated Node.js from **22.22.1 to 22.22.2**. Node 22.22.2 ships with a bundled npm 10.9.7 that has a broken internal module tree — `promise-retry` is missing from npm's own `@npmcli/arborist` dependency, so npm cannot even upgrade itself.

Evidence from CI logs — same workflow, same day, ~90 minutes apart:

| Run ID | Time (UTC) | Node version | Result |
|--------|-----------|-------------|--------|
| [`23860972927`](https://github.com/Shopify/shopify-app-js/actions/runs/23860972927) | Apr 1, 17:08 | `node/22.22.1` | :white_check_mark: Success |
| [`23865129745`](https://github.com/Shopify/shopify-app-js/actions/runs/23865129745) | Apr 1, 18:47 | `node/22.22.2` | :x: Failure |

Recent failing runs (all with the same `promise-retry` error):

- [Apr 14, 14:28 UTC](https://github.com/Shopify/shopify-app-js/actions/runs/24404695728)
- [Apr 14, 13:09 UTC](https://github.com/Shopify/shopify-app-js/actions/runs/24400757822)
- [Apr 13, 23:32 UTC](https://github.com/Shopify/shopify-app-js/actions/runs/24372350322)
- [Apr 9, 16:25 UTC](https://github.com/Shopify/shopify-app-js/actions/runs/24103168459)
- [Apr 6, 15:03 UTC](https://github.com/Shopify/shopify-app-js/actions/runs/23972527791)

This is a widely reported upstream bug:

- [nodejs/node#62430](https://github.com/nodejs/node/issues/62430)
- [nodejs/node#62425](https://github.com/nodejs/node/issues/62425)
- [npm/cli#9151](https://github.com/npm/cli/issues/9151)
- [actions/runner-images#13883](https://github.com/actions/runner-images/issues/13883)

## Why the npm self-upgrade step existed

The step was [added](https://github.com/Shopify/shopify-app-js/commit/f574f01cd9d098a11b799b1ab8d40decade19e69) when the repo switched from `NPM_TOKEN` (classic auth) to OIDC trusted publishing (`NPM_CONFIG_PROVENANCE`). **Trusted publishing requires npm 11.5.1+**, and Node 22 only ships with npm 10.x, so the workflow had to self-upgrade npm.

Note: even though the workflow runs `pnpm release` → `changeset publish`, the changesets CLI detects pnpm and runs `pnpm publish`, which [delegates to npm under the hood](https://github.com/pnpm/pnpm/issues/6607) for the actual registry interaction. So the system npm version matters.

## The fix

Switch to Node 24, which ships with npm 11.11.0 natively. This:

- Provides npm 11.5.1+ for trusted publishing without any self-upgrade
- Eliminates the broken self-upgrade step entirely
- Is the [recommended approach](https://github.com/actions/runner-images/issues/13883) from the GitHub Actions community

## Test plan

- [ ] Merge this PR and verify the `main-release` workflow succeeds on the next push to `main`
- [ ] Verify the "Packages for release" PR (#3095) gets updated by the changesets action

🤖 Generated with [Claude Code](https://claude.com/claude-code)