### PR TITLE
Render App Bridge instead of login redirect when shop/host params are missing in embedded apps

### DIFF
--- a/.changeset/render-app-bridge-missing-params.md
+++ b/.changeset/render-app-bridge-missing-params.md
@@ -15,3 +15,8 @@ This is a non-breaking change. The previous login redirect was effectively dead
 code for embedded apps (`isEmbeddedApp` is always `true` for apps using this
 library; the `ShopifyAdmin` distribution is excluded earlier in the pipeline).
 No public APIs are added, removed, or changed.
+
+Additionally hardened `renderAppBridge` to sanitize the `shop` query param
+before using it in response headers, so an invalid/attacker-controlled value
+cannot be reflected into the `Content-Security-Policy: frame-ancestors` or
+`Link` preconnect headers.

--- a/.changeset/render-app-bridge-missing-params.md
+++ b/.changeset/render-app-bridge-missing-params.md
@@ -1,0 +1,17 @@
+---
+'@shopify/shopify-app-react-router': patch
+---
+
+Fixed an issue where embedded apps would incorrectly show the login page when
+`shop` or `host` query params were missing from a document request (e.g. after
+SPA navigation followed by a full page reload during local development).
+
+Instead of redirecting to the login path, the server now renders a minimal App
+Bridge page. App Bridge detects it is still embedded in the Shopify admin iframe,
+retrieves the session token from the parent frame, and re-authenticates
+seamlessly — no user interaction required.
+
+This is a non-breaking change. The previous login redirect was effectively dead
+code for embedded apps (`isEmbeddedApp` is always `true` for apps using this
+library; the `ShopifyAdmin` distribution is excluded earlier in the pipeline).
+No public APIs are added, removed, or changed.

--- a/packages/apps/shopify-app-react-router/src/server/__test-helpers/expect-login-redirect.ts
+++ b/packages/apps/shopify-app-react-router/src/server/__test-helpers/expect-login-redirect.ts
@@ -1,8 +1,0 @@
-import {APP_URL} from './const';
-
-export function expectLoginRedirect(response: Response) {
-  expect(response.status).toBe(302);
-
-  const {pathname} = new URL(response.headers.get('location')!, APP_URL);
-  expect(pathname).toBe('/auth/login');
-}

--- a/packages/apps/shopify-app-react-router/src/server/__test-helpers/index.ts
+++ b/packages/apps/shopify-app-react-router/src/server/__test-helpers/index.ts
@@ -2,7 +2,6 @@ export * from './const';
 export * from './expect-admin-api-client';
 export * from './expect-document-request-headers';
 export * from './expect-exit-iframe';
-export * from './expect-login-redirect';
 export * from './expect-storefront-api-client';
 export * from './get-hmac';
 export * from './get-jwt';

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
@@ -1,4 +1,5 @@
 import {shopifyApp} from '../../..';
