### PR TITLE
fix(mongodb): properly handle expires field conversion in session sto…

### DIFF
--- a/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/mongodb.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/mongodb.ts
@@ -92,6 +92,7 @@ export class MongoDBSessionStorage implements SessionStorage {
     return true;
   }
 
+  
   public async findSessionsByShop(shop: string): Promise<Session[]> {
     await this.ready;
 

--- a/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/mongodb.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/mongodb.ts
@@ -48,13 +48,17 @@ export class MongoDBSessionStorage implements SessionStorage {
   public async storeSession(session: Session): Promise<boolean> {
     await this.ready;
 
-    await this.collection.findOneAndReplace(
-      {id: session.id},
-      session.toObject(),
-      {
-        upsert: true,
-      },
-    );
+    const entries = session.toPropertyArray();
+    const doc: Record<string, any> = {};
+    for (const [key, value] of entries) {
+      if (value !== undefined && value !== null) {
+        doc[key] = value;
+      }
+    }
+
+    await this.collection.findOneAndReplace({id: session.id}, doc, {
+      upsert: true,
+    });
     return true;
   }
 
@@ -63,7 +67,17 @@ export class MongoDBSessionStorage implements SessionStorage {
 
     const result = await this.collection.findOne({id});
 
-    return result ? new Session(result) : undefined;
+    if (!result) return undefined;
+
+    const entries: [string, any][] = [];
+    for (const [key, value] of Object.entries(result)) {
+      if (key === '_id') continue;
+      if (value !== null && value !== undefined) {
+        entries.push([key, value]);
+      }
+    }
+
+    return Session.fromPropertyArray(entries);
   }
 
   public async deleteSession(id: string): Promise<boolean> {
@@ -84,7 +98,16 @@ export class MongoDBSessionStorage implements SessionStorage {
     const rawResults = await this.collection.find({shop}).toArray();
     if (!rawResults || rawResults?.length === 0) return [];
 
-    return rawResults.map((rawResult: any) => new Session(rawResult));
+    return rawResults.map((rawResult: any) => {
+      const entries: [string, any][] = [];
+      for (const [key, value] of Object.entries(rawResult)) {
+        if (key === '_id') continue;
+        if (value !== null && value !== undefined) {
+          entries.push([key, value]);
+        }
+      }
+      return Session.fromPropertyArray(entries);
+    });
   }
 
   public async disconnect(): Promise<void> {


### PR DESCRIPTION
Fixes a bug in the MongoDB session storage adapter where the \`expires\` field was not being properly serialized/deserialized, causing \`TypeError: this.expires.getTime is not a function\` error
## Problems
The MongoDB adapter was using:
- \`session.toObject()\` to store sessions - which converts \`expires\` to an ISO string
- \`new Session(result)\` to load sessions - which doesn't properly reconstruct the Date object
## Solutions
- Use \`session.toPropertyArray()\` in \`storeSession\` to get the property array with \`expires\` as milliseconds (number)
- Use \`Session.fromPropertyArray(entries)\` in \`loadSession\` and \`findSessionsByShop\` to properly re construct the Session with \`expires\` as a Date object"
## How to Replicate
1. Install a Shopify app using MongoDB session storage
2. Perform a fresh app installation (OAuth flow)
3. The session is stored in MongoDB with `expires` as an ISO string
4. On subsequent requests, when Shopify's internal code tries to access `session.expires.getTime()`, it throws:
   `TypeError: this.expires.getTime is not a function`
5. This also causes 403 errors when Shopify API rejects the token because the expiry format is invalid
## Root Cause
The `Session.toObject()` method converts the `expires` Date object to a string when serializing. When loading with `new Session(result)`, the string is passed directly without conversion back to a Date, causing the internal `_expires` property to be a string instead of a Date.
## Shopify API Change (April 2026)
This bug became critical due to Shopify's recent enforcement of expiring offline access tokens:
**December 2025:** Shopify introduced expiring offline access tokens (60-minute expiry with refresh tokens)
**April 1, 2026:** Shopify started enforcing expiring tokens for all new public apps. The Admin API now returns:
403 Forbidden - "Non-expiring access tokens are no longer accepted for the Admin API"
Apps must now:
1. Request expiring offline tokens during OAuth (include `access_mode=offline`)
2. Store the `expires_in` value and track token expiry
3. Use the refresh token to obtain new tokens before expiry
The MongoDB adapter bug prevents proper token expiry tracking because:
- The `accessTokenExpiresAt` field is stored as a string, not a Date
- Token refresh logic cannot properly compare expiry times
- This causes the refresh flow to fail, leading to 403 errors
