### PR TITLE
fix: log actual shop in 'Authenticating admin request' (fixes #2916)

### DIFF
--- a/.changeset/fix-null-shop-in-admin-auth-log.md
+++ b/.changeset/fix-null-shop-in-admin-auth-log.md
@@ -1,0 +1,6 @@
+---
+'@shopify/shopify-app-remix': patch
+'@shopify/shopify-app-react-router': patch
+---
+
+Fix 'Authenticating admin request' info log always showing null for shop. The shop is now logged after it is extracted from the session token context, so it reflects the actual shop value instead of null.

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
@@ -1,3 +1,5 @@
+import {LogSeverity} from '@shopify/shopify-api';
+
 import {shopifyApp} from '../../..';
 import {
   APP_URL,
@@ -55,4 +57,31 @@ describe('authorize.session token header path', () => {
       });
     },
   );
+
+  describe('logging', () => {
+    it('logs the shop from the session token instead of null', async () => {
+      // GIVEN
+      const logFn = jest.fn();
+      const shopify = shopifyApp(
+        testConfig({logger: {log: logFn, level: LogSeverity.Debug}}),
+      );
+      await setUpValidSession(shopify.sessionStorage);
+
+      // WHEN
+      const {token} = await getJwt();
+      await shopify.authenticate.admin(
+        new Request(APP_URL, {
+          headers: {Authorization: `Bearer ${token}`},
+        }),
+      );
+
+      // THEN
+      expect(logFn).toHaveBeenCalledWith(
+        LogSeverity.Info,
+        expect.stringContaining(
+          `Authenticating admin request | {shop: ${TEST_SHOP}}`,
+        ),
+      );
+    });
+  });
 });

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/authenticate.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/authenticate.ts
@@ -156,12 +156,10 @@ export function authStrategyFactory<ConfigArg extends AppConfigArg>({
         await ensureSessionTokenSearchParamIfRequired(params, request);
       }
 
-      logger.info('Authenticating admin request', {
-        shop: getShopFromRequest(request),
-      });
-
       const {payload, shop, sessionId, sessionToken} =
         await getSessionTokenContext(params, request);
+
+      logger.info('Authenticating admin request', {shop});
 
       logger.debug('Loading session from storage', {shop, sessionId});
       const existingSession = sessionId

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/__tests__/session-token-header-path.test.ts
@@ -1,4 +1,4 @@
-import {SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
+import {LogSeverity, SESSION_COOKIE_NAME, Session} from '@shopify/shopify-api';
 
 import {shopifyApp} from '../../..';
 import {
@@ -85,4 +85,31 @@ describe('authorize.session token header path', () => {
       });
     },
   );
+
+  describe('logging', () => {
+    it('logs the shop from the session token instead of null', async () => {
+      // GIVEN
+      const logFn = jest.fn();
+      const shopify = shopifyApp(
+        testConfig({logger: {log: logFn, level: LogSeverity.Debug}}),
+      );
+      await setUpValidSession(shopify.sessionStorage);
+
+      // WHEN
+      const {token} = await getJwt();
+      await shopify.authenticate.admin(
+        new Request(APP_URL, {
+          headers: {Authorization: `Bearer ${token}`},
+        }),
+      );
+
+      // THEN
+      expect(logFn).toHaveBeenCalledWith(
+        LogSeverity.Info,
+        expect.stringContaining(
+          `Authenticating admin request | {shop: ${TEST_SHOP}}`,
+        ),
+      );
+    });
+  });
 });

--- a/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/admin/authenticate.ts
@@ -156,12 +156,10 @@ export function authStrategyFactory<ConfigArg extends AppConfigArg>({
         await ensureSessionTokenSearchParamIfRequired(params, request);
       }
 
-      logger.info('Authenticating admin request', {
-        shop: getShopFromRequest(request),
-      });
-
       const {payload, shop, sessionId, sessionToken} =
         await getSessionTokenContext(params, request);
+
+      logger.info('Authenticating admin request', {shop});
 
       logger.debug('Loading session from storage', {shop, sessionId});
       const existingSession = sessionId


### PR DESCRIPTION
## Why
The `info` log at the start of `authenticateAdmin` called `getShopFromRequest(request)`, which reads the `shop` query param. For token-exchange / embedded requests the shop lives in the JWT, not the URL, so the log always emitted `shop: null`. Fixes #2916.

## What
- Move `logger.info('Authenticating admin request', {shop})` to **after** `getSessionTokenContext` resolves, so it logs the shop extracted from the session token.
- Ports the fix to **both** `@shopify/shopify-app-remix` **and** `@shopify/shopify-app-react-router` (the latter had the identical bug at the same line and is the package new apps use).
- Adds a regression test in each package asserting the logged shop value (verified it fails with `{shop: null}` on the current code and passes with the fix).

## Supersedes / relationship
Supersedes #3159 (which only touched remix and never ran the test matrix because it was opened by `github-actions[bot]`). This branch is pushed from a human account so CI runs.

## Behaviour tradeoff (please confirm)
Moving the log means a request that throws inside `getSessionTokenContext` (e.g. a token-exchange bounce) no longer emits this specific info line. The earlier `debug` 'Attempting to authenticate session token' and the failure-path logs still fire, so observability loss is limited to the info-level line. Alternative would be to keep the log first and just drop the misleading `shop` key. Flagging so a reviewer picks deliberately.