### PR TITLE
Auto-label + Slack notifications for new gardener items

### DIFF
--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -1,4 +1,4 @@
-name: Devtools Investigate for Gardener
+name: Gardener - Investigate Issue
 # Automatically investigates GitHub issues using Claude Code when the
 # 'devtools-investigate-for-gardener' label is applied. Can also be triggered manually
 # via workflow_dispatch for a specific issue number.

--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -43,6 +43,31 @@ jobs:
           echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
           echo "url=https://github.com/${{ github.repository }}/issues/$NUMBER" >> "$GITHUB_OUTPUT"
 
+      # Post a starter message so reviewers can follow along while Claude works.
+      # `continue-on-error: true` keeps a Slack outage from blocking the run.
+      # The response `ts` is stashed for the completion step to thread onto.
+      - name: Post investigation start to Slack
+        id: start_slack
+        continue-on-error: true
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_GARDENER_BOT_TOKEN }}
+          payload: |-
+            {
+              "channel": "${{ vars.GARDENER_SLACK_CHANNEL_ID }}",
+              "text": "Investigation started for issue #${{ steps.issue.outputs.number }}",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":mag: *<${{ steps.issue.outputs.url }}|Issue #${{ steps.issue.outputs.number }}>* — investigation starting…\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>"
+                  }
+                }
+              ]
+            }
+
       - name: Investigate issue
         id: investigate
         timeout-minutes: 30
@@ -70,52 +95,131 @@ jobs:
         run: |
           echo "$STRUCTURED_OUTPUT" | jq -r '.report' >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post investigation report to Slack
-        if: always() && steps.investigate.outputs.structured_output
+      # Build a single Slack payload — success shape when Claude returned
+      # structured output, failure shape otherwise (crash, timeout, cancel,
+      # or no structured_output). Running in github-script so we can parse
+      # the starter response to thread onto it, and use JSON.stringify to
+      # dodge shell-escaping hazards. The report is Claude's trusted
+      # structured output, so no HTML-escape pass.
+      - name: Prepare Slack payload
+        id: slack_payload
+        if: always()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           STRUCTURED_OUTPUT: ${{ steps.investigate.outputs.structured_output }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GARDENER_WEBHOOK_URL }}
-          SLACK_CHANNEL_ID: ${{ vars.GARDENER_SLACK_CHANNEL_ID }}
+          START_RESPONSE: ${{ steps.start_slack.outputs.response }}
+          CHANNEL_ID: ${{ vars.GARDENER_SLACK_CHANNEL_ID }}
           ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
           ISSUE_URL: ${{ steps.issue.outputs.url }}
