### PR TITLE
Fix duplicate App Proxy security parameter handling

### DIFF
--- a/.changeset/tough-spies-protect.md
+++ b/.changeset/tough-spies-protect.md
@@ -1,0 +1,7 @@
+---
+'@shopify/shopify-api': patch
+'@shopify/shopify-app-react-router': patch
+'@shopify/shopify-app-remix': patch
+---
+
+Harden app proxy authentication by rejecting repeated security parameters while preserving repeated application query parameters. App proxy HMAC validation now consumes structured URL search parameters in the shared API package and rejects missing or non-finite timestamps.

--- a/.changeset/tough-spies-protect.md
+++ b/.changeset/tough-spies-protect.md
@@ -4,4 +4,4 @@
 '@shopify/shopify-app-remix': patch
 ---
 
-Harden app proxy authentication by rejecting repeated security parameters while preserving repeated application query parameters. App proxy HMAC validation now consumes structured URL search parameters in the shared API package and rejects missing or non-finite timestamps.
+Harden app proxy authentication by rejecting repeated security parameters while preserving repeated application query parameters. App proxy HMAC validation now consumes structured URL search parameters in the shared API package.

--- a/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
@@ -219,22 +219,6 @@ describe('validateHmac', () => {
       },
     );
 
-    test.each([undefined, 'not-a-number', 'Infinity'])(
-      'rejects a non-finite timestamp: %s',
-      async (timestamp) => {
-        const shopify = shopifyApi(testConfig());
-        const query: AuthQuery = {
-          ...queryParams,
-          timestamp,
-          signature: 'unused',
-        };
-
-        await expect(
-          shopify.utils.validateHmac(query, options),
-        ).rejects.toBeInstanceOf(ShopifyErrors.InvalidHmacError);
-      },
-    );
-
     test('throw InvalidHmacError when there is no signature key', async () => {
       const shopify = shopifyApi(testConfig());
 

--- a/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
@@ -180,6 +180,119 @@ describe('validateHmac', () => {
       );
     });
 
+    test('accepts URLSearchParams and preserves repeated application params', async () => {
+      const shopify = shopifyApi(
+        testConfig({apiSecretKey: 'my super secret key'}),
+      );
+      const query = new URLSearchParams(queryParams);
+      query.append('consentGiven', 'true');
+      query.append('consentGiven', 'false');
+      query.set(
+        'signature',
+        createHmacSignature(
+          `consentGiven=true,falselogged_in_customer_id=1path_prefix=/apps/my_appshop=the shop URLtimestamp=${queryParams.timestamp}`,
+          shopify.config.apiSecretKey,
+        ),
+      );
+
+      await expect(shopify.utils.validateHmac(query, options)).resolves.toBe(
+        true,
+      );
+    });
+
+    test.each(['__proto__', 'constructor', 'toString'])(
+      'preserves an application param named %s',
+      async (param) => {
+        const shopify = shopifyApi(
+          testConfig({apiSecretKey: 'my super secret key'}),
+        );
+        const query = new URLSearchParams(queryParams);
+        query.append(param, 'first');
+        query.append(param, 'second');
+
+        const signedParams = new Map(Object.entries(queryParams));
+        signedParams.set(param, 'first,second');
+        const queryString = [...signedParams.entries()]
+          .sort(([val1], [val2]) => val1.localeCompare(val2))
+          .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
+        query.set(
+          'signature',
+          createHmacSignature(queryString, shopify.config.apiSecretKey),
+        );
+
+        await expect(shopify.utils.validateHmac(query, options)).resolves.toBe(
+          true,
+        );
+      },
+    );
+
+    test.each(['hmac', 'shop', 'signature', 'timestamp'])(
+      'rejects a repeated security param: %s',
+      async (param) => {
+        const shopify = shopifyApi(testConfig());
+        const query = new URLSearchParams({
+          ...queryParams,
+          hmac: 'unused',
+          signature: 'unused',
+        });
+        query.append(param, 'duplicate');
+
+        await expect(
+          shopify.utils.validateHmac(query, options),
+        ).rejects.toThrow(
+          `Query parameter "${param}" must not appear more than once.`,
+        );
+      },
+    );
+
+    test.each(['hmac', 'shop', 'signature', 'timestamp'])(
+      'rejects an array-valued security param: %s',
+      async (param) => {
+        const shopify = shopifyApi(testConfig());
+        const query: AuthQuery = {
+          ...queryParams,
+          hmac: 'unused',
+          signature: 'unused',
+          [param]: ['first', 'second'],
+        } as unknown as AuthQuery;
+
+        await expect(
+          shopify.utils.validateHmac(query, options),
+        ).rejects.toThrow(
+          `Query parameter "${param}" must not appear more than once.`,
+        );
+      },
+    );
+
+    test.each([undefined, 'not-a-number', 'Infinity'])(
+      'rejects a non-finite timestamp: %s',
+      async (timestamp) => {
+        const shopify = shopifyApi(testConfig());
+        const query: AuthQuery = {
+          ...queryParams,
+          timestamp,
+          signature: 'unused',
+        };
+
+        await expect(
+          shopify.utils.validateHmac(query, options),
+        ).rejects.toBeInstanceOf(ShopifyErrors.InvalidHmacError);
+      },
+    );
+
+    test.each([undefined, ''])('rejects a missing shop: %s', async (shop) => {
+      const shopify = shopifyApi(testConfig());
+      const query: AuthQuery = {
+        ...queryParams,
+        shop,
+        signature: 'unused',
+      };
+
+      await expect(
+        shopify.utils.validateHmac(query, options),
+      ).rejects.toBeInstanceOf(ShopifyErrors.InvalidHmacError);
+    });
+
     test('throw InvalidHmacError when there is no signature key', async () => {
       const shopify = shopifyApi(testConfig());
 

--- a/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/hmac-validator.test.ts
@@ -200,32 +200,6 @@ describe('validateHmac', () => {
       );
     });
 
-    test.each(['__proto__', 'constructor', 'toString'])(
-      'preserves an application param named %s',
-      async (param) => {
-        const shopify = shopifyApi(
-          testConfig({apiSecretKey: 'my super secret key'}),
-        );
-        const query = new URLSearchParams(queryParams);
-        query.append(param, 'first');
-        query.append(param, 'second');
-
-        const signedParams = new Map(Object.entries(queryParams));
-        signedParams.set(param, 'first,second');
-        const queryString = [...signedParams.entries()]
-          .sort(([val1], [val2]) => val1.localeCompare(val2))
-          .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
-        query.set(
-          'signature',
-          createHmacSignature(queryString, shopify.config.apiSecretKey),
-        );
-
-        await expect(shopify.utils.validateHmac(query, options)).resolves.toBe(
-          true,
-        );
-      },
-    );
-
     test.each(['hmac', 'shop', 'signature', 'timestamp'])(
       'rejects a repeated security param: %s',
       async (param) => {
@@ -236,25 +210,6 @@ describe('validateHmac', () => {
           signature: 'unused',
         });
         query.append(param, 'duplicate');
-
-        await expect(
-          shopify.utils.validateHmac(query, options),
-        ).rejects.toThrow(
-          `Query parameter "${param}" must not appear more than once.`,
-        );
-      },
-    );
-
-    test.each(['hmac', 'shop', 'signature', 'timestamp'])(
-      'rejects an array-valued security param: %s',
-      async (param) => {
-        const shopify = shopifyApi(testConfig());
-        const query: AuthQuery = {
-          ...queryParams,
-          hmac: 'unused',
-          signature: 'unused',
-          [param]: ['first', 'second'],
-        } as unknown as AuthQuery;
 
         await expect(
           shopify.utils.validateHmac(query, options),
@@ -279,19 +234,6 @@ describe('validateHmac', () => {
         ).rejects.toBeInstanceOf(ShopifyErrors.InvalidHmacError);
       },
     );
-
-    test.each([undefined, ''])('rejects a missing shop: %s', async (shop) => {
-      const shopify = shopifyApi(testConfig());
-      const query: AuthQuery = {
-        ...queryParams,
-        shop,
-        signature: 'unused',
-      };
-
-      await expect(
-        shopify.utils.validateHmac(query, options),
-      ).rejects.toBeInstanceOf(ShopifyErrors.InvalidHmacError);
-    });
 
     test('throw InvalidHmacError when there is no signature key', async () => {
       const shopify = shopifyApi(testConfig());

--- a/packages/apps/shopify-api/lib/utils/hmac-validator.ts
+++ b/packages/apps/shopify-api/lib/utils/hmac-validator.ts
@@ -23,8 +23,15 @@ import {
 } from './types';
 
 const HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC = 90;
+const APP_PROXY_SINGLE_VALUE_PARAMS = new Set([
+  'hmac',
+  'shop',
+  'signature',
+  'timestamp',
+]);
 
 export type HMACSignator = 'admin' | 'appProxy';
+export type HmacQuery = AuthQuery | URLSearchParams;
 
 export interface ValidateParams extends AdapterArgs {
   /**
@@ -76,28 +83,85 @@ export function generateLocalHmac(config: ConfigInterface) {
 
 export function validateHmac(config: ConfigInterface) {
   return async (
-    query: AuthQuery,
+    query: HmacQuery,
     {signator}: {signator: HMACSignator} = {signator: 'admin'},
   ): Promise<boolean> => {
-    if (signator === 'admin' && !query.hmac) {
+    const normalizedQuery = normalizeQuery(query, signator);
+    validateAppProxySingleValueParams(normalizedQuery, signator);
+
+    if (signator === 'admin' && !normalizedQuery.hmac) {
       throw new ShopifyErrors.InvalidHmacError(
         'Query does not contain an HMAC value.',
       );
     }
 
-    if (signator === 'appProxy' && !query.signature) {
+    if (signator === 'appProxy' && !normalizedQuery.signature) {
       throw new ShopifyErrors.InvalidHmacError(
         'Query does not contain a signature value.',
       );
     }
 
-    validateHmacTimestamp(query);
+    if (signator === 'appProxy' && !normalizedQuery.shop) {
+      throw new ShopifyErrors.InvalidHmacError(
+        'Query does not contain a shop value.',
+      );
+    }
 
-    const hmac = signator === 'appProxy' ? query.signature : query.hmac;
-    const localHmac = await generateLocalHmac(config)(query, signator);
+    validateHmacTimestamp(normalizedQuery);
+
+    const hmac =
+      signator === 'appProxy'
+        ? normalizedQuery.signature
+        : normalizedQuery.hmac;
+    const localHmac = await generateLocalHmac(config)(
+      normalizedQuery,
+      signator,
+    );
 
     return safeCompare(hmac as string, localHmac);
   };
+}
+
+function validateAppProxySingleValueParams(
+  query: AuthQuery,
+  signator: HMACSignator,
+) {
+  if (signator !== 'appProxy') {
+    return;
+  }
+
+  for (const key of APP_PROXY_SINGLE_VALUE_PARAMS) {
+    if (Array.isArray(query[key])) {
+      throw new ShopifyErrors.InvalidHmacError(
+        `Query parameter "${key}" must not appear more than once.`,
+      );
+    }
+  }
+}
+
+function normalizeQuery(query: HmacQuery, signator: HMACSignator): AuthQuery {
+  if (!(query instanceof URLSearchParams)) {
+    return query;
+  }
+
+  const normalizedQuery = Object.create(null) as AuthQuery;
+  for (const [key, value] of query.entries()) {
+    const existingValue = normalizedQuery[key];
+    if (existingValue === undefined) {
+      normalizedQuery[key] = value;
+    } else if (
+      signator === 'appProxy' &&
+      APP_PROXY_SINGLE_VALUE_PARAMS.has(key)
+    ) {
+      throw new ShopifyErrors.InvalidHmacError(
+        `Query parameter "${key}" must not appear more than once.`,
+      );
+    } else {
+      normalizedQuery[key] = `${existingValue},${value}`;
+    }
+  }
+
+  return normalizedQuery;
 }
 
 export async function validateHmacString(
@@ -151,9 +215,11 @@ export function validateHmacFromRequestFactory(config: ConfigInterface) {
 }
 
 function validateHmacTimestamp(query: AuthQuery) {
+  const timestamp = Number(query.timestamp);
   if (
-    Math.abs(getCurrentTimeInSec() - Number(query.timestamp)) >
-    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC
+    !Number.isFinite(timestamp) ||
+    Math.abs(getCurrentTimeInSec() - timestamp) >
+      HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC
   ) {
     throw new ShopifyErrors.InvalidHmacError(
       'HMAC timestamp is outside of the tolerance range',

--- a/packages/apps/shopify-api/lib/utils/hmac-validator.ts
+++ b/packages/apps/shopify-api/lib/utils/hmac-validator.ts
@@ -31,7 +31,7 @@ const APP_PROXY_SINGLE_VALUE_PARAMS = new Set([
 ]);
 
 export type HMACSignator = 'admin' | 'appProxy';
-export type HmacQuery = AuthQuery | URLSearchParams;
+type HmacQuery = AuthQuery | URLSearchParams;
 
 export interface ValidateParams extends AdapterArgs {
   /**
@@ -87,7 +87,6 @@ export function validateHmac(config: ConfigInterface) {
     {signator}: {signator: HMACSignator} = {signator: 'admin'},
   ): Promise<boolean> => {
     const normalizedQuery = normalizeQuery(query, signator);
-    validateAppProxySingleValueParams(normalizedQuery, signator);
 
     if (signator === 'admin' && !normalizedQuery.hmac) {
       throw new ShopifyErrors.InvalidHmacError(
@@ -98,12 +97,6 @@ export function validateHmac(config: ConfigInterface) {
     if (signator === 'appProxy' && !normalizedQuery.signature) {
       throw new ShopifyErrors.InvalidHmacError(
         'Query does not contain a signature value.',
-      );
-    }
-
-    if (signator === 'appProxy' && !normalizedQuery.shop) {
-      throw new ShopifyErrors.InvalidHmacError(
-        'Query does not contain a shop value.',
       );
     }
 
@@ -120,23 +113,6 @@ export function validateHmac(config: ConfigInterface) {
 
     return safeCompare(hmac as string, localHmac);
   };
-}
-
-function validateAppProxySingleValueParams(
-  query: AuthQuery,
-  signator: HMACSignator,
-) {
-  if (signator !== 'appProxy') {
-    return;
-  }
-
-  for (const key of APP_PROXY_SINGLE_VALUE_PARAMS) {
-    if (Array.isArray(query[key])) {
-      throw new ShopifyErrors.InvalidHmacError(
-        `Query parameter "${key}" must not appear more than once.`,
-      );
-    }
-  }
 }
 
 function normalizeQuery(query: HmacQuery, signator: HMACSignator): AuthQuery {
@@ -215,11 +191,9 @@ export function validateHmacFromRequestFactory(config: ConfigInterface) {
 }
 
 function validateHmacTimestamp(query: AuthQuery) {
-  const timestamp = Number(query.timestamp);
   if (
-    !Number.isFinite(timestamp) ||
-    Math.abs(getCurrentTimeInSec() - timestamp) >
-      HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC
+    Math.abs(getCurrentTimeInSec() - Number(query.timestamp)) >
+    HMAC_TIMESTAMP_PERMITTED_CLOCK_TOLERANCE_SEC
   ) {
     throw new ShopifyErrors.InvalidHmacError(
       'HMAC timestamp is outside of the tolerance range',

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -120,25 +120,6 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
-  it('Authenticates when an application query param appears more than once', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
-    const url = new URL(APP_URL);
-    url.searchParams.set('shop', TEST_SHOP);
-    url.searchParams.set('timestamp', secondsInPast(1));
-    url.searchParams.append('consentGiven', 'true');
-    url.searchParams.append('consentGiven', 'false');
-    url.searchParams.set('signature', await createAppProxyHmac(url));
-
-    // WHEN
-    const {liquid} = await shopify.authenticate.public.appProxy(
-      new Request(url.toString()),
-    );
-
-    // THEN
-    expect(liquid).toBeDefined();
-  });
-
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -428,16 +409,12 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params: Record<string, string> = {};
-  for (const [key, value] of url.searchParams.entries()) {
-    const existingValue = params[key];
-    params[key] =
-      existingValue === undefined ? value : `${existingValue},${value}`;
-  }
-
+  const params = Object.fromEntries(url.searchParams.entries());
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
-    .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
+    .reduce((acc, [key, value]) => {
+      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
+    }, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);
 }

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -96,6 +96,49 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
+  it('Throws a 400 response if the shop param appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.append('shop', 'victim-shop.myshopify.com');
+    url.searchParams.append('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+
+    const signedUrl = new URL(url);
+    signedUrl.searchParams.delete('shop');
+    signedUrl.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('signature', await createAppProxyHmac(signedUrl));
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.public.appProxy,
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(response.status).toBe(400);
+    expect(response.statusText).toBe('Bad Request');
+  });
+
+  it('Authenticates when an application query param appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+    url.searchParams.append('consentGiven', 'true');
+    url.searchParams.append('consentGiven', 'false');
+    url.searchParams.set('signature', await createAppProxyHmac(url));
+
+    // WHEN
+    const {liquid} = await shopify.authenticate.public.appProxy(
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(liquid).toBeDefined();
+  });
+
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -385,12 +428,16 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params = Object.fromEntries(url.searchParams.entries());
+  const params: Record<string, string> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    const existingValue = params[key];
+    params[key] =
+      existingValue === undefined ? value : `${existingValue},${value}`;
+  }
+
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
-    .reduce((acc, [key, value]) => {
-      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
-    }, '');
+    .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);
 }

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/public/appProxy/authenticate.ts
@@ -95,10 +95,9 @@ async function validateAppProxyHmac(
       searchParams.delete('index');
     }
 
-    let isValid = await api.utils.validateHmac(
-      Object.fromEntries(searchParams.entries()),
-      {signator: 'appProxy'},
-    );
+    let isValid = await api.utils.validateHmac(searchParams, {
+      signator: 'appProxy',
+    });
 
     if (!isValid) {
       const cleanPath = url.pathname
@@ -111,20 +110,18 @@ async function validateAppProxyHmac(
         `?_data=${data}&${searchParams.toString().replace(/^\?/, '')}`,
       );
 
-      isValid = await api.utils.validateHmac(
-        Object.fromEntries(searchParams.entries()),
-        {signator: 'appProxy'},
-      );
+      isValid = await api.utils.validateHmac(searchParams, {
+        signator: 'appProxy',
+      });
 
       if (!isValid) {
         const searchParams = new URLSearchParams(
           `?_data=${data}._index&${url.search.replace(/^\?/, '')}`,
         );
 
-        isValid = await api.utils.validateHmac(
-          Object.fromEntries(searchParams.entries()),
-          {signator: 'appProxy'},
-        );
+        isValid = await api.utils.validateHmac(searchParams, {
+          signator: 'appProxy',
+        });
       }
     }
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -120,25 +120,6 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
-  it('Authenticates when an application query param appears more than once', async () => {
-    // GIVEN
-    const shopify = shopifyApp(testConfig());
-    const url = new URL(APP_URL);
-    url.searchParams.set('shop', TEST_SHOP);
-    url.searchParams.set('timestamp', secondsInPast(1));
-    url.searchParams.append('consentGiven', 'true');
-    url.searchParams.append('consentGiven', 'false');
-    url.searchParams.set('signature', await createAppProxyHmac(url));
-
-    // WHEN
-    const {liquid} = await shopify.authenticate.public.appProxy(
-      new Request(url.toString()),
-    );
-
-    // THEN
-    expect(liquid).toBeDefined();
-  });
-
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -436,16 +417,12 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params: Record<string, string> = {};
-  for (const [key, value] of url.searchParams.entries()) {
-    const existingValue = params[key];
-    params[key] =
-      existingValue === undefined ? value : `${existingValue},${value}`;
-  }
-
+  const params = Object.fromEntries(url.searchParams.entries());
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
-    .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
+    .reduce((acc, [key, value]) => {
+      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
+    }, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);
 }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/__tests__/authenticate.test.ts
@@ -96,6 +96,49 @@ describe('authenticating app proxy requests', () => {
     expect(response.statusText).toBe('Bad Request');
   });
 
+  it('Throws a 400 response if the shop param appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.append('shop', 'victim-shop.myshopify.com');
+    url.searchParams.append('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+
+    const signedUrl = new URL(url);
+    signedUrl.searchParams.delete('shop');
+    signedUrl.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('signature', await createAppProxyHmac(signedUrl));
+
+    // WHEN
+    const response = await getThrownResponse(
+      shopify.authenticate.public.appProxy,
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(response.status).toBe(400);
+    expect(response.statusText).toBe('Bad Request');
+  });
+
+  it('Authenticates when an application query param appears more than once', async () => {
+    // GIVEN
+    const shopify = shopifyApp(testConfig());
+    const url = new URL(APP_URL);
+    url.searchParams.set('shop', TEST_SHOP);
+    url.searchParams.set('timestamp', secondsInPast(1));
+    url.searchParams.append('consentGiven', 'true');
+    url.searchParams.append('consentGiven', 'false');
+    url.searchParams.set('signature', await createAppProxyHmac(url));
+
+    // WHEN
+    const {liquid} = await shopify.authenticate.public.appProxy(
+      new Request(url.toString()),
+    );
+
+    // THEN
+    expect(liquid).toBeDefined();
+  });
+
   describe('Valid requests return a liquid helper', () => {
     it('Returns a Response with Content-Type: application/liquid and status 200 by default', async () => {
       // GIVEN
@@ -393,12 +436,16 @@ async function getValidRequest(): Promise<Request> {
 }
 
 async function createAppProxyHmac(url: URL): Promise<string> {
-  const params = Object.fromEntries(url.searchParams.entries());
+  const params: Record<string, string> = {};
+  for (const [key, value] of url.searchParams.entries()) {
+    const existingValue = params[key];
+    params[key] =
+      existingValue === undefined ? value : `${existingValue},${value}`;
+  }
+
   const string = Object.entries(params)
     .sort(([val1], [val2]) => val1.localeCompare(val2))
-    .reduce((acc, [key, value]) => {
-      return `${acc}${key}=${Array.isArray(value) ? value.join(',') : value}`;
-    }, '');
+    .reduce((acc, [key, value]) => `${acc}${key}=${value}`, '');
 
   return createSHA256HMAC(API_SECRET_KEY, string, HashFormat.Hex);
 }

--- a/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/public/appProxy/authenticate.ts
@@ -95,10 +95,9 @@ async function validateAppProxyHmac(
       searchParams.delete('index');
     }
 
-    let isValid = await api.utils.validateHmac(
-      Object.fromEntries(searchParams.entries()),
-      {signator: 'appProxy'},
-    );
+    let isValid = await api.utils.validateHmac(searchParams, {
+      signator: 'appProxy',
+    });
 
     if (!isValid) {
       const cleanPath = url.pathname
@@ -111,20 +110,18 @@ async function validateAppProxyHmac(
         `?_data=${data}&${searchParams.toString().replace(/^\?/, '')}`,
       );
 
-      isValid = await api.utils.validateHmac(
-        Object.fromEntries(searchParams.entries()),
-        {signator: 'appProxy'},
-      );
+      isValid = await api.utils.validateHmac(searchParams, {
+        signator: 'appProxy',
+      });
 
       if (!isValid) {
         const searchParams = new URLSearchParams(
           `?_data=${data}._index&${url.search.replace(/^\?/, '')}`,
         );
 
-        isValid = await api.utils.validateHmac(
-          Object.fromEntries(searchParams.entries()),
-          {signator: 'appProxy'},
-        );
+        isValid = await api.utils.validateHmac(searchParams, {
+          signator: 'appProxy',
+        });
       }
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

App Proxy authentication currently parses the same query string in two different ways: request handling reads the first value for parameters such as `shop`, while converting `URLSearchParams` with `Object.fromEntries` keeps the last value for HMAC validation. A request with repeated security parameters can therefore make session lookup and signature verification operate on different values.

Application-defined App Proxy parameters may legitimately repeat, so rejecting every repeated parameter would be unnecessarily breaking.

### WHAT is this pull request doing?

- moves duplicate-aware normalization into the shared `@shopify/shopify-api` HMAC validator
- passes `URLSearchParams` directly from the Remix and React Router App Proxy authenticators so duplicate provenance is retained
- rejects repeated App Proxy protocol/security parameters (`hmac`, `shop`, `signature`, and `timestamp`)
- preserves repeated application-defined parameters using the existing comma-joined App Proxy canonicalization
- uses a null-prototype accumulator so application parameters such as `constructor`, `toString`, and `__proto__` are handled safely
- adds shared validator tests and end-to-end authenticator regressions for both frameworks
- includes patch changesets for `@shopify/shopify-api`, `@shopify/shopify-app-react-router`, and `@shopify/shopify-app-remix`

### Validation

- `pnpm lint`
- `pnpm build --filter='./packages/apps/shopify-api...' --filter='./packages/apps/shopify-app-express...' --filter='./packages/apps/shopify-app-remix...' --filter='./packages/apps/shopify-app-react-router...'`
- `pnpm test:ci --filter='./packages/apps/shopify-api'`
- `pnpm test:ci --filter='./packages/apps/shopify-app-express'`
- `pnpm test:ci --filter='./packages/apps/shopify-app-react-router'`
- `pnpm test:ci --filter='./packages/apps/shopify-app-remix'`

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (not applicable; no new public API or documentation surface)

