### PR TITLE
chore: decouple Prettier from the linter (1/3 of #3058)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Run linting
         run: pnpm lint
 
+      - name: Check formatting
+        run: pnpm prettier
+
   # Test API Client packages
   test-api-clients:
     name: Test_ApiClients_Node_${{ matrix.version }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,5 +2,12 @@
 coverage
 
 packages/apps/shopify-app-remix/docs/**/*.json
-packages/apps/shopify-app-remix/**/*.example.tsx?
+packages/apps/shopify-app-remix/**/*.example.ts
+packages/apps/shopify-app-remix/**/*.example.tsx
+packages/apps/shopify-app-remix/**/*.example.*.ts
+packages/apps/shopify-app-remix/**/*.example.*.tsx
+packages/apps/shopify-app-react-router/**/*.example.ts
+packages/apps/shopify-app-react-router/**/*.example.tsx
+packages/apps/shopify-app-react-router/**/*.example.*.ts
+packages/apps/shopify-app-react-router/**/*.example.*.tsx
 packages/apps/shopify-api/rest/admin

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test:ci": "CI=true turbo run test:ci --filter='!./packages/apps/session-storage/*'",
     "test:ci_sessions": "CI=true turbo run test",
     "lint": "ESLINT_USE_FLAT_CONFIG=true CI=true turbo lint",
+    "prettier": "prettier --check \"**/*.{ts,tsx}\"",
+    "prettier:fix": "prettier --write \"**/*.{ts,tsx}\"",
     "release": "turbo build && changeset publish",
     "dev": "turbo dev --no-cache --continue",
     "clean": "turbo clean",


### PR DESCRIPTION
First of three PRs splitting up #3058 (which is now in draft).

## What this does
Enforces Prettier independently of the linter, so the upcoming ESLint to Oxlint swap does not silently drop formatting checks.

- Adds `prettier` and `prettier:fix` scripts, scoped to TS source (`**/*.{ts,tsx}`), which is the same scope the eslint-plugin-prettier check already covered.
- Runs `pnpm prettier` as a `Check formatting` step in the CI Lint job.
- Adds the `*.example.*` doc files to `.prettierignore`.

ESLint is untouched here and still runs, so formatting is currently enforced in two places. That is intentional: PR 3 removes ESLint, and this standalone check keeps Prettier enforced after it is gone.

## Scope note
The check covers `**/*.{ts,tsx}` only. `.js`, `.md`, `.json`, and `.yml` are not checked, which matches the previous eslint-based behavior, so no regression.

## Note
Branch is behind main and needs a branch update before merge.

## Follow-ups
- 2/3: #3346 (code cleanups)
- 3/3: #3347 (ESLint to Oxlint swap)