### PR TITLE
Don't recompile regex on every call to api.utils.sanitizeShop()

### DIFF
--- a/packages/apps/shopify-api/lib/utils/shop-validator.ts
+++ b/packages/apps/shopify-api/lib/utils/shop-validator.ts
@@ -9,27 +9,28 @@ import {
 } from './domain-transformer';
 
 export function sanitizeShop(config: ConfigInterface) {
+  const domainsRegex = [
+    'myshopify\\.com',
+    'shopify\\.com',
+    'myshopify\\.io',
+    'shop\\.dev',
+  ];
+
+  // Add domains from transformations (both source and target)
+  if (config.domainTransformations) {
+    domainsRegex.push(...getTransformationDomains(config));
+  }
+
+  const shopUrlRegex = new RegExp(
+    `^[a-zA-Z0-9][a-zA-Z0-9-_]*\\.(${domainsRegex.join('|')})[/]*$`,
+  );
+
+  const shopAdminRegex = new RegExp(
+    `^admin\\.(${domainsRegex.join('|')})/store/([a-zA-Z0-9][a-zA-Z0-9-_]*)$`,
+  );
+
   return (shop: string, throwOnInvalid = false): string | null => {
     let shopUrl = shop;
-    const domainsRegex = [
-      'myshopify\\.com',
-      'shopify\\.com',
-      'myshopify\\.io',
-      'shop\\.dev',
-    ];
-
-    // Add domains from transformations (both source and target)
-    if (config.domainTransformations) {
-      domainsRegex.push(...getTransformationDomains(config));
-    }
-
-    const shopUrlRegex = new RegExp(
-      `^[a-zA-Z0-9][a-zA-Z0-9-_]*\\.(${domainsRegex.join('|')})[/]*$`,
-    );
-
-    const shopAdminRegex = new RegExp(
-      `^admin\\.(${domainsRegex.join('|')})/store/([a-zA-Z0-9][a-zA-Z0-9-_]*)$`,
-    );
 
     const isShopAdminUrl = shopAdminRegex.test(shopUrl);
     if (isShopAdminUrl) {


### PR DESCRIPTION
sanitizeShop() recompiled multiple complex regular expressions on each call. Instead move the compilation into the factory function.

<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Don't recompile multiple complex regular expressions on every request.

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

Move the compilation into the factory function.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
