### PR TITLE
Group simple Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,16 @@
 version: 2
 updates:
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: '/'
     schedule:
       interval: weekly
+    groups:
+      minor-and-patch-updates:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
   # Enable version updates for npm
   - package-ecosystem: 'npm'
     # Look for `package.json` and `lock` files in the `root` directory
@@ -24,7 +31,6 @@ updates:
       semver-patch-days: 14
 
     groups:
-
       # Group together PRs of interdependant packages
       aws-sdk:
         patterns:
@@ -49,12 +55,13 @@ updates:
           - 'react'
           - 'react-dom'
 
-      # Group all patch updates not accounted for in prior groups in a single PR.
+      # Group all non-major production updates not accounted for in prior groups in a single PR.
       # This reduces the number of PRs to review and rebase.
       # We skip development dependencies because those are auto-merged by .github/workflows/dependabot_auto_merge.yml
-      patch-updates:
+      minor-and-patch-updates:
         patterns:
-          - "*"
+          - '*'
         update-types:
-          - "patch"
-        dependency-type: "production"
+          - 'minor'
+          - 'patch'
+        dependency-type: 'production'


### PR DESCRIPTION
## What
- Group GitHub Actions minor and patch updates into one Dependabot PR
- Group npm production minor and patch updates into one Dependabot PR
- Keep major updates separate and preserve existing dev-dependency auto-merge behavior

## Testing
- pnpm exec prettier --check .github/dependabot.yml