### PR TITLE
fix: add preview.admin.shopify.com to CSP frame-ancestors

### DIFF
--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/csp-headers.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/csp-headers.test.ts
@@ -15,7 +15,7 @@ const TESTS: {
   [TEST_SHOP, 12345, undefined].forEach((shop) => {
     let expectedCSP = `frame-ancestors 'none';`;
     if (isEmbeddedApp && typeof shop === 'string') {
-      expectedCSP = `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`;
+      expectedCSP = `frame-ancestors https://${shop} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`;
     }
     TESTS.push({shop, isEmbeddedApp, expectedCSP});
   });

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -52,7 +52,7 @@ describe('ensureInstalledOnShop', () => {
       },
     });
     expect(response.headers['content-security-policy']).toEqual(
-      `frame-ancestors https://${TEST_SHOP} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+      `frame-ancestors https://${TEST_SHOP} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
   });
 

--- a/packages/apps/shopify-app-express/src/middlewares/csp-headers.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/csp-headers.ts
@@ -23,7 +23,7 @@ export function addCSPHeader(api: Shopify, req: Request, res: Response) {
       'Content-Security-Policy',
       `frame-ancestors https://${encodeURIComponent(
         shop,
-      )} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+      )} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
   } else {
     res.setHeader('Content-Security-Policy', `frame-ancestors 'none';`);

--- a/packages/apps/shopify-app-react-router/src/server/__test-helpers/expect-document-request-headers.ts
+++ b/packages/apps/shopify-app-react-router/src/server/__test-helpers/expect-document-request-headers.ts
@@ -12,7 +12,7 @@ export function expectDocumentRequestHeaders(
     expect(headers.get('Content-Security-Policy')).toEqual(
       `frame-ancestors https://${encodeURIComponent(
         TEST_SHOP,
-      )} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+      )} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
     expect(headers.get('Link')).toEqual(
       `<${CDN_URL}>; rel="preconnect", <${APP_BRIDGE_URL}>; rel="preload"; as="script", <${POLARIS_URL}>; rel="preload"; as="script"`,

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/add-response-headers.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/add-response-headers.ts
@@ -37,7 +37,7 @@ export function addDocumentResponseHeaders(
     if (shop) {
       headers.set(
         'Content-Security-Policy',
-        `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+        `frame-ancestors https://${shop} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
       );
     }
   } else {

--- a/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-document-request-headers.ts
+++ b/packages/apps/shopify-app-remix/src/server/__test-helpers/expect-document-request-headers.ts
@@ -12,7 +12,7 @@ export function expectDocumentRequestHeaders(
     expect(headers.get('Content-Security-Policy')).toEqual(
       `frame-ancestors https://${encodeURIComponent(
         TEST_SHOP,
-      )} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+      )} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
     );
     expect(headers.get('Link')).toEqual(
       `<${APP_BRIDGE_URL}>; rel="preload"; as="script";`,

--- a/packages/apps/shopify-app-remix/src/server/authenticate/helpers/add-response-headers.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/helpers/add-response-headers.ts
@@ -34,7 +34,7 @@ export function addDocumentResponseHeaders(
     if (shop) {
       headers.set(
         'Content-Security-Policy',
-        `frame-ancestors https://${shop} https://admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
+        `frame-ancestors https://${shop} https://admin.shopify.com https://*.preview.admin.shopify.com https://*.spin.dev https://admin.myshopify.io https://admin.shop.dev;`,
       );
     }
   } else {


### PR DESCRIPTION
## Summary
- Adds `https://*.preview.admin.shopify.com` to the CSP `frame-ancestors` directive across all three framework packages (Remix, Express, React Router)
- Embedded apps were refusing to load inside admin preview environments because this origin was missing from the allowed framing domains
- Updates all corresponding test files (7 files total)

## Test plan
- [x] Remix `add-response-headers` tests pass (4 tests)
- [x] Express `csp-headers` tests pass (7 tests)
- [x] React Router `add-response-headers` tests pass (1 test)
- [ ] Verify an embedded app loads correctly in a `*.preview.admin.shopify.com` environment after bumping to this version

🤖 Generated with [Claude Code](https://claude.com/claude-code)