-        run: |
-          REPORT=$(echo "$STRUCTURED_OUTPUT" | jq -r '.report')
-          # Convert Markdown to Slack mrkdwn format
-          REPORT=$(echo "$REPORT" | perl -pe '
-            s/^#{1,6}\s+(.+)$/*$1*/gm;
-            s/\*\*(.+?)\*\*/*$1*/g;
-            s/\[([^\]]+)\]\(([^)]+)\)/<$2|$1>/g;
-          ')
-          # Slack webhook messages have a 3000 char limit for text blocks.
-          # Truncate and link to the full run if needed.
-          MAX_LEN=2500
-          if [ ${#REPORT} -gt $MAX_LEN ]; then
-            REPORT="${REPORT:0:$MAX_LEN}…\n\n<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View full report>"
-          fi
-          jq -n \
-            --arg channel "$SLACK_CHANNEL_ID" \
-            --arg text "Investigation report for issue #$ISSUE_NUMBER" \
-            --arg report "$REPORT" \
-            --arg issue_url "$ISSUE_URL" \
-            --arg issue_num "$ISSUE_NUMBER" \
-            '{
-              channel: $channel,
-              text: $text,
-              blocks: [
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: ("*<" + $issue_url + "|Issue #" + $issue_num + ">* — Investigation Report")
-                  }
-                },
-                { type: "divider" },
-                {
-                  type: "section",
-                  text: {
-                    type: "mrkdwn",
-                    text: $report
-                  }
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          INVESTIGATE_OUTCOME: ${{ steps.investigate.outcome }}
+        with:
+          result-encoding: string
+          script: |
+            const num = process.env.ISSUE_NUMBER;
+            const url = process.env.ISSUE_URL;
+            const runUrl = process.env.RUN_URL;
+
+            // Thread onto the starter post when it succeeded; otherwise
+            // the result still posts standalone to the channel.
+            let threadTs = null;
+            try {
+              const r = JSON.parse(process.env.START_RESPONSE || '{}');
+              if (r.ok && r.ts) threadTs = r.ts;
+            } catch (_) {}
+
+            let text, blocks;
+
+            // Gate on STRUCTURED_OUTPUT (not report content) so the
+            // empty-report edge case still goes through the success path,
+            // matching the previous two-step behavior. Wrapped in try/catch
+            // so a malformed payload falls through to the failure notice
+            // instead of leaving the starter message orphaned.
+            let builtSuccess = false;
+            if (process.env.STRUCTURED_OUTPUT) {
+              try {
+                const structured = JSON.parse(process.env.STRUCTURED_OUTPUT);
+                const report = structured.report || '';
+
+                // Top-sections slice: keep everything up to and including
+                // the Summary section, drop sections that follow it. Falls
+                // back to the full report if the template no longer contains
+                // "## Summary".
+                const lines = report.split('\n');
+                const slice = [];
+                let sawSummary = false;
+                for (const line of lines) {
+                  if (sawSummary && /^## /.test(line)) break;
+                  slice.push(line);
+                  if (/^## Summary/.test(line)) sawSummary = true;
                 }
-              ]
-            }' | curl -sf -X POST -H 'Content-type: application/json' -d @- "$SLACK_WEBHOOK_URL"
+                // Stash fenced code blocks so their contents don't get
+                // rewritten by the header/bullet passes below.
+                const codeBlocks = [];
+                let slackReport = (slice.join('\n').trim() || report)
+                  .replace(/^```[^\n]*\n([\s\S]*?)\n```$/gm, (_m, c) => {
+                    codeBlocks.push(c);
+                    return `\x04${codeBlocks.length - 1}\x05`;
+                  })
+                  .replace(/^#{1,6}\s+(.+)$/gm, '*$1*')
+                  .replace(/\*\*(.+?)\*\*/g, '*$1*')
+                  .replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<$2|$1>')
+                  .replace(/^(\s*)- \[x\]\s+/gm, '$1✓ ')
+                  .replace(/^(\s*)[-*]\s+/gm, '$1• ')
+                  .replace(/\x04(\d+)\x05/g, (_m, i) => '```\n' + codeBlocks[+i] + '\n```');
+
+                // Slack section blocks cap at 3000 chars; leave headroom for the footer.
+                const footer = `\n\n<${runUrl}|View full report>`;
+                const MAX = 2900;
+                if (slackReport.length + footer.length > MAX) {
+                  slackReport = slackReport.slice(0, MAX - footer.length - 1) + '…';
+                }
+                slackReport += footer;
+
+                text = `Investigation report for issue #${num}`;
+                blocks = [
+                  { type: 'section',
+                    text: { type: 'mrkdwn',
+                            text: `*<${url}|Issue #${num}>* — Investigation Report` } },
+                  { type: 'divider' },
+                  { type: 'section',
+                    text: { type: 'mrkdwn', text: slackReport } }
+                ];
+                builtSuccess = true;
+              } catch (e) {
+                core.warning(`Failed to build success payload: ${e}; posting failure notice`);
+              }
+            }
+
+            if (!builtSuccess) {
+              const outcome = process.env.INVESTIGATE_OUTCOME;
+              // Outcome = 'success' + no structured output means Claude
+              // returned without a structured report — distinct from an
+              // outright failure.
+              const reason = outcome === 'success'
+                ? 'completed without a report'
+                : `${outcome || 'did not complete'}`;
+              text = `Investigation failed for issue #${num}`;
+              blocks = [
+                { type: 'section',
+                  text: { type: 'mrkdwn',
+                          text: `:x: *<${url}|Issue #${num}>* — investigation ${reason}. <${runUrl}|View run>` } }
+              ];
+            }
+
+            const payload = { channel: process.env.CHANNEL_ID, text, blocks };
+            if (threadTs) {
+              payload.thread_ts = threadTs;
+              // Broadcasts the threaded reply back to the channel so the
+              // summary shows up inline, not only for thread subscribers.
+              payload.reply_broadcast = true;
+            }
+            return JSON.stringify(payload);
+
+      - name: Post to Slack
+        if: always() && steps.slack_payload.outputs.result
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_GARDENER_BOT_TOKEN }}
+          payload: '${{ steps.slack_payload.outputs.result }}'

--- a/.github/workflows/gardener-notify-event.yml
+++ b/.github/workflows/gardener-notify-event.yml
@@ -1,0 +1,35 @@
+name: Gardener - Notify Event
+# Tiny event capturer: stashes the triggering issue/PR payload as an artifact
+# for `gardener-notify-slack.yml` to pick up via workflow_run.
+#
+# Why two workflows? When Dependabot triggers a workflow, GitHub forces
+# GITHUB_TOKEN to read-only and hides Actions secrets — so labeling and
+# Slack posting from this workflow would fail on every Dependabot PR. A
+# workflow_run-triggered follow-up runs in the default-branch context with
+# full permissions and secret access, regardless of the upstream actor.
+#
+# Uses pull_request_target so fork-opened PRs still produce an artifact.
+# No code is checked out here; this workflow only reads the pre-parsed
+# event payload, so there is no pwn-request surface.
+on:
+  issues:
+    types: [opened, labeled]
+  pull_request_target:
+    types: [opened, labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  capture:
+    if: github.event.action == 'opened' || github.event.label.name == 'devtools-gardener'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Stash event payload
+        run: cp "$GITHUB_EVENT_PATH" event.json
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: gardener-event
+          path: event.json
+          retention-days: 1

--- a/.github/workflows/gardener-notify-slack.yml
+++ b/.github/workflows/gardener-notify-slack.yml
@@ -1,0 +1,116 @@
+name: Gardener - Notify Slack
+# Runs after `Gardener - Notify Event` completes and does the real work:
+# applies the devtools-gardener label and posts a summary to Slack.
+#
+# The workflow_run trigger runs this job in the default-branch context with
+# full GITHUB_TOKEN permissions and Actions secret access — this is what
+# lets it succeed for Dependabot-opened PRs, where the upstream event
+# workflow can't label or reach secrets directly.
+on:
+  workflow_run:
+    workflows: ['Gardener - Notify Event']
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  notify:
+    # `conclusion == success` also covers runs where the capture job was
+    # skipped by its `if` gate (no matching label, etc.) — in that case
+    # no artifact was uploaded, so the download step below no-ops.
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download event payload
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: gardener-event
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add devtools-gardener label
+        if: steps.download.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          ACTION=$(jq -r '.action' event.json)
+          # On `labeled` events the label is already there — skip.
+          if [ "$ACTION" != "opened" ]; then
+            exit 0
+          fi
+          NUMBER=$(jq -r '(.issue // .pull_request).number' event.json)
+          if jq -e 'has("pull_request")' event.json > /dev/null; then
+            gh pr edit "$NUMBER" --add-label devtools-gardener
+          else
+            gh issue edit "$NUMBER" --add-label devtools-gardener
+          fi
+
+      - name: Post to Slack
+        if: steps.download.outcome == 'success'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_GARDENER_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ vars.GARDENER_SLACK_CHANNEL_ID }}
+        run: |
+          KIND=$(jq -r 'if has("pull_request") then "PR" else "Issue" end' event.json)
+          # Pull the body out, truncate, then convert GitHub Markdown to
+          # Slack mrkdwn. Links and fenced code blocks are stashed before
+          # the HTML-escape pass so their contents survive verbatim (a `&`
+          # inside a URL must stay raw, and code content shouldn't be
+          # mangled). Blockquote `> ` markers are also stashed so the
+          # `>` → `&gt;` escape doesn't break them. Everything else is
+          # HTML-escaped so user-supplied `<`, `>`, `&` can't collide
+          # with Slack link syntax or injected mentions like <!channel>.
+          BODY=$(jq -r '(.issue // .pull_request).body // ""' event.json)
+          if [ ${#BODY} -gt 1000 ]; then
+            BODY="${BODY:0:1000}…"
+          fi
+          BODY=$(printf '%s' "$BODY" | perl -0777 -pe '
+            my @u;
+            s{\[([^\]]+)\]\(([^)]+)\)}{push @u, $2; "\x01$#u\x02$1\x03"}ge;
+            my @c;
+            s{^```[^\n]*\n(.*?)\n```$}{push @c, $1; "\x04$#c\x05"}gems;
+            s/^> /\x06/gm;
+            s/^#{1,6}\s+(.+)$/*$1*/gm;
+            s/\*\*(.+?)\*\*/*$1*/g;
+            s/^(\s*)- \[x\]\s+/$1✓ /gm;
+            s/^(\s*)[-*]\s+/$1• /gm;
+            s/&/&amp;/g;
+            s/</&lt;/g;
+            s/>/&gt;/g;
+            s/\x06/> /g;
+            s{\x01(\d+)\x02(.*?)\x03}{"<$u[$1]|$2>"}ge;
+            s{\x04(\d+)\x05}{"```\n$c[$1]\n```"}ge;
+          ')
+          jq \
+            --arg channel "$SLACK_CHANNEL_ID" \
+            --arg kind "$KIND" \
+            --arg body "$BODY" \
+            '
+              def escape: gsub("&";"&amp;") | gsub("<";"&lt;") | gsub(">";"&gt;");
+
+              (.issue // .pull_request) as $i
+              | ([$i.labels[]?.name | select(. != "devtools-gardener")]
+                  | map("`\(.)`") | join(" ")) as $labels
+              | (if $kind == "PR"
+                  then " · \($i.changed_files) files, +\($i.additions)/-\($i.deletions)"
+                       + (if $i.draft then " · draft" else "" end)
+                  else "" end) as $meta
+              | [ "*<\($i.html_url)|\($kind) #\($i.number)>* — \(($i.title | escape))",
+                  "_opened by \($i.user.login)\($meta)_" ]
+                + (if $body != "" then [$body] else [] end)
+                + (if $labels != "" then [$labels] else [] end)
+              | join("\n") as $msg
+              | { channel: $channel, text: "\($kind) #\($i.number): \($i.title)",
+                  blocks: [{ type: "section", text: { type: "mrkdwn", text: $msg } }] }
+            ' event.json | curl -sf -X POST \
+              -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+              -H 'Content-type: application/json; charset=utf-8' \
+              -d @- https://slack.com/api/chat.postMessage


### PR DESCRIPTION
## Summary

Wires the `devtools-gardener` label and a `#gardener` Slack channel to every new issue and PR — including Dependabot — and also posts when someone manually applies the label. Separately, upgrades the existing investigate workflow (renamed from `devtools-investigate-for-gardener` to `gardener-investigate-issue`) to post threaded start/complete updates to Slack.

## What's in the branch

Three focused commits:

### 1. Rename investigate workflow to `gardener-investigate-issue`
Pure file rename with a matching `name:` field update. No behavior change. Establishes a `gardener-*` naming family so the new notification workflows slot in alongside.

### 2. Add auto-label + Slack notifications for new issues and PRs
Two workflows that together handle "something new showed up":

- **`gardener-notify-event.yml`** — tiny capturer. Triggers on `issues` / `pull_request_target` (`opened`, `labeled`). Stashes the triggering event payload as an artifact, then exits. Uses `pull_request_target` so fork PRs (and Dependabot) produce an artifact. No code is checked out, so there's no pwn-request surface.
- **`gardener-notify-slack.yml`** — triggered via `workflow_run` after the capturer completes. The `workflow_run` trigger runs in the default-branch context with full `GITHUB_TOKEN` permissions and Actions secret access, which is what lets labelling + posting succeed for Dependabot PRs (where the upstream `pull_request_target` event gets a read-only token and no secrets). Adds the `devtools-gardener` label on `opened`, then posts a summary to Slack via `chat.postMessage`.

Result: **every new issue/PR gets labelled and a Slack summary; manually adding `devtools-gardener` to an existing item also posts a summary.**

### 3. Add threaded Slack updates to the investigate workflow
The investigate workflow now posts a "Claude is investigating…" starter message before running, then threads the completion (or failure) post onto it with `reply_broadcast: true` so the summary shows up inline in the channel. A single `github-script` step builds either the success or failure payload; the success branch is wrapped in try/catch so a malformed payload falls through to the failure notice instead of leaving the starter message orphaned.

## GitHub Markdown → Slack mrkdwn converter

Both posting paths convert GitHub-flavoured Markdown into Slack's `mrkdwn`:

- Headers (`#…######`) → `*bold*`
- `**bold**` → `*bold*`
- `[text](url)` → `<url|text>` (URL stashed around the HTML-escape pass so `&` inside it stays raw)
- `- [x] task` → `✓ task`
- `- ` / `* ` bullets → `• `
- Fenced code blocks → triple-backtick (language identifier stripped; contents stashed so they aren't rewritten by other passes)
- `> ` blockquotes preserved (markers stashed so the `>` → `&gt;` escape doesn't break them)

The untrusted-body path (new-issue/PR summaries) HTML-escapes everything outside the stashed regions so user-supplied `<`, `>`, `&` can't collide with Slack link syntax or inject `<!channel>`-style mentions. The Claude-report path skips the HTML-escape since the output is trusted structured output.

## Infra required

- Secret `SLACK_GARDENER_BOT_TOKEN` — Slack bot token with `chat:write` (and `chat:write.public` if posting to a channel the bot isn't in).
- Variable `GARDENER_SLACK_CHANNEL_ID` — the channel to post to.
- Repo label `devtools-gardener` must exist (it does).

The old webhook secret `SLACK_GARDENER_WEBHOOK_URL` is no longer referenced and can be removed.

## Security notes

- `pull_request_target` in `gardener-notify-event.yml` does not check out PR code — only reads the pre-parsed event payload.
- `workflow_run` indirection is what lets Dependabot PRs be labelled + posted; without it, Dependabot's read-only token and blocked secrets would break both.
- The untrusted-body converter HTML-escapes around the stashed regions to neutralise injected Slack mentions in user content.

## Test plan

- [ ] Open a new issue as a Shopifolk account → `devtools-gardener` label appears; Slack gets a summary post in the configured channel.
- [ ] Open a new PR as a Shopifolk account → same.
- [ ] Wait for a Dependabot PR (or trigger one) → label applied; Slack gets a summary post. Confirms the `workflow_run` path works with the restricted upstream token.
- [ ] Manually add `devtools-gardener` to an existing issue/PR → Slack gets a summary post (no duplicate label-add attempted).
- [ ] Issue body containing `**bold**`, `[link](https://example.com/?a=1&b=2)`, a fenced code block, a bulleted list, and `<script>` → Slack renders bold/link/code/bullets correctly, `<script>` is escaped, `&` in URL stays raw.
- [ ] Apply `devtools-investigate-for-gardener` to an issue → starter post in Slack, then threaded completion with the investigation summary broadcast back to the channel.
- [ ] Simulate a Claude crash/timeout in the investigate workflow → starter post still gets a threaded failure notice (not orphaned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)