### PR TITLE
Fix: respond to CORS preflight OPTIONS requests without authenticating (shopify-app-express)

### DIFF
--- a/.changeset/express-options-preflight-cors.md
+++ b/.changeset/express-options-preflight-cors.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-express': patch
+---
+
+Respond to CORS preflight `OPTIONS` requests in `validateAuthenticatedSession` by setting CORS headers and returning `204`, instead of running them through the authentication flow. Preflight requests don't carry a session token, so authenticating them always failed and redirected to auth, breaking authenticated fetches from admin extensions.

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -360,5 +360,32 @@ describe('validateAuthenticatedSession', () => {
         'X-Shopify-Api-Request-Failure-Reauthorize-Url',
       );
     });
+
+    it('still responds 204 with CORS headers when no Origin header is sent', async () => {
+      // Admin extension preflights do not always carry an Origin header; the
+      // handler is unconditional, so it must not depend on Origin being present.
+      const getCurrentIdSpy = jest.spyOn(shopify.api.session, 'getCurrentId');
+
+      const response = await request(app)
+        .options('/test/shop?shop=my-shop.myshopify.io')
+        .expect(204);
+
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+      expect(getCurrentIdSpy).not.toHaveBeenCalled();
+      expect(response.headers.location).toBeUndefined();
+    });
+
+    it('does not short-circuit non-OPTIONS requests', async () => {
+      // The early return must be scoped to OPTIONS only: a GET still runs the
+      // full authentication flow (here, an unauthenticated GET is redirected).
+      const getCurrentIdSpy = jest.spyOn(shopify.api.session, 'getCurrentId');
+
+      const response = await request(app).get(
+        '/test/shop?shop=my-shop.myshopify.io',
+      );
+
+      expect(response.status).not.toBe(204);
+      expect(getCurrentIdSpy).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/validate-authenticated-session.test.ts
@@ -313,4 +313,52 @@ describe('validateAuthenticatedSession', () => {
       ).toBe(`${shopify.config.auth.path}?shop=my-shop.myshopify.io`);
     });
   });
+
+  describe('for CORS preflight OPTIONS requests', () => {
+    beforeEach(() => {
+      shopify.api.config.isEmbeddedApp = true;
+
+      app = express();
+      app.use('/test', shopify.validateAuthenticatedSession());
+      app.get('/test/shop', async (req, res) => {
+        res.json({data: {shop: {name: req.query.shop}}});
+      });
+    });
+
+    it('responds with CORS headers and does not try to authenticate', async () => {
+      const getCurrentIdSpy = jest.spyOn(shopify.api.session, 'getCurrentId');
+
+      const response = await request(app)
+        .options('/test/shop?shop=my-shop.myshopify.io')
+        .set('Origin', 'https://extensions.shopifycdn.com')
+        .expect(204);
+
+      expect(response.headers['access-control-allow-origin']).toBe('*');
+      expect(response.headers['access-control-allow-headers']).toBe(
+        'Authorization, Content-Type',
+      );
+      expect(response.headers['access-control-max-age']).toBe('7200');
+
+      // The preflight must not be authenticated nor redirected to auth.
+      expect(getCurrentIdSpy).not.toHaveBeenCalled();
+      expect(response.headers.location).toBeUndefined();
+      expect(
+        response.headers['x-shopify-api-request-failure-reauthorize'],
+      ).toBeUndefined();
+    });
+
+    it('exposes the reauthorization headers for the follow-up request', async () => {
+      const response = await request(app)
+        .options('/test/shop?shop=my-shop.myshopify.io')
+        .set('Origin', 'https://extensions.shopifycdn.com')
+        .expect(204);
+
+      expect(response.headers['access-control-expose-headers']).toContain(
+        'X-Shopify-Api-Request-Failure-Reauthorize',
+      );
+      expect(response.headers['access-control-expose-headers']).toContain(
+        'X-Shopify-Api-Request-Failure-Reauthorize-Url',
+      );
+    });
+  });
 });