+import {APP_BRIDGE_URL} from '../../const';
 import {
   API_KEY,
   APP_URL,
@@ -8,7 +9,6 @@ import {
   getThrownResponse,
   setUpValidSession,
   testConfig,
-  expectLoginRedirect,
 } from '../../../__test-helpers';
 
 describe('authorize.admin doc request path', () => {
@@ -18,22 +18,32 @@ describe('authorize.admin doc request path', () => {
       {shop: TEST_SHOP, host: 'invalid-domain.test'},
       {shop: undefined, host: BASE64_HOST},
       {shop: 'invalid', host: BASE64_HOST},
-    ])('throws when %s', async ({shop, host}) => {
-      // GIVEN
-      const shopify = shopifyApp(testConfig());
-      const searchParams = new URLSearchParams();
-      if (shop) searchParams.set('shop', shop);
-      if (host) searchParams.set('host', host);
+    ])(
+      'renders App Bridge when embedded app has missing or invalid params: %s',
+      async ({shop, host}) => {
+        // GIVEN
+        const config = testConfig();
+        const shopify = shopifyApp(config);
+        const searchParams = new URLSearchParams();
+        if (shop) searchParams.set('shop', shop);
+        if (host) searchParams.set('host', host);
 
-      // WHEN
-      const response = await getThrownResponse(
-        shopify.authenticate.admin,
-        new Request(`${APP_URL}?${searchParams.toString()}`),
-      );
+        // WHEN
+        const response = await getThrownResponse(
+          shopify.authenticate.admin,
+          new Request(`${APP_URL}?${searchParams.toString()}`),
+        );
 
-      // THEN
-      expectLoginRedirect(response);
-    });
+        // THEN
+        expect(response.status).toBe(200);
+        expect(response.headers.get('content-type')).toBe(
+          'text/html;charset=utf-8',
+        );
+        expect((await response.text()).trim()).toBe(
+          `<script data-api-key="${config.apiKey}" src="${APP_BRIDGE_URL}"></script>`,
+        );
+      },
+    );
 
     it('throws an error if the request URL is the login path', async () => {
       // GIVEN

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/doc-request-path.test.ts
@@ -45,6 +45,38 @@ describe('authorize.admin doc request path', () => {
       },
     );
 
+    it('does not leak an attacker-controlled shop into response headers when shop is invalid', async () => {
+      // Regression test: when `?shop=evil.com` fails sanitizeShop, the App
+      // Bridge page must not echo that value into CSP frame-ancestors or the
+      // Link preconnect header. See render-app-bridge.ts.
+      // GIVEN
+      const config = testConfig();
+      const shopify = shopifyApp(config);
+      const evilShop = 'evil.com';
+      const searchParams = new URLSearchParams();
+      searchParams.set('shop', evilShop);
+      searchParams.set('host', BASE64_HOST);
+
+      // WHEN
+      const response = await getThrownResponse(
+        shopify.authenticate.admin,
+        new Request(`${APP_URL}?${searchParams.toString()}`),
+      );
+
+      // THEN
+      expect(response.status).toBe(200);
+      const csp = response.headers.get('Content-Security-Policy');
+      // For an embedded app with no valid shop, no shop-specific frame-ancestors
+      // entry should be emitted, and certainly not the attacker-controlled value.
+      if (csp !== null) {
+        expect(csp).not.toContain(evilShop);
+      }
+      const link = response.headers.get('Link');
+      // The Link preconnect header is only set when shop is valid; with an
+      // invalid shop it should be absent.
+      expect(link).toBeNull();
+    });
+
     it('throws an error if the request URL is the login path', async () => {
       // GIVEN
       const shopify = shopifyApp(testConfig());

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/render-app-bridge.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/render-app-bridge.ts
@@ -12,7 +12,7 @@ export interface RedirectToOptions {
 }
 
 export function renderAppBridge(
-  {config}: BasicParams,
+  {api, config}: BasicParams,
   request: Request,
   redirectTo?: RedirectToOptions,
 ): never {
@@ -31,11 +31,13 @@ export function renderAppBridge(
     'content-type': 'text/html;charset=utf-8',
   });
   const isEmbeddedApp = config.distribution !== AppDistribution.ShopifyAdmin;
-  addDocumentResponseHeaders(
-    responseHeaders,
-    isEmbeddedApp,
-    new URL(request.url).searchParams.get('shop'),
+  // Sanitize the shop param before using it in response headers (e.g. CSP
+  // frame-ancestors, Link preconnect). An attacker-controlled `?shop=evil.com`
+  // must not end up in security-sensitive headers.
+  const shop = api.utils.sanitizeShop(
+    new URL(request.url).searchParams.get('shop')!,
   );
+  addDocumentResponseHeaders(responseHeaders, isEmbeddedApp, shop);
 
   throw new Response(
     `

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/validate-shop-and-host-params.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/validate-shop-and-host-params.ts
@@ -1,6 +1,6 @@
-import {redirect} from 'react-router';
-
 import {BasicParams, AppDistribution} from '../../../types';
+
+import {renderAppBridge} from './render-app-bridge';
 
 export function validateShopAndHostParams(
   params: BasicParams,
@@ -12,24 +12,24 @@ export function validateShopAndHostParams(
     const url = new URL(request.url);
     const shop = api.utils.sanitizeShop(url.searchParams.get('shop')!);
     if (!shop) {
-      logger.debug('Missing or invalid shop, redirecting to login path', {
+      logger.debug('Missing or invalid shop, rendering App Bridge', {
         shop,
       });
-      throw redirectToLoginPath(request, params);
+      throw renderAppBridgeOrError(request, params);
     }
 
     const host = api.utils.sanitizeHost(url.searchParams.get('host')!);
     if (!host) {
-      logger.debug('Invalid host, redirecting to login path', {
+      logger.debug('Invalid host, rendering App Bridge', {
         shop,
         host: url.searchParams.get('host'),
       });
-      throw redirectToLoginPath(request, params);
+      throw renderAppBridgeOrError(request, params);
     }
   }
 }
 
-function redirectToLoginPath(request: Request, params: BasicParams): never {
+function renderAppBridgeOrError(request: Request, params: BasicParams): never {
   const {config, logger} = params;
 
   const {pathname} = new URL(request.url);
@@ -42,5 +42,8 @@ function redirectToLoginPath(request: Request, params: BasicParams): never {
     throw new Response(message, {status: 500});
   }
 
-  throw redirect(config.auth.loginPath);
+  logger.debug(
+    'Missing shop or host params, rendering App Bridge to retrieve session',
+  );
+  throw renderAppBridge(params, request);
 }

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/__tests__/reject-bot-request.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/__tests__/reject-bot-request.test.ts
@@ -36,6 +36,9 @@ describe('Reject bot requests', () => {
     );
 
     // THEN
-    expect(response.status).toBe(302);
+    // The request passes the bot check and proceeds to auth validation.
+    // For embedded apps without shop/host params, this renders the App Bridge
+    // page (200) to retrieve the session token from the parent frame.
+    expect(response.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Problem

During local development of embedded Shopify apps, there's an annoying workflow where the login screen appears inappropriately:

1. Navigate to a new URL within the app (the `id_token` / `shop` / `host` query params are lost from the URL)
2. Make a code change
3. Vite triggers a full page reload (this happens intermittently — not all changes trigger HMR, some cause a full reload)
4. The server receives a document request with no `shop` or `host` params and no `Authorization` header
5. `validateShopAndHostParams` redirects to the login page

This is incorrect because the app is still running inside the Shopify admin iframe — it just lost the URL search params during SPA navigation + reload.

## Solution

In `validateShopAndHostParams`, when `shop` or `host` params are missing/invalid, we now render a minimal App Bridge page instead of redirecting to login.

When App Bridge loads inside the Shopify admin iframe, it:
1. Detects it's embedded in the admin
2. Retrieves the session token from the parent frame
3. Re-authenticates the app seamlessly

This is the same mechanism used by the existing "bounce page" flow (`/auth/session-token`), just applied earlier in the auth pipeline.

The previous code had a `throw redirect(config.auth.loginPath)` fallback for non-embedded apps, but `isEmbeddedApp` is hardcoded to `true` in `shopify-app.ts` for all apps using this library (the `ShopifyAdmin` distribution is already excluded earlier in the function). This made the login redirect dead code. This PR removes that dead code — no public APIs are changed.

Note: this is a production behavior change, not just a dev improvement. Any request to an embedded app without `shop`/`host` params (e.g., bookmarked deep links, direct URL access) will now get the App Bridge page instead of a login redirect. This is correct behavior — App Bridge will handle re-embedding in the admin.

### What changed

- **`validate-shop-and-host-params.ts`**: Replaced the `redirectToLoginPath` helper with `renderAppBridgeOrError`. Instead of redirecting to the login page, renders the App Bridge page so it can recover the session. Removed the unused `redirect` import from `react-router` and the dead login redirect code path. The login path guard (500 error when `authenticate.admin()` is called from the login route) is preserved.
- **`doc-request-path.test.ts`**: Updated the 4 test cases for missing/invalid shop/host params to expect an App Bridge page (200 with App Bridge script tag) instead of a login redirect (302).
- **`reject-bot-request.test.ts`**: Updated the "allowed Shopify agents" assertions to expect 200 (App Bridge page) instead of 302 (login redirect), confirming the request passes the bot check and proceeds to auth validation.
- **`expect-login-redirect.ts`**: Removed — no longer used by any test.
- **`__test-helpers/index.ts`**: Removed the `expect-login-redirect` export.