### PR TITLE
Docs: clarify that anonymous codegen operations are silently ignored

### DIFF
--- a/.changeset/docs-codegen-anonymous-operations.md
+++ b/.changeset/docs-codegen-anonymous-operations.md
@@ -1,0 +1,8 @@
+---
+'@shopify/api-codegen-preset': patch
+---
+
+Document that anonymous GraphQL operations are silently ignored during type
+generation. Only named queries and mutations produce types; a project
+containing only anonymous operations generates an empty `*.generated.d.ts`
+without an error. (README-only change.)

--- a/packages/api-clients/api-codegen-preset/README.md
+++ b/packages/api-clients/api-codegen-preset/README.md
@@ -332,7 +332,28 @@ pnpm graphql-codegen --project=UIExtensions
 > [!NOTE]
 > Codegen will fail if it can't find any documents to parse.
 > To fix that, either create a query or set the [`ignoreNoDocuments` option](https://the-guild.dev/graphql/codegen/docs/config-reference/codegen-config#configuration-options) to `true`.
-> Queries and mutations must have a name for the parsing to work.
+
+> [!IMPORTANT]
+> Your queries and mutations **must be named** for types to be generated.
+> Anonymous operations (e.g. `query { ... }` with no operation name) are
+> counted as documents, so they won't trigger the "no documents" error above,
+> but they are silently skipped during generation. A project containing only
+> anonymous operations therefore produces an empty `*.generated.d.ts` file with
+> no warning. Give every operation a name to have its types generated:
+>
+> ```ts
+> // Not generated — anonymous operation:
+> `#graphql
+> query {
+>   products(first: 5) { edges { node { id } } }
+> }`;
+>
+> // Generated — named operation:
+> `#graphql
+> query getProducts {
+>   products(first: 5) { edges { node { id } } }
+> }`;
+> ```
 
 Once the script parses your operations, you can mark any operations for parsing by adding the `#graphql` tag to the string.
 For example:


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #1997

`@shopify/api-codegen-preset` only generates types for **named** queries and
mutations. Anonymous operations are counted as documents — so they don't trigger
the "no documents to parse" error — but they're skipped during generation. A
project containing only anonymous operations therefore produces an empty
`*.generated.d.ts` with no error or warning, which is easy to misdiagnose. The
README mentioned operations "must have a name" but didn't explain this
silent-failure behavior.

### WHAT is this pull request doing?

- Expands the note in the README's "Generating types" section to explain that
  anonymous operations are silently skipped (no error, empty output), and adds a
  short named-vs-anonymous example.

No code changes — this is the upstream graphql-codegen behavior; this PR just
documents it.

#### How was this verified?
- README-only change; no new links added (markdown link check unaffected).
- Confirmed against the package's own fixtures, which use only named operations.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue) — documentation fix
- [ ] Minor: New feature
- [ ] Major: Breaking change

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry
- [ ] I have added/updated tests for this change — n/a (docs only)
- [x] I have documented new APIs/updated the documentation for modified APIs
