### PR TITLE
feat(shopify-app-remix): allow overriding linkComponent on AppProvider

### DIFF
--- a/.changeset/app-provider-custom-link-component.md
+++ b/.changeset/app-provider-custom-link-component.md
@@ -1,0 +1,14 @@
+---
+'@shopify/shopify-app-remix': minor
+---
+
+`AppProvider` now accepts an optional `linkComponent` prop, allowing apps to override the default `RemixPolarisLink`. This unblocks use cases like passing Remix's `NavLink` to drive active-route styling for Polaris `Navigation.Item` or `Link`. When omitted, the existing `RemixPolarisLink` is used, so this is a non-breaking addition.
+
+```tsx
+import {NavLink} from '@remix-run/react';
+import {AppProvider} from '@shopify/shopify-app-remix/react';
+
+<AppProvider apiKey={apiKey} linkComponent={NavLink}>
+  <Outlet />
+</AppProvider>
+```

--- a/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx
@@ -40,6 +40,26 @@ export interface AppProviderProps extends Omit<
    */
   i18n?: PolarisAppProviderProps['i18n'];
   /**
+   * A custom link component to use throughout the app. Polaris components that
+   * render links (such as `Link`, `Navigation.Item`, etc.) will forward all
+   * link props to this component.
+   *
+   * Defaults to a thin wrapper around Remix's `Link` that strips Polaris-only
+   * props. Override when you need access to Remix navigation state, for
+   * example to drive an active style with `NavLink`:
+   *
+   * ```tsx
+   * import {NavLink} from '@remix-run/react';
+   *
+   * <AppProvider apiKey={apiKey} linkComponent={NavLink}>
+   *   <Outlet />
+   * </AppProvider>
+   * ```
+   *
+   * {@link https://polaris.shopify.com/components/utilities/app-provider#props}
+   */
+  linkComponent?: PolarisAppProviderProps['linkComponent'];
+  /**
    * Used internally by Shopify. You don't need to set this.
    * @private
    */
@@ -115,6 +135,7 @@ export function AppProvider(props: AppProviderProps) {
     apiKey,
     i18n,
     isEmbeddedApp = true,
+    linkComponent = RemixPolarisLink,
     __APP_BRIDGE_URL = APP_BRIDGE_URL,
     ...polarisProps
   } = props;
@@ -141,7 +162,7 @@ export function AppProvider(props: AppProviderProps) {
       {isEmbeddedApp && <script src={__APP_BRIDGE_URL} data-api-key={apiKey} />}
       <PolarisAppProvider
         {...polarisProps}
-        linkComponent={RemixPolarisLink}
+        linkComponent={linkComponent}
         i18n={i18n || englishI18n}
       >
         {children}

--- a/packages/apps/shopify-app-remix/src/react/components/AppProvider/__tests__/AppProvider.test.tsx
+++ b/packages/apps/shopify-app-remix/src/react/components/AppProvider/__tests__/AppProvider.test.tsx
@@ -72,6 +72,24 @@ describe('<AppProvider />', () => {
     });
   });
 
+  it('forwards a custom linkComponent to the Polaris provider', () => {
+    // GIVEN a consumer-supplied link component (e.g. Remix `NavLink`)
+    const CustomLink = (props: any) => <a {...props} />;
+
+    // WHEN
+    const component = mount(
+      <AppProvider {...defaultProps} linkComponent={CustomLink}>
+        Hello world
+      </AppProvider>,
+    );
+
+    // THEN the Polaris provider receives the custom component, not the
+    // default RemixPolarisLink.
+    expect(component).toContainReactComponent(PolarisAppProvider, {
+      linkComponent: CustomLink,
+    });
+  });
+
   it('handles "shopify:navigate" events correctly', () => {
     const component = mount(
       <AppProvider isEmbeddedApp apiKey={'test-api-key'}>


### PR DESCRIPTION
## What

Adds an optional `linkComponent` prop to `<AppProvider>` so apps can override the default `RemixPolarisLink`. When omitted, behaviour is identical to today (existing `RemixPolarisLink` is used), so this is a non-breaking minor.

```tsx
import {NavLink} from '@remix-run/react';
import {AppProvider} from '@shopify/shopify-app-remix/react';

<AppProvider apiKey={apiKey} linkComponent={NavLink}>
  <Outlet />
</AppProvider>
```

## Why

Closes [Shopify/shopify-app-template-remix#486](https://github.com/Shopify/shopify-app-template-remix/issues/486). The issue author (@blanklob) wants Polaris components that render links to use Remix's `NavLink` (or any custom wrapper) so they can pick up navigation state like `isActive`. Until now `AppProvider` `Omit`-stripped `linkComponent` from its public prop surface and hardcoded `RemixPolarisLink`, which left no escape hatch short of forking the provider.

This mirrors how `i18n` is already exposed: omit the Polaris prop, then re-declare a typed wrapper that defaults to the in-package value. The change is a single destructured default plus a new JSDoc-documented prop, so reviewers can audit it in one read.

## What changed

| File | Change |
|---|---|
| `packages/apps/shopify-app-remix/src/react/components/AppProvider/AppProvider.tsx` | Added `linkComponent?: PolarisAppProviderProps['linkComponent']` to `AppProviderProps` with JSDoc. Destructured with `RemixPolarisLink` as the default. Forwarded to `<PolarisAppProvider>`. |
| `packages/apps/shopify-app-remix/src/react/components/AppProvider/__tests__/AppProvider.test.tsx` | Added one test verifying a consumer-supplied link component is forwarded to the Polaris provider (the existing test confirms the default still resolves to `RemixPolarisLink`). |
| `.changeset/app-provider-custom-link-component.md` | Minor changeset for `@shopify/shopify-app-remix` with a usage snippet. |

## Test plan

- [x] All 6 existing `AppProvider` tests still pass (`npx jest --testPathPatterns AppProvider`)
- [x] New regression test passes (custom `linkComponent` reaches `<PolarisAppProvider>`)
- [x] Default-omit behaviour preserved (`linkComponent: RemixPolarisLink` assertion in the existing i18n test continues to pass unchanged)
- [x] No type changes to the exported surface beyond adding an optional prop

## Notes

- The issue author originally floated the name `customLink`, but `linkComponent` matches the existing Polaris convention (and is the prop we forward to anyway), so I went with that to avoid two names for the same thing. Happy to rename if maintainers prefer.
- The example uses Remix's `NavLink`, which is the headline use case from the issue's Loom.