### PR TITLE
chore: use temp runner for the preview automation workflow

### DIFF
--- a/.github/workflows/shopify-dev-preview-automation.yml
+++ b/.github/workflows/shopify-dev-preview-automation.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   dispatch-docs-sync:
     name: Dispatch docs sync to shopify-dev in the monorepo
-    runs-on: ubuntu-latest
+    runs-on: shopify-docs-ubuntu-latest
     timeout-minutes: 10
     if: github.repository_owner == 'Shopify'
     steps:


### PR DESCRIPTION
We need to temporarily use shopify-docs-ubuntu-latest because ubuntu-latest has been blocked from communicating with shopify-dev. Until we find an alternative.