### PR TITLE
Fix: default cookies to HttpOnly, matching the CookieData JSDoc

### DIFF
--- a/.changeset/fix-cookie-httponly-default.md
+++ b/.changeset/fix-cookie-httponly-default.md
@@ -1,0 +1,12 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Set `httpOnly` by default when writing cookies
+
+`Cookies.set` (and therefore `Cookies.setAndSign`) now applies `httpOnly: true`
+by default, matching the long-standing `CookieData.httpOnly` JSDoc which already
+documented `true` as the default. Previously the default was never applied, so
+the OAuth `shopify_app_state` cookie (and the non-embedded session cookie) were
+emitted without the `HttpOnly` flag. Callers that need client-side JavaScript
+access can still opt out by explicitly passing `httpOnly: false`.

--- a/packages/apps/shopify-api/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/__tests__/oauth.test.ts
@@ -65,6 +65,13 @@ describe('beginAuth', () => {
       expect(cookies.outgoingCookieJar.shopify_app_state.value).toEqual(
         VALID_NONCE,
       );
+      // The state cookie (and its signature) must be HttpOnly so it is not
+      // exposed to client-side JavaScript. See issue #3207. The value is a
+      // string here because it is parsed back out of the Set-Cookie header.
+      expect(cookies.outgoingCookieJar.shopify_app_state.httpOnly).toBe('true');
+      expect(cookies.outgoingCookieJar['shopify_app_state.sig'].httpOnly).toBe(
+        'true',
+      );
     });
   });
 
@@ -323,6 +330,8 @@ describe('callback', () => {
       callbackResponse.headers['Set-Cookie'],
     );
     expect(responseCookies.shopify_app_session.value).toEqual(expectedId);
+    // The non-embedded session cookie must also be HttpOnly. See issue #3207.
+    expect(responseCookies.shopify_app_session.httpOnly).toBe('true');
     expect(callbackResponse.session.accessToken).toBe(
       successResponse.access_token,
     );

--- a/packages/apps/shopify-api/lib/auth/oauth/__tests__/oauth.test.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/__tests__/oauth.test.ts
@@ -747,3 +747,36 @@ function setCallbackCookieFromResponse(
     `shopify_app_state.sig=${responseCookies.outgoingCookieJar['shopify_app_state.sig'].value}`,
   ].join(';');
 }
+
+describe('Cookies.set httpOnly default (issue #3207)', () => {
+  // These assert the in-memory CookieData directly (a real boolean), which is a
+  // stronger check than the header-parsed string assertions above, and pin the
+  // opt-out path the fix promises in its changeset and PR body.
+  const response = {} as NormalizedResponse;
+
+  it('defaults httpOnly to true when the caller does not pass it', () => {
+    const cookies = new Cookies({} as NormalizedRequest, response, {keys: []});
+
+    cookies.set('test_cookie', 'value');
+
+    expect(cookies.outgoingCookieJar.test_cookie.httpOnly).toBe(true);
+  });
+
+  it('lets a caller opt out with httpOnly: false', () => {
+    const cookies = new Cookies({} as NormalizedRequest, response, {keys: []});
+
+    cookies.set('test_cookie', 'value', {httpOnly: false});
+
+    expect(cookies.outgoingCookieJar.test_cookie.httpOnly).toBe(false);
+  });
+
+  it('does not clobber other caller options when applying the default', () => {
+    const cookies = new Cookies({} as NormalizedRequest, response, {keys: []});
+
+    cookies.set('test_cookie', 'value', {sameSite: 'lax', secure: true});
+
+    expect(cookies.outgoingCookieJar.test_cookie.httpOnly).toBe(true);
+    expect(cookies.outgoingCookieJar.test_cookie.sameSite).toBe('lax');
+    expect(cookies.outgoingCookieJar.test_cookie.secure).toBe(true);
+  });
+});

--- a/packages/apps/shopify-api/runtime/http/cookies.ts
+++ b/packages/apps/shopify-api/runtime/http/cookies.ts
@@ -153,6 +153,9 @@ export class Cookies {
 
   set(name: string, value: string, opts: Partial<CookieData> = {}): void {
     this.outgoingCookieJar[name] = {
+      // Default to httpOnly: true, matching the CookieData.httpOnly JSDoc.
+      // Callers can still opt out by explicitly passing httpOnly: false.
+      httpOnly: true,
       ...opts,
       name,
       value,


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3207

`CookieData.httpOnly` is documented as "true by default", but `Cookies.set`
never applies that default — it only spreads the caller's options. No caller in
`lib/auth/oauth/oauth.ts` passes `httpOnly`, so the OAuth `shopify_app_state`
cookie (and the non-embedded session cookie) are emitted **without** the
`HttpOnly` flag. An OWASP ZAP baseline scan flags this as "Cookie No HttpOnly
Flag". These cookies have no legitimate need for client-side JavaScript access.

### WHAT is this pull request doing?

- `Cookies.set` (and therefore `Cookies.setAndSign`) now defaults `httpOnly` to
  `true`, matching the existing `CookieData.httpOnly` JSDoc. The default is
  applied before spreading caller options, so callers can still opt out by
  explicitly passing `httpOnly: false`. This fixes every call site at once,
  including the non-embedded session cookie.
- Extends the existing OAuth begin/callback tests to assert that the state
  cookie, its `.sig` companion, and the non-embedded session cookie all carry
  `HttpOnly`.
- Adds focused coverage for the `Cookies.set` default, explicit opt-out, and
  preservation of other caller options.

No behavior change other than the added flag; existing callers that relied on
the absence of `HttpOnly` can pass `httpOnly: false`.

#### How was this verified?
- Targeted `jest --selectProjects library --testPathPatterns "oauth\\.test"` in
  `packages/apps/shopify-api`: 23/23 pass.
- Red→green: with the change reverted, the new assertions fail
  (`httpOnly` is `undefined`); with it applied they pass.
- `eslint .` and `tsc --noEmit`: both clean.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature
- [ ] Major: Breaking change

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs — n/a (no public API surface change; the JSDoc already documented this default)