--- a/packages/apps/shopify-app-express/src/middlewares/respond-to-options-request.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/respond-to-options-request.ts
@@ -1,0 +1,39 @@
+import {Request, Response} from 'express';
+
+import {AppConfigInterface} from '../config-types';
+
+/**
+ * For CORS preflight `OPTIONS` requests we should only set the CORS headers and
+ * respond, instead of trying to authenticate them. Admin extensions send a
+ * preflight `OPTIONS` request before the authenticated fetch, and that request
+ * never carries the session token, so running it through the authentication
+ * flow would always fail and redirect.
+ *
+ * Returns `true` when the request was an `OPTIONS` preflight and a response was
+ * sent, so callers can stop further processing.
+ */
+export function respondToOptionsRequest(
+  config: AppConfigInterface,
+  req: Request,
+  res: Response,
+): boolean {
+  if (req.method !== 'OPTIONS') {
+    return false;
+  }
+
+  config.logger.debug(
+    'Preflight OPTIONS request, responding with CORS headers',
+  );
+
+  res.status(204);
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Authorization, Content-Type');
+  res.append('Access-Control-Expose-Headers', [
+    'X-Shopify-Api-Request-Failure-Reauthorize',
+    'X-Shopify-Api-Request-Failure-Reauthorize-Url',
+  ]);
+  res.header('Access-Control-Max-Age', '7200');
+  res.end();
+
+  return true;
+}

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -7,6 +7,7 @@ import {redirectOutOfApp} from '../redirect-out-of-app';
 
 import {ValidateAuthenticatedSessionMiddleware} from './types';
 import {hasValidAccessToken} from './has-valid-access-token';
+import {respondToOptionsRequest} from './respond-to-options-request';
 
 type validateAuthenticatedSessionParams = ApiAndConfigParams;
 
@@ -17,6 +18,12 @@ export function validateAuthenticatedSession({
   return function validateAuthenticatedSession() {
     return async (req: Request, res: Response, next: NextFunction) => {
       config.logger.debug('Running validateAuthenticatedSession');
+
+      // CORS preflight OPTIONS requests don't carry a session token, so we just
+      // set the CORS headers and respond instead of trying to authenticate them.
+      if (respondToOptionsRequest(config, req, res)) {
+        return undefined;
+      }
 
       let sessionId: string | undefined;
       try {


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1420

The `validateAuthenticatedSession` middleware in `@shopify/shopify-app-express`
runs every request — including CORS preflight `OPTIONS` requests — through the
full authentication flow. A preflight request never carries a session cookie or
`Authorization: Bearer` header, so it always fails authentication and is
redirected to `/auth` (HTTP 302). The browser's CORS preflight then fails on the
redirect, so the real authenticated request from an admin extension to the app's
own backend never fires.

This is the behavior the maintainer confirmed in #1420: for `OPTIONS` we should
just set the CORS headers and respond, instead of trying to authenticate.

### WHAT is this pull request doing?

- Adds a small `respondToOptionsRequest` helper to the Express package that, for
  `OPTIONS` requests, sets the CORS headers (`Access-Control-Allow-Origin`,
  `Access-Control-Allow-Headers`, `Access-Control-Expose-Headers`,
  `Access-Control-Max-Age`) and responds `204` without authenticating. This
  adapts the preflight handling already used by `shopify-app-remix` and
  `shopify-app-react-router` to the Express middleware path.
- Calls it at the top of `validateAuthenticatedSession`, before any session
  lookup, returning early for preflight requests.
- Adds unit tests covering the `OPTIONS` path: the preflight now returns `204`
  with CORS headers, never invokes session lookup, never redirects, and still
  handles preflights without an `Origin` header.

No behavior change for any non-`OPTIONS` request.

#### How was this verified?
- Targeted `jest` for `validate-authenticated-session.test.ts`: 18/18 tests
  pass, including the hardened preflight coverage.
- Red→green check: with the fix removed, the new tests fail with
  `expected 204, got 302` — reproducing the reported redirect — and pass once
  restored.
- `eslint .` and `tsc --noEmit` for the package: both clean.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs) — n/a, no public API change
