### PR TITLE
Fix admin extension CORS preflight in `validateAuthenticatedSession`

### DIFF
--- a/.changeset/fix-admin-extension-cors-preflight.md
+++ b/.changeset/fix-admin-extension-cors-preflight.md
@@ -1,0 +1,5 @@
+---
+"@shopify/shopify-app-express": patch
+---
+
+Respond to CORS preflight (`OPTIONS`) requests in `validateAuthenticatedSession` instead of trying to authenticate them. Admin UI extension `fetch` calls to an app's backend send a preflight request that carries no `Authorization` header, so the middleware would redirect/403 and the browser would block the real request on CORS. The middleware now short-circuits `OPTIONS` requests, responding `204` with the CORS headers for `https://extensions.shopifycdn.com`.

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -225,6 +225,43 @@ describe('validateAuthenticatedSession', () => {
 
       expect((response.error as any).text).toBe('Storage error');
     });
+
+    it('responds to a CORS preflight OPTIONS request without authenticating', async () => {
+      const getCurrentIdSpy = jest.spyOn(shopify.api.session, 'getCurrentId');
+
+      const response = await request(app)
+        .options('/test/shop')
+        .set('Origin', 'https://extensions.shopifycdn.com')
+        .expect(204);
+
+      expect(response.headers['access-control-allow-origin']).toBe(
+        'https://extensions.shopifycdn.com',
+      );
+      expect(getCurrentIdSpy).not.toHaveBeenCalled();
+    });
+
+    it('allows the Authorization header on the preflight response', async () => {
+      const response = await request(app)
+        .options('/test/shop')
+        .set('Origin', 'https://extensions.shopifycdn.com')
+        .expect(204);
+
+      expect(response.headers['access-control-allow-headers']).toContain(
+        'Authorization',
+      );
+    });
+
+    it('allows the request methods on the preflight response', async () => {
+      const response = await request(app)
+        .options('/test/shop')
+        .set('Origin', 'https://extensions.shopifycdn.com')
+        .expect(204);
+
+      expect(response.headers['access-control-allow-methods']).toContain('GET');
+      expect(response.headers['access-control-allow-methods']).toContain(
+        'POST',
+      );
+    });
   });
 
   describe('for non-embedded apps', () => {

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -18,6 +18,17 @@ export function validateAuthenticatedSession({
     return async (req: Request, res: Response, next: NextFunction) => {
       config.logger.debug('Running validateAuthenticatedSession');
 
+      if (req.method === 'OPTIONS') {
+        res.set({
+          'Access-Control-Allow-Origin': 'https://extensions.shopifycdn.com',
+          'Access-Control-Allow-Methods':
+            'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Authorization, Content-Type',
+        });
+        res.status(204).end();
+        return undefined;
+      }
+
       let sessionId: string | undefined;
       try {
         sessionId = await api.session.getCurrentId({


### PR DESCRIPTION
### What

Admin UI extension `fetch` calls to an app's backend (Express template) fail because the CORS preflight `OPTIONS` request is run through `validateAuthenticatedSession`. The preflight carries no `Authorization` header, so the middleware redirects/403s it, and the browser then blocks the real (authenticated) request on CORS.

A maintainer confirmed the fix direction in #1420:

> we're not handling `OPTIONS` requests properly in that package - we should be just setting the CORS headers and responding in that case, instead of trying to authenticate it.

### How

`validateAuthenticatedSession` now short-circuits `OPTIONS` requests before the auth logic runs: it responds `204` with the CORS headers for `https://extensions.shopifycdn.com` — the origin that Shopify's [admin-extensions security docs](https://shopify.dev/docs/api/admin-extensions#security) require apps to allow. The short-circuit is config-agnostic, so it applies to both embedded and non-embedded apps.

### Before / after

Before: `OPTIONS /api/...` → `302` redirect to `/api/auth` (or `403`) → browser blocks the real request on CORS.
After: `OPTIONS /api/...` → `204` with `Access-Control-Allow-Origin: https://extensions.shopifycdn.com` (+ Allow-Methods / Allow-Headers) → the real request proceeds and is authenticated exactly as before.

### Tests

Added 3 tests to `validate-authenticated-session.test.ts`: preflight returns `204` without calling `getCurrentId` (no auth attempt); allows the `Authorization` header; allows the request methods. Full `shopify-app-express` suite: 88 passing, no regressions. `tsc` + lint clean. Changeset added (patch).

### Open to feedback

- **Allowed origin** — hardcoded to `https://extensions.shopifycdn.com` per the docs. Happy to make it configurable or echo a validated `Origin` if you'd prefer.
- **Allow-Methods / Allow-Headers** — currently `GET, POST, PUT, PATCH, DELETE, OPTIONS` and `Authorization, Content-Type`. Can narrow/widen to match what extensions actually send.
- **Allow-Credentials** — not set (admin extension auth uses the `Authorization` header, not cookies). Let me know if a case needs it.

### AI disclosure

This change was developed with AI assistance (Claude). The approach, code, and tests were reviewed and verified locally by me.

Fixes #1420
