### PR TITLE
set expiring to true in auth callback

### DIFF
--- a/packages/apps/shopify-app-express/src/auth/auth-callback.ts
+++ b/packages/apps/shopify-app-express/src/auth/auth-callback.ts
@@ -23,6 +23,7 @@ export async function authCallback({
     const callbackResponse = await api.auth.callback({
       rawRequest: req,
       rawResponse: res,
+      expiring: true,
     });
 
     config.logger.debug('Callback is valid, storing session', {


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #3234 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

Sets the `expiring` parameter for the access token callback to `true`, since Shopify requires now all access tokens to be expiring.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

It might be breaking to some uses, if you store the token and don't implement refreshing logic, but that would happen anyway on 2027-01-01.

## Checklist

- [ ] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [ ] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)