### PR TITLE
feat(express): Add token exchange auth strategy

### DIFF
--- a/.changeset/express-token-exchange.md
+++ b/.changeset/express-token-exchange.md
@@ -2,8 +2,38 @@
 '@shopify/shopify-app-express': minor
 ---
 
-Add token exchange authentication support for embedded apps, behind the `unstable_tokenExchange` future flag. When enabled, embedded apps fetch access tokens via token exchange (no OAuth redirect flicker) instead of the auth code flow. Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+Add token exchange authentication support for embedded apps, behind the `tokenExchange` future flag.
 
-Also adds a `hooks.afterAuth` config option and a `shopify.registerWebhooks({session})` helper for registering webhooks outside the OAuth callback.
+When enabled, embedded apps get access tokens via [token exchange](https://github.com/Shopify/shopify-app-js/blob/main/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md) instead of the OAuth redirect flow: on load, App Bridge provides a short-lived session token that the app exchanges with Shopify for an API access token. This removes the redirect flicker the Auth Code flow causes on load. Non-embedded apps, and apps with the flag off, continue to use the Auth Code flow. (Auth Code flow and token exchange are both OAuth flows.)
 
-This builds on the original work by @mrmarufpro in #3097. Thank you for contributing this.
+**Requirements:** the app must be embedded (`isEmbeddedApp: true`), use [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation), and load [App Bridge](https://shopify.dev/docs/api/app-bridge-library) on the frontend. Enabling the flag on a non-embedded app throws at startup.
+
+**Enabling it:**
+
+```diff
+  const shopify = shopifyApp({
+    api: {/* ... */},
+    auth: {path: '/api/auth', callbackPath: '/api/auth/callback'},
+    webhooks: {path: '/api/webhooks'},
++   future: {
++     tokenExchange: true,
++   },
++   hooks: {
++     afterAuth: async ({session}) => {
++       await shopify.registerWebhooks({session});
++     },
++   },
+  });
+```
+
+**What changes when enabled:**
+
+- `validateAuthenticatedSession` uses token exchange for embedded apps (decided once, up front: token exchange when the flag is on and the app is embedded, otherwise the Auth Code flow).
+- Fetch requests with a missing or stale session token get a `401` with the `X-Shopify-Retry-Invalid-Session-Request` header, so App Bridge fetches a fresh token and retries.
+- Document requests with a missing or stale session token render App Bridge, which fetches a fresh token and reloads. No top-level OAuth redirect.
+- The OAuth routes (`auth.begin` / `auth.callback`) are not used and return an error if called.
+- Revoked (but unexpired) tokens are not re-authenticated automatically. Handle a `401` from the Admin API by retrying the request (which triggers a fresh exchange) or re-authenticating. Expired tokens are handled automatically.
+
+This also adds a `hooks.afterAuth` config option and a `shopify.registerWebhooks({session})` helper for registering webhooks outside the OAuth callback.
+
+Builds on the original work by [@mrmarufpro](https://github.com/mrmarufpro) in [#3097](https://github.com/Shopify/shopify-app-js/pull/3097). Thank you for contributing this.

--- a/.changeset/express-token-exchange.md
+++ b/.changeset/express-token-exchange.md
@@ -1,0 +1,9 @@
+---
+'@shopify/shopify-app-express': minor
+---
+
+Add token exchange authentication support for embedded apps, behind the `unstable_tokenExchange` future flag. When enabled, embedded apps fetch access tokens via token exchange (no OAuth redirect flicker) instead of the auth code flow. Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+
+Also adds a `hooks.afterAuth` config option and a `shopify.registerWebhooks({session})` helper for registering webhooks outside the OAuth callback.
+
+This builds on the original work by @mrmarufpro in #3097. Thank you for contributing this.

--- a/packages/apps/shopify-app-express/docs/reference/ensureInstalledOnShop.md
+++ b/packages/apps/shopify-app-express/docs/reference/ensureInstalledOnShop.md
@@ -5,7 +5,7 @@ This function creates an Express middleware that ensures any request to that end
 You don't need to use it if your app is not embedded, because you can use `validateAuthenticatedSession` on any non-embedded request.
 If you call this middleware on a non-embedded app, it will behave like `validateAuthenticatedSession` instead.
 
-When the [`unstable_tokenExchange`](./guides/token-exchange.md) future flag is enabled, this middleware does not check session storage to decide whether the app is installed (under managed installation a shop may have no stored session until its first token exchange). It embeds the app if needed and loads it; the first authenticated request then mints the session via token exchange.
+When the [`tokenExchange`](./guides/token-exchange.md) future flag is enabled, this middleware does not check session storage to decide whether the app is installed (under managed installation a shop may have no stored session until its first token exchange). It embeds the app if needed and loads it; the first authenticated request then mints the session via token exchange.
 
 ## Example
 

--- a/packages/apps/shopify-app-express/docs/reference/ensureInstalledOnShop.md
+++ b/packages/apps/shopify-app-express/docs/reference/ensureInstalledOnShop.md
@@ -5,6 +5,8 @@ This function creates an Express middleware that ensures any request to that end
 You don't need to use it if your app is not embedded, because you can use `validateAuthenticatedSession` on any non-embedded request.
 If you call this middleware on a non-embedded app, it will behave like `validateAuthenticatedSession` instead.
 
+When the [`unstable_tokenExchange`](./guides/token-exchange.md) future flag is enabled, this middleware does not check session storage to decide whether the app is installed (under managed installation a shop may have no stored session until its first token exchange). It embeds the app if needed and loads it; the first authenticated request then mints the session via token exchange.
+
 ## Example
 
 ```ts

--- a/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
+++ b/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
@@ -1,8 +1,8 @@
 # Token exchange
 
-Token exchange lets embedded apps get access tokens without the OAuth redirect flow. When an embedded app loads, App Bridge provides a short-lived session token; the app exchanges that token with Shopify for an API access token. This removes the redirect flicker that the OAuth code flow causes on load.
+Token exchange lets embedded apps get access tokens without the OAuth redirect flow. When an embedded app loads, App Bridge provides a short-lived session token; the app exchanges that token with Shopify for an API access token. This removes the redirect flicker that the Auth Code flow causes on load.
 
-Support is behind the `unstable_tokenExchange` future flag and is off by default.
+Support is behind the `tokenExchange` future flag and is off by default.
 
 ## Requirements
 
@@ -10,7 +10,7 @@ Support is behind the `unstable_tokenExchange` future flag and is off by default
 - The app must use [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation).
 - The frontend must load [App Bridge](https://shopify.dev/docs/api/app-bridge-library), which provides the session token.
 
-Non-embedded apps with the flag off continue to use the OAuth code flow. Enabling the flag on a non-embedded app (`isEmbeddedApp: false`) throws at startup, because token exchange requires the App Bridge session token that only embedded apps have.
+Non-embedded apps with the flag off continue to use the Auth Code flow. Enabling the flag on a non-embedded app (`isEmbeddedApp: false`) throws at startup, because token exchange requires the App Bridge session token that only embedded apps have.
 
 ## Enabling it
 
@@ -24,7 +24,7 @@ const shopify = shopifyApp({
   auth: {path: '/api/auth', callbackPath: '/api/auth/callback'},
   webhooks: {path: '/api/webhooks'},
   future: {
-    unstable_tokenExchange: true,
+    tokenExchange: true,
   },
   hooks: {
     afterAuth: async ({session}) => {
@@ -36,7 +36,7 @@ const shopify = shopifyApp({
 
 ## What changes when it is enabled
 
-- `validateAuthenticatedSession` uses token exchange for embedded apps. It decides once, up front: token exchange when the flag is on and the app is embedded, otherwise the OAuth code flow.
+- `validateAuthenticatedSession` uses token exchange for embedded apps. It decides once, up front: token exchange when the flag is on and the app is embedded, otherwise the Auth Code flow.
 - **Fetch requests** with a missing or stale session token receive a `401` with the `X-Shopify-Retry-Invalid-Session-Request` header, so App Bridge fetches a fresh token and retries.
 - **Document requests** (page loads) with a missing or stale session token render App Bridge, which fetches a fresh token and reloads the page. No top-level OAuth redirect.
 - The OAuth routes (`auth.begin` / `auth.callback`) are not used and return an error if called.
@@ -47,4 +47,4 @@ Token exchange reuses a stored access token while it is unexpired. If a token is
 
 ## Webhooks
 
-The OAuth code flow registers webhooks in its callback. Token exchange has no such callback, so register webhooks yourself with `shopify.registerWebhooks({session})`, typically from the `afterAuth` hook (see the example above).
+The Auth Code flow registers webhooks in its callback. Token exchange has no such callback, so register webhooks yourself with `shopify.registerWebhooks({session})`, typically from the `afterAuth` hook (see the example above).

--- a/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
+++ b/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
@@ -1,0 +1,46 @@
+# Token exchange
+
+Token exchange lets embedded apps get access tokens without the OAuth redirect flow. When an embedded app loads, App Bridge provides a short-lived session token; the app exchanges that token with Shopify for an API access token. This removes the redirect flicker that the OAuth code flow causes on load.
+
+Support is behind the `unstable_tokenExchange` future flag and is off by default.
+
+## Requirements
+
+- The app must be **embedded** (`isEmbeddedApp: true`, the default).
+- The app must use [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation).
+- The frontend must load [App Bridge](https://shopify.dev/docs/api/app-bridge-library), which provides the session token.
+
+Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+
+## Enabling it
+
+```ts
+import {shopifyApp} from '@shopify/shopify-app-express';
+
+const shopify = shopifyApp({
+  api: {
+    /* ... */
+  },
+  auth: {path: '/api/auth', callbackPath: '/api/auth/callback'},
+  webhooks: {path: '/api/webhooks'},
+  future: {
+    unstable_tokenExchange: true,
+  },
+  hooks: {
+    afterAuth: async ({session}) => {
+      await shopify.registerWebhooks({session});
+    },
+  },
+});
+```
+
+## What changes when it is enabled
+
+- `validateAuthenticatedSession` uses token exchange for embedded apps. It decides once, up front: token exchange when the flag is on and the app is embedded, otherwise the OAuth code flow.
+- **Fetch requests** with a missing or stale session token receive a `401` with the `X-Shopify-Retry-Invalid-Session-Request` header, so App Bridge fetches a fresh token and retries.
+- **Document requests** (page loads) with a missing or stale session token render App Bridge, which fetches a fresh token and reloads the page. No top-level OAuth redirect.
+- The OAuth routes (`auth.begin` / `auth.callback`) are not used and return an error if called.
+
+## Webhooks
+
+The OAuth code flow registers webhooks in its callback. Token exchange has no such callback, so register webhooks yourself with `shopify.registerWebhooks({session})`, typically from the `afterAuth` hook (see the example above).

--- a/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
+++ b/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
@@ -41,6 +41,10 @@ const shopify = shopifyApp({
 - **Document requests** (page loads) with a missing or stale session token render App Bridge, which fetches a fresh token and reloads the page. No top-level OAuth redirect.
 - The OAuth routes (`auth.begin` / `auth.callback`) are not used and return an error if called.
 
+## Handling revoked access tokens
+
+Token exchange reuses a stored access token while it is unexpired. If a token is **revoked** by the merchant before it expires, it still looks valid locally, so the library will use it and the Admin API call will fail with a `401`. The library does not automatically re-authenticate in that case, so your app should handle a `401` from the Admin API by re-running the request (which triggers a fresh token exchange) or re-authenticating. Expired tokens are handled automatically.
+
 ## Webhooks
 
 The OAuth code flow registers webhooks in its callback. Token exchange has no such callback, so register webhooks yourself with `shopify.registerWebhooks({session})`, typically from the `afterAuth` hook (see the example above).

--- a/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
+++ b/packages/apps/shopify-app-express/docs/reference/guides/token-exchange.md
@@ -10,7 +10,7 @@ Support is behind the `unstable_tokenExchange` future flag and is off by default
 - The app must use [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation).
 - The frontend must load [App Bridge](https://shopify.dev/docs/api/app-bridge-library), which provides the session token.
 
-Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+Non-embedded apps with the flag off continue to use the OAuth code flow. Enabling the flag on a non-embedded app (`isEmbeddedApp: false`) throws at startup, because token exchange requires the App Bridge session token that only embedded apps have.
 
 ## Enabling it
 

--- a/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
+++ b/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
@@ -69,6 +69,32 @@ When enabled, the app requests an expiring offline access token during OAuth and
 
 Your session storage must persist the `refreshToken` and `refreshTokenExpires` fields for this to work.
 
+#### token exchange
+
+`future: {unstable_tokenExchange: true}` | Defaults to `false`
+
+When enabled, embedded apps fetch access tokens via [token exchange](./guides/token-exchange.md) instead of the OAuth redirect flow, which removes the redirect flicker on load. Requires an embedded app (`isEmbeddedApp`) using [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation). Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+
+When token exchange is active, the OAuth routes (`auth.begin` / `auth.callback`) are not used and will return an error if called. Because there is no OAuth callback to register webhooks, use [`registerWebhooks`](#registerwebhooks) (typically from the `afterAuth` hook).
+
+### hooks
+
+`{afterAuth?: (options: {session: Session}) => void | Promise<void>}`
+
+Callbacks that run at points in the authentication lifecycle.
+
+#### afterAuth
+
+Runs after authentication completes (both token exchange and the OAuth callback), with the resulting session. A common use is registering webhooks:
+
+```ts
+hooks: {
+  afterAuth: async ({session}) => {
+    await shopify.registerWebhooks({session});
+  },
+},
+```
+
 ## Return
 
 Returns an object that contains everything an app needs to interact with Shopify:
@@ -127,6 +153,12 @@ A function that redirects to any URL at the browser's top level, regardless of w
 `(shop: string) => Promise<Session | undefined>`
 
 Loads the offline session for a shop and, when the `expiringOfflineAccessTokens` future flag is enabled, refreshes its access token if it is expired or close to expiring. Returns `undefined` when no offline session is stored. Use this from background work (webhooks, cron jobs, queues) that needs a valid offline token. Callers should trigger re-authentication if the refresh token has been revoked.
+
+### registerWebhooks
+
+`(params: {session: Session}) => Promise<void>`
+
+Registers the app's webhook subscriptions for a shop. When using token exchange there is no OAuth callback to register webhooks, so call this yourself, usually from the `afterAuth` hook.
 
 ## Example
 

--- a/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
+++ b/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
@@ -75,6 +75,8 @@ Your session storage must persist the `refreshToken` and `refreshTokenExpires` f
 
 When enabled, embedded apps fetch access tokens via [token exchange](./guides/token-exchange.md) instead of the OAuth redirect flow, which removes the redirect flicker on load. Requires an embedded app (`isEmbeddedApp`) using [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation). Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
 
+Token exchange is only available for embedded apps. Enabling this flag with `isEmbeddedApp: false` throws at startup, since a non-embedded app cannot obtain the App Bridge session token that token exchange relies on.
+
 When token exchange is active, the OAuth routes (`auth.begin` / `auth.callback`) are not used and will return an error if called. Because there is no OAuth callback to register webhooks, use [`registerWebhooks`](#registerwebhooks) (typically from the `afterAuth` hook).
 
 ### hooks

--- a/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
+++ b/packages/apps/shopify-app-express/docs/reference/shopifyApp.md
@@ -71,9 +71,9 @@ Your session storage must persist the `refreshToken` and `refreshTokenExpires` f
 
 #### token exchange
 
-`future: {unstable_tokenExchange: true}` | Defaults to `false`
+`future: {tokenExchange: true}` | Defaults to `false`
 
-When enabled, embedded apps fetch access tokens via [token exchange](./guides/token-exchange.md) instead of the OAuth redirect flow, which removes the redirect flicker on load. Requires an embedded app (`isEmbeddedApp`) using [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation). Non-embedded apps, and apps with the flag off, continue to use the OAuth code flow.
+When enabled, embedded apps fetch access tokens via [token exchange](./guides/token-exchange.md) instead of the OAuth redirect flow, which removes the redirect flicker on load. Requires an embedded app (`isEmbeddedApp`) using [Shopify managed installation](https://shopify.dev/docs/apps/auth/installation). Non-embedded apps, and apps with the flag off, continue to use the Auth Code flow.
 
 Token exchange is only available for embedded apps. Enabling this flag with `isEmbeddedApp: false` throws at startup, since a non-embedded app cannot obtain the App Bridge session token that token exchange relies on.
 

--- a/packages/apps/shopify-app-express/docs/reference/validateAuthenticatedSession.md
+++ b/packages/apps/shopify-app-express/docs/reference/validateAuthenticatedSession.md
@@ -9,6 +9,8 @@ If the verification fails in either case, it will redirect the user to complete 
 - When not embedded, it will verify that the request contains a valid session cookie set up during the OAuth process.
   - XHR requests will return a `403 Forbidden` response with the `X-Shopify-Api-Request-Failure-Reauthorize-Url` header indicating where to redirect the user for authentication.
 
+When the [`unstable_tokenExchange`](./guides/token-exchange.md) future flag is enabled and the app is embedded, this middleware uses token exchange instead of the OAuth code flow: it exchanges the request's session token for an access token, rendering App Bridge on document requests or returning a `401` with a retry header on fetch requests when the token is missing or stale.
+
 Please visit [our documentation](https://shopify.dev/docs/apps/auth/oauth/session-tokens) to learn more about session tokens and how they work.
 
 ## Example

--- a/packages/apps/shopify-app-express/docs/reference/validateAuthenticatedSession.md
+++ b/packages/apps/shopify-app-express/docs/reference/validateAuthenticatedSession.md
@@ -9,7 +9,7 @@ If the verification fails in either case, it will redirect the user to complete 
 - When not embedded, it will verify that the request contains a valid session cookie set up during the OAuth process.
   - XHR requests will return a `403 Forbidden` response with the `X-Shopify-Api-Request-Failure-Reauthorize-Url` header indicating where to redirect the user for authentication.
 
-When the [`unstable_tokenExchange`](./guides/token-exchange.md) future flag is enabled and the app is embedded, this middleware uses token exchange instead of the OAuth code flow: it exchanges the request's session token for an access token, rendering App Bridge on document requests or returning a `401` with a retry header on fetch requests when the token is missing or stale.
+When the [`tokenExchange`](./guides/token-exchange.md) future flag is enabled and the app is embedded, this middleware uses token exchange instead of the Auth Code flow: it exchanges the request's session token for an access token, rendering App Bridge on document requests or returning a `401` with a retry header on fetch requests when the token is missing or stale.
 
 Please visit [our documentation](https://shopify.dev/docs/apps/auth/oauth/session-tokens) to learn more about session tokens and how they work.
 

--- a/packages/apps/shopify-app-express/src/__tests__/index.test.ts
+++ b/packages/apps/shopify-app-express/src/__tests__/index.test.ts
@@ -41,7 +41,7 @@ describe('shopifyApp', () => {
       shopifyApp({
         ...testConfig,
         api: {...testConfig.api, isEmbeddedApp: false},
-        future: {unstable_tokenExchange: true},
+        future: {tokenExchange: true},
       }),
     ).toThrow(ShopifyError);
   });
@@ -51,7 +51,7 @@ describe('shopifyApp', () => {
       shopifyApp({
         ...testConfig,
         api: {...testConfig.api, isEmbeddedApp: true},
-        future: {unstable_tokenExchange: true},
+        future: {tokenExchange: true},
       }),
     ).not.toThrow();
   });

--- a/packages/apps/shopify-app-express/src/__tests__/index.test.ts
+++ b/packages/apps/shopify-app-express/src/__tests__/index.test.ts
@@ -36,6 +36,26 @@ describe('shopifyApp', () => {
     expect(() => shopifyApp({} as any)).toThrow(ShopifyError);
   });
 
+  it('throws when token exchange is enabled on a non-embedded app', () => {
+    expect(() =>
+      shopifyApp({
+        ...testConfig,
+        api: {...testConfig.api, isEmbeddedApp: false},
+        future: {unstable_tokenExchange: true},
+      }),
+    ).toThrow(ShopifyError);
+  });
+
+  it('allows token exchange on an embedded app', () => {
+    expect(() =>
+      shopifyApp({
+        ...testConfig,
+        api: {...testConfig.api, isEmbeddedApp: true},
+        future: {unstable_tokenExchange: true},
+      }),
+    ).not.toThrow();
+  });
+
   it('properly defaults missing configs based on env vars', () => {
     /* eslint-disable no-process-env */
     process.env.SHOPIFY_API_KEY = 'envKey';

--- a/packages/apps/shopify-app-express/src/auth/auth-callback.ts
+++ b/packages/apps/shopify-app-express/src/auth/auth-callback.ts
@@ -2,14 +2,13 @@ import {Request, Response} from 'express';
 import {
   BotActivityDetected,
   CookieNotFound,
-  privacyTopics,
   InvalidOAuthError,
-  Session,
   Shopify,
 } from '@shopify/shopify-api';
 
 import {AppConfigInterface} from '../config-types';
 import {redirectToAuth} from '../redirect-to-auth';
+import {registerWebhooks} from '../helpers/register-webhooks';
 
 import {AuthCallbackParams} from './types';
 
@@ -54,6 +53,8 @@ export async function authCallback({
       session: callbackResponse.session,
     };
 
+    await config.hooks?.afterAuth?.({session: callbackResponse.session});
+
     config.logger.debug('Completed OAuth callback', {
       shop: callbackResponse.session.shop,
       isOnline: callbackResponse.session.isOnline,
@@ -67,42 +68,6 @@ export async function authCallback({
   }
 
   return false;
-}
-
-async function registerWebhooks(
-  config: AppConfigInterface,
-  api: Shopify,
-  session: Session,
-) {
-  config.logger.debug('Registering webhooks', {shop: session.shop});
-
-  const responsesByTopic = await api.webhooks.register({session});
-
-  for (const topic in responsesByTopic) {
-    if (!Object.prototype.hasOwnProperty.call(responsesByTopic, topic)) {
-      continue;
-    }
-
-    for (const response of responsesByTopic[topic]) {
-      if (!response.success && !privacyTopics.includes(topic)) {
-        const result: any = response.result;
-
-        if (result.errors) {
-          config.logger.error(
-            `Failed to register ${topic} webhook: ${result.errors[0].message}`,
-            {shop: session.shop},
-          );
-        } else {
-          config.logger.error(
-            `Failed to register ${topic} webhook: ${JSON.stringify(
-              result.data,
-            )}`,
-            {shop: session.shop},
-          );
-        }
-      }
-    }
-  }
 }
 
 async function handleCallbackError(

--- a/packages/apps/shopify-app-express/src/auth/index.ts
+++ b/packages/apps/shopify-app-express/src/auth/index.ts
@@ -7,13 +7,41 @@ import {authCallback} from './auth-callback';
 import {AuthMiddleware} from './types';
 
 export function auth({api, config}: ApiAndConfigParams): AuthMiddleware {
+  const usesTokenExchange = () =>
+    Boolean(config.future?.unstable_tokenExchange && api.config.isEmbeddedApp);
+
   return {
     begin(): RequestHandler {
-      return async (req: Request, res: Response) =>
-        redirectToAuth({req, res, api, config});
+      return async (req: Request, res: Response) => {
+        if (usesTokenExchange()) {
+          config.logger.error(
+            'auth.begin() was called while token exchange is enabled. Embedded apps using token exchange do not use the OAuth code flow routes.',
+          );
+          res
+            .status(400)
+            .send(
+              'This app uses token exchange (unstable_tokenExchange). The OAuth auth routes are not used in this mode.',
+            );
+          return;
+        }
+
+        return redirectToAuth({req, res, api, config});
+      };
     },
     callback(): RequestHandler {
       return async (req: Request, res: Response, next: NextFunction) => {
+        if (usesTokenExchange()) {
+          config.logger.error(
+            'auth.callback() was called while token exchange is enabled. Embedded apps using token exchange do not use the OAuth code flow routes.',
+          );
+          res
+            .status(400)
+            .send(
+              'This app uses token exchange (unstable_tokenExchange). The OAuth auth routes are not used in this mode.',
+            );
+          return;
+        }
+
         config.logger.info('Handling request to complete OAuth process');
 
         const oauthCompleted = await authCallback({

--- a/packages/apps/shopify-app-express/src/auth/index.ts
+++ b/packages/apps/shopify-app-express/src/auth/index.ts
@@ -8,19 +8,19 @@ import {AuthMiddleware} from './types';
 
 export function auth({api, config}: ApiAndConfigParams): AuthMiddleware {
   const usesTokenExchange = () =>
-    Boolean(config.future?.unstable_tokenExchange && api.config.isEmbeddedApp);
+    Boolean(config.future?.tokenExchange && api.config.isEmbeddedApp);
 
   return {
     begin(): RequestHandler {
       return async (req: Request, res: Response) => {
         if (usesTokenExchange()) {
           config.logger.error(
-            'auth.begin() was called while token exchange is enabled. Embedded apps using token exchange do not use the OAuth code flow routes.',
+            'auth.begin() was called while token exchange is enabled. Embedded apps using token exchange do not use the Auth Code flow routes.',
           );
           res
             .status(400)
             .send(
-              'This app uses token exchange (unstable_tokenExchange). The OAuth auth routes are not used in this mode.',
+              'This app uses token exchange (tokenExchange). The OAuth auth routes are not used in this mode.',
             );
           return;
         }
@@ -32,12 +32,12 @@ export function auth({api, config}: ApiAndConfigParams): AuthMiddleware {
       return async (req: Request, res: Response, next: NextFunction) => {
         if (usesTokenExchange()) {
           config.logger.error(
-            'auth.callback() was called while token exchange is enabled. Embedded apps using token exchange do not use the OAuth code flow routes.',
+            'auth.callback() was called while token exchange is enabled. Embedded apps using token exchange do not use the Auth Code flow routes.',
           );
           res
             .status(400)
             .send(
-              'This app uses token exchange (unstable_tokenExchange). The OAuth auth routes are not used in this mode.',
+              'This app uses token exchange (tokenExchange). The OAuth auth routes are not used in this mode.',
             );
           return;
         }

--- a/packages/apps/shopify-app-express/src/config-types.ts
+++ b/packages/apps/shopify-app-express/src/config-types.ts
@@ -27,11 +27,11 @@ export interface FutureFlags {
 
   /**
    * When enabled, embedded apps fetch access tokens via token exchange instead of the OAuth redirect flow. Requires
-   * Shopify managed installation. Non-embedded apps continue to use the OAuth code flow.
+   * Shopify managed installation. Non-embedded apps continue to use the Auth Code flow.
    *
    * @default false
    */
-  unstable_tokenExchange?: boolean;
+  tokenExchange?: boolean;
 }
 
 export interface HooksConfigInterface {

--- a/packages/apps/shopify-app-express/src/config-types.ts
+++ b/packages/apps/shopify-app-express/src/config-types.ts
@@ -1,10 +1,13 @@
 import {
   ApiVersion,
   ConfigParams as ApiConfigParams,
+  Session,
   Shopify,
   ShopifyRestResources,
 } from '@shopify/shopify-api';
 import {SessionStorage} from '@shopify/shopify-app-session-storage';
+
+import {IdempotentPromiseHandler} from './helpers/idempotent-promise-handler';
 
 // Make apiVersion required while keeping other API config fields optional
 export type ExpressApiConfigParams<
@@ -21,6 +24,21 @@ export interface FutureFlags {
    * @default false
    */
   expiringOfflineAccessTokens?: boolean;
+
+  /**
+   * When enabled, embedded apps fetch access tokens via token exchange instead of the OAuth redirect flow. Requires
+   * Shopify managed installation. Non-embedded apps continue to use the OAuth code flow.
+   *
+   * @default false
+   */
+  unstable_tokenExchange?: boolean;
+}
+
+export interface HooksConfigInterface {
+  /**
+   * Called after authentication completes (both token exchange and OAuth), with the resulting session.
+   */
+  afterAuth?: (options: {session: Session}) => void | Promise<void>;
 }
 
 export interface AppConfigParams<
@@ -34,6 +52,7 @@ export interface AppConfigParams<
   exitIframePath?: string;
   sessionStorage?: Storage;
   future?: FutureFlags;
+  hooks?: HooksConfigInterface;
 }
 
 export interface AppConfigInterface<
@@ -45,6 +64,8 @@ export interface AppConfigInterface<
   exitIframePath: string;
   sessionStorage: Storage;
   future: FutureFlags;
+  hooks: HooksConfigInterface;
+  idempotentPromiseHandler: IdempotentPromiseHandler;
 }
 
 export interface AuthConfigInterface {

--- a/packages/apps/shopify-app-express/src/const.ts
+++ b/packages/apps/shopify-app-express/src/const.ts
@@ -1,0 +1,2 @@
+export const RETRY_INVALID_SESSION_HEADER =
+  'X-Shopify-Retry-Invalid-Session-Request';

--- a/packages/apps/shopify-app-express/src/const.ts
+++ b/packages/apps/shopify-app-express/src/const.ts
@@ -3,5 +3,3 @@ export const RETRY_INVALID_SESSION_HEADER =
 
 export const APP_BRIDGE_URL =
   'https://cdn.shopify.com/shopifycloud/app-bridge.js';
-
-export const SESSION_TOKEN_PARAM = 'id_token';

--- a/packages/apps/shopify-app-express/src/const.ts
+++ b/packages/apps/shopify-app-express/src/const.ts
@@ -1,2 +1,7 @@
 export const RETRY_INVALID_SESSION_HEADER =
   'X-Shopify-Retry-Invalid-Session-Request';
+
+export const APP_BRIDGE_URL =
+  'https://cdn.shopify.com/shopifycloud/app-bridge.js';
+
+export const SESSION_TOKEN_PARAM = 'id_token';

--- a/packages/apps/shopify-app-express/src/future/flags.ts
+++ b/packages/apps/shopify-app-express/src/future/flags.ts
@@ -1,0 +1,30 @@
+import {Shopify} from '@shopify/shopify-api';
+
+import {AppConfigInterface} from '../config-types';
+
+/**
+ * Logs a startup hint for each future flag that is currently disabled, so
+ * developers can discover opt-in features.
+ */
+export function logDisabledFutureFlags(
+  config: AppConfigInterface,
+  logger: Shopify['logger'],
+): void {
+  const logFlag = (flag: string, message: string) =>
+    logger.info(`Future flag ${flag} is disabled.\n\n  ${message}\n`);
+
+  if (!config.future?.unstable_tokenExchange) {
+    logFlag(
+      'unstable_tokenExchange',
+      'Enable this to use OAuth token exchange instead of the auth code flow for embedded apps. ' +
+        'Your app must use Shopify managed installation: https://shopify.dev/docs/apps/auth/installation',
+    );
+  }
+
+  if (!config.future?.expiringOfflineAccessTokens) {
+    logFlag(
+      'expiringOfflineAccessTokens',
+      'Enable this to use expiring offline access tokens and automatically refresh them before they expire.',
+    );
+  }
+}

--- a/packages/apps/shopify-app-express/src/future/flags.ts
+++ b/packages/apps/shopify-app-express/src/future/flags.ts
@@ -13,10 +13,10 @@ export function logDisabledFutureFlags(
   const logFlag = (flag: string, message: string) =>
     logger.info(`Future flag ${flag} is disabled.\n\n  ${message}\n`);
 
-  if (!config.future?.unstable_tokenExchange) {
+  if (!config.future?.tokenExchange) {
     logFlag(
-      'unstable_tokenExchange',
-      'Enable this to use OAuth token exchange instead of the auth code flow for embedded apps. ' +
+      'tokenExchange',
+      'Enable this to use OAuth token exchange instead of the Auth Code flow for embedded apps. ' +
         'Your app must use Shopify managed installation: https://shopify.dev/docs/apps/auth/installation',
     );
   }

--- a/packages/apps/shopify-app-express/src/helpers/__tests__/idempotent-promise-handler.test.ts
+++ b/packages/apps/shopify-app-express/src/helpers/__tests__/idempotent-promise-handler.test.ts
@@ -1,0 +1,26 @@
+import {IdempotentPromiseHandler} from '../idempotent-promise-handler';
+
+describe('IdempotentPromiseHandler', () => {
+  it('runs the promise once per identifier, even under concurrent calls', async () => {
+    const handler = new IdempotentPromiseHandler();
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await Promise.all([
+      handler.handlePromise({promiseFunction: fn, identifier: 'same'}),
+      handler.handlePromise({promiseFunction: fn, identifier: 'same'}),
+      handler.handlePromise({promiseFunction: fn, identifier: 'same'}),
+    ]);
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs the promise again for a different identifier', async () => {
+    const handler = new IdempotentPromiseHandler();
+    const fn = jest.fn().mockResolvedValue(undefined);
+
+    await handler.handlePromise({promiseFunction: fn, identifier: 'a'});
+    await handler.handlePromise({promiseFunction: fn, identifier: 'b'});
+
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/apps/shopify-app-express/src/helpers/get-session-token.ts
+++ b/packages/apps/shopify-app-express/src/helpers/get-session-token.ts
@@ -1,0 +1,15 @@
+import {Request} from 'express';
+
+const SESSION_TOKEN_PARAM = 'id_token';
+
+export function getSessionTokenHeader(req: Request): string | undefined {
+  return req.headers.authorization?.match(/Bearer (.*)/)?.[1];
+}
+
+export function getSessionTokenFromUrlParam(req: Request): string | undefined {
+  return req.query[SESSION_TOKEN_PARAM] as string | undefined;
+}
+
+export function getSessionToken(req: Request): string | undefined {
+  return getSessionTokenHeader(req) ?? getSessionTokenFromUrlParam(req);
+}

--- a/packages/apps/shopify-app-express/src/helpers/idempotent-promise-handler.ts
+++ b/packages/apps/shopify-app-express/src/helpers/idempotent-promise-handler.ts
@@ -1,0 +1,45 @@
+export interface IdempotentHandlePromiseParams {
+  promiseFunction: () => Promise<any>;
+  identifier: string;
+}
+
+const IDENTIFIER_TTL_MS = 60000;
+
+export class IdempotentPromiseHandler {
+  protected identifiers: Map<string, number>;
+
+  constructor() {
+    this.identifiers = new Map<string, number>();
+  }
+
+  async handlePromise({
+    promiseFunction,
+    identifier,
+  }: IdempotentHandlePromiseParams): Promise<any> {
+    try {
+      if (this.isPromiseRunnable(identifier)) {
+        await promiseFunction();
+      }
+    } finally {
+      this.clearStaleIdentifiers();
+    }
+
+    return Promise.resolve();
+  }
+
+  private isPromiseRunnable(identifier: string) {
+    if (!this.identifiers.has(identifier)) {
+      this.identifiers.set(identifier, Date.now());
+      return true;
+    }
+    return false;
+  }
+
+  private async clearStaleIdentifiers() {
+    this.identifiers.forEach((date, identifier, map) => {
+      if (Date.now() - date > IDENTIFIER_TTL_MS) {
+        map.delete(identifier);
+      }
+    });
+  }
+}

--- a/packages/apps/shopify-app-express/src/helpers/invalidate-access-token.ts
+++ b/packages/apps/shopify-app-express/src/helpers/invalidate-access-token.ts
@@ -1,0 +1,12 @@
+import {Session} from '@shopify/shopify-api';
+
+import {AppConfigInterface} from '../config-types';
+
+export async function invalidateAccessToken(
+  session: Session,
+  config: AppConfigInterface,
+): Promise<void> {
+  config.logger.debug('Invalidating stale access token', {shop: session.shop});
+  session.accessToken = undefined;
+  await config.sessionStorage.storeSession(session);
+}

--- a/packages/apps/shopify-app-express/src/helpers/register-webhooks.ts
+++ b/packages/apps/shopify-app-express/src/helpers/register-webhooks.ts
@@ -1,0 +1,39 @@
+import {privacyTopics, Session, Shopify} from '@shopify/shopify-api';
+
+import {AppConfigInterface} from '../config-types';
+
+export async function registerWebhooks(
+  config: AppConfigInterface,
+  api: Shopify,
+  session: Session,
+): Promise<void> {
+  config.logger.debug('Registering webhooks', {shop: session.shop});
+
+  const responsesByTopic = await api.webhooks.register({session});
+
+  for (const topic in responsesByTopic) {
+    if (!Object.prototype.hasOwnProperty.call(responsesByTopic, topic)) {
+      continue;
+    }
+
+    for (const response of responsesByTopic[topic]) {
+      if (!response.success && !privacyTopics.includes(topic)) {
+        const result: any = response.result;
+
+        if (result.errors) {
+          config.logger.error(
+            `Failed to register ${topic} webhook: ${result.errors[0].message}`,
+            {shop: session.shop},
+          );
+        } else {
+          config.logger.error(
+            `Failed to register ${topic} webhook: ${JSON.stringify(
+              result.data,
+            )}`,
+            {shop: session.shop},
+          );
+        }
+      }
+    }
+  }
+}

--- a/packages/apps/shopify-app-express/src/helpers/render-app-bridge.ts
+++ b/packages/apps/shopify-app-express/src/helpers/render-app-bridge.ts
@@ -4,13 +4,9 @@ import {Shopify} from '@shopify/shopify-api';
 import {APP_BRIDGE_URL} from '../const';
 import {addCSPHeader} from '../middlewares/csp-headers';
 
-let appBridgeUrlOverride: string | undefined;
-export function setAppBridgeUrlOverride(url: string) {
-  appBridgeUrlOverride = url;
-}
 function appBridgeUrl() {
   // eslint-disable-next-line no-process-env
-  return appBridgeUrlOverride || process.env.APP_BRIDGE_URL || APP_BRIDGE_URL;
+  return process.env.APP_BRIDGE_URL || APP_BRIDGE_URL;
 }
 
 /**
@@ -25,16 +21,10 @@ export function renderAppBridge(
   api: Shopify,
   req: Request,
   res: Response,
-  redirectTo?: string,
 ): void {
   addCSPHeader(api, req, res);
 
-  const redirectToScript = redirectTo
-    ? `<script>window.open(${JSON.stringify(redirectTo)}, '_top')</script>`
-    : '';
-
   res.status(200).set('content-type', 'text/html;charset=utf-8').send(`
       <script data-api-key="${api.config.apiKey}" src="${appBridgeUrl()}"></script>
-      ${redirectToScript}
     `);
 }

--- a/packages/apps/shopify-app-express/src/helpers/render-app-bridge.ts
+++ b/packages/apps/shopify-app-express/src/helpers/render-app-bridge.ts
@@ -1,0 +1,40 @@
+import {Request, Response} from 'express';
+import {Shopify} from '@shopify/shopify-api';
+
+import {APP_BRIDGE_URL} from '../const';
+import {addCSPHeader} from '../middlewares/csp-headers';
+
+let appBridgeUrlOverride: string | undefined;
+export function setAppBridgeUrlOverride(url: string) {
+  appBridgeUrlOverride = url;
+}
+function appBridgeUrl() {
+  // eslint-disable-next-line no-process-env
+  return appBridgeUrlOverride || process.env.APP_BRIDGE_URL || APP_BRIDGE_URL;
+}
+
+/**
+ * Serves the App Bridge bootstrap shim for a document (page load) request.
+ *
+ * App Bridge loads in the browser, obtains a fresh session token, and reloads
+ * the page with it attached. This is how an embedded document request that is
+ * missing or has a stale session token recovers, without a top-level OAuth
+ * redirect. Mirrors `renderAppBridge` in the React Router package.
+ */
+export function renderAppBridge(
+  api: Shopify,
+  req: Request,
+  res: Response,
+  redirectTo?: string,
+): void {
+  addCSPHeader(api, req, res);
+
+  const redirectToScript = redirectTo
+    ? `<script>window.open(${JSON.stringify(redirectTo)}, '_top')</script>`
+    : '';
+
+  res.status(200).set('content-type', 'text/html;charset=utf-8').send(`
+      <script data-api-key="${api.config.apiKey}" src="${appBridgeUrl()}"></script>
+      ${redirectToScript}
+    `);
+}

--- a/packages/apps/shopify-app-express/src/helpers/respond-to-invalid-session-token.ts
+++ b/packages/apps/shopify-app-express/src/helpers/respond-to-invalid-session-token.ts
@@ -1,0 +1,28 @@
+import {Response} from 'express';
+
+import {RETRY_INVALID_SESSION_HEADER} from '../const';
+
+/**
+ * Sends a 401 response indicating the session token is invalid.
+ *
+ * When `retryRequest` is true, the response includes the
+ * `X-Shopify-Retry-Invalid-Session-Request: 1` header, which signals App
+ * Bridge to obtain a fresh session token and automatically retry the request.
+ * Pass `true` when the token itself was stale or unverifiable; pass `false`
+ * (the default) when auth has failed for another reason (e.g. a revoked access
+ * token) and a retry without first re-authenticating would not help.
+ *
+ * This mirrors the behaviour of `respondToInvalidSessionToken` in the Remix
+ * package, adapted for Express (no bounce-page redirect since Express apps
+ * do not have an equivalent route).
+ */
+export function respondToInvalidSessionToken(
+  res: Response,
+  message: string,
+  retryRequest = false,
+): void {
+  if (retryRequest) {
+    res.set(RETRY_INVALID_SESSION_HEADER, '1');
+  }
+  res.status(401).send(message);
+}

--- a/packages/apps/shopify-app-express/src/helpers/respond-to-invalid-session-token.ts
+++ b/packages/apps/shopify-app-express/src/helpers/respond-to-invalid-session-token.ts
@@ -1,26 +1,43 @@
-import {Response} from 'express';
+import {Request, Response} from 'express';
+import {Shopify} from '@shopify/shopify-api';
 
 import {RETRY_INVALID_SESSION_HEADER} from '../const';
 
+import {getSessionTokenHeader} from './get-session-token';
+import {renderAppBridge} from './render-app-bridge';
+
+interface RespondToInvalidSessionTokenParams {
+  api: Shopify;
+  req: Request;
+  res: Response;
+  message: string;
+  retryRequest?: boolean;
+}
+
 /**
- * Sends a 401 response indicating the session token is invalid.
+ * Responds to a request whose session token is missing, stale, or unverifiable.
  *
- * When `retryRequest` is true, the response includes the
- * `X-Shopify-Retry-Invalid-Session-Request: 1` header, which signals App
- * Bridge to obtain a fresh session token and automatically retry the request.
- * Pass `true` when the token itself was stale or unverifiable; pass `false`
- * (the default) when auth has failed for another reason (e.g. a revoked access
- * token) and a retry without first re-authenticating would not help.
- *
- * This mirrors the behaviour of `respondToInvalidSessionToken` in the Remix
- * package, adapted for Express (no bounce-page redirect since Express apps
- * do not have an equivalent route).
+ * - Document requests (no Authorization header, e.g. an embedded page load)
+ *   get the App Bridge bounce so the browser fetches a fresh token and reloads.
+ * - Fetch requests (Authorization header present) get a 401. The
+ *   `X-Shopify-Retry-Invalid-Session-Request` header is added only when a retry
+ *   would help (`retryRequest`), so App Bridge refetches with a new token;
+ *   it is omitted when re-auth is required (e.g. a revoked access token).
  */
-export function respondToInvalidSessionToken(
-  res: Response,
-  message: string,
+export function respondToInvalidSessionToken({
+  api,
+  req,
+  res,
+  message,
   retryRequest = false,
-): void {
+}: RespondToInvalidSessionTokenParams): void {
+  const isDocumentRequest = !getSessionTokenHeader(req);
+
+  if (isDocumentRequest) {
+    renderAppBridge(api, req, res);
+    return;
+  }
+
   if (retryRequest) {
     res.set(RETRY_INVALID_SESSION_HEADER, '1');
   }

--- a/packages/apps/shopify-app-express/src/index.ts
+++ b/packages/apps/shopify-app-express/src/index.ts
@@ -5,6 +5,7 @@ import {
   ConfigParams as ApiConfigParams,
   Shopify,
   FeatureDeprecatedError,
+  ShopifyError,
   ShopifyRestResources,
   Session,
 } from '@shopify/shopify-api';
@@ -84,6 +85,16 @@ export function shopifyApp<Params extends AppConfigParams>(
 
   const api = shopifyApi(apiConfigWithDefaults(apiConfig));
   const validatedConfig = validateAppConfig(appConfig, api);
+
+  if (
+    validatedConfig.future?.unstable_tokenExchange &&
+    !api.config.isEmbeddedApp
+  ) {
+    throw new ShopifyError(
+      'unstable_tokenExchange requires an embedded app (isEmbeddedApp: true). ' +
+        'Token exchange is not available for non-embedded apps; remove the flag or set isEmbeddedApp to true.',
+    );
+  }
 
   logDisabledFutureFlags(validatedConfig, api.logger);
 

--- a/packages/apps/shopify-app-express/src/index.ts
+++ b/packages/apps/shopify-app-express/src/index.ts
@@ -13,6 +13,8 @@ import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory'
 import {SHOPIFY_EXPRESS_LIBRARY_VERSION} from './version';
 import {AppConfigInterface, AppConfigParams} from './config-types';
 import {IdempotentPromiseHandler} from './helpers/idempotent-promise-handler';
+import {registerWebhooks} from './helpers/register-webhooks';
+import {logDisabledFutureFlags} from './future/flags';
 import {
   validateAuthenticatedSession,
   cspHeaders,
@@ -72,6 +74,7 @@ export interface ShopifyApp<Params extends AppConfigParams = AppConfigParams> {
   redirectToShopifyOrAppRoot: RedirectToShopifyOrAppRootMiddleware;
   redirectOutOfApp: RedirectOutOfAppFunction;
   ensureValidOfflineSession: (shop: string) => Promise<Session | undefined>;
+  registerWebhooks: (params: {session: Session}) => Promise<void>;
 }
 
 export function shopifyApp<Params extends AppConfigParams>(
@@ -81,6 +84,8 @@ export function shopifyApp<Params extends AppConfigParams>(
 
   const api = shopifyApi(apiConfigWithDefaults(apiConfig));
   const validatedConfig = validateAppConfig(appConfig, api);
+
+  logDisabledFutureFlags(validatedConfig, api.logger);
 
   return {
     config: validatedConfig,
@@ -106,6 +111,8 @@ export function shopifyApp<Params extends AppConfigParams>(
     redirectOutOfApp: redirectOutOfApp({api, config: validatedConfig}),
     ensureValidOfflineSession: (shop: string) =>
       ensureValidOfflineSession({api, config: validatedConfig}, shop),
+    registerWebhooks: ({session}: {session: Session}) =>
+      registerWebhooks(validatedConfig, api, session),
   };
 }
 

--- a/packages/apps/shopify-app-express/src/index.ts
+++ b/packages/apps/shopify-app-express/src/index.ts
@@ -12,6 +12,7 @@ import {MemorySessionStorage} from '@shopify/shopify-app-session-storage-memory'
 
 import {SHOPIFY_EXPRESS_LIBRARY_VERSION} from './version';
 import {AppConfigInterface, AppConfigParams} from './config-types';
+import {IdempotentPromiseHandler} from './helpers/idempotent-promise-handler';
 import {
   validateAuthenticatedSession,
   cspHeaders,
@@ -143,6 +144,8 @@ function validateAppConfig<Params extends Omit<AppConfigParams, 'api'>>(
     useOnlineTokens: false,
     exitIframePath: '/exitiframe',
     future: {},
+    hooks: {},
+    idempotentPromiseHandler: new IdempotentPromiseHandler(),
     sessionStorage: (sessionStorage ??
       new MemorySessionStorage()) as ConfigInterfaceFromParams<Params>['sessionStorage'],
     ...configWithoutSessionStorage,

--- a/packages/apps/shopify-app-express/src/index.ts
+++ b/packages/apps/shopify-app-express/src/index.ts
@@ -86,12 +86,9 @@ export function shopifyApp<Params extends AppConfigParams>(
   const api = shopifyApi(apiConfigWithDefaults(apiConfig));
   const validatedConfig = validateAppConfig(appConfig, api);
 
-  if (
-    validatedConfig.future?.unstable_tokenExchange &&
-    !api.config.isEmbeddedApp
-  ) {
+  if (validatedConfig.future?.tokenExchange && !api.config.isEmbeddedApp) {
     throw new ShopifyError(
-      'unstable_tokenExchange requires an embedded app (isEmbeddedApp: true). ' +
+      'tokenExchange requires an embedded app (isEmbeddedApp: true). ' +
         'Token exchange is not available for non-embedded apps; remove the flag or set isEmbeddedApp to true.',
     );
   }

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -194,7 +194,7 @@ describe('ensureInstalledOnShop', () => {
 
   describe('with token exchange enabled', () => {
     beforeEach(() => {
-      shopify.config.future = {unstable_tokenExchange: true};
+      shopify.config.future = {tokenExchange: true};
     });
 
     it('loads the app with no stored session (skips the storage install check)', async () => {

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/ensure-installed-on-shop.test.ts
@@ -191,4 +191,23 @@ describe('ensureInstalledOnShop', () => {
       ),
     );
   });
+
+  describe('with token exchange enabled', () => {
+    beforeEach(() => {
+      shopify.config.future = {unstable_tokenExchange: true};
+    });
+
+    it('loads the app with no stored session (skips the storage install check)', async () => {
+      mockShopifyResponse({data: {shop: {name: TEST_SHOP}}});
+
+      // No session stored on purpose: under token exchange, a fresh shop has
+      // no session until the first authenticated request mints one.
+      const encodedHost = Buffer.from(SHOPIFY_HOST, 'utf-8').toString('base64');
+      const response = await request(app)
+        .get(`/test/shop?shop=${TEST_SHOP}&host=${encodedHost}&embedded=1`)
+        .expect(200);
+
+      expect(response.body).toEqual({data: {shop: {name: TEST_SHOP}}});
+    });
+  });
 });

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
@@ -1,0 +1,131 @@
+import {createSecretKey} from 'crypto';
+
+import request from 'supertest';
+import express, {Express} from 'express';
+import {SignJWT} from 'jose';
+
+import {
+  mockShopifyResponse,
+  shopify,
+  TEST_SHOP,
+} from '../../__tests__/test-helper';
+import {RETRY_INVALID_SESSION_HEADER} from '../../const';
+
+async function signSessionToken(overrides: Record<string, any> = {}) {
+  return new SignJWT({
+    aud: shopify.api.config.apiKey,
+    dest: `https://${TEST_SHOP}`,
+    sub: '42',
+    ...overrides,
+  })
+    .setProtectedHeader({alg: 'HS256'})
+    .setExpirationTime('1h')
+    .sign(createSecretKey(Buffer.from(shopify.api.config.apiSecretKey)));
+}
+
+function buildApp(): Express {
+  const app = express();
+  app.use('/test', shopify.validateAuthenticatedSession());
+  app.get('/test/data', async (_req, res) => {
+    res.json({ok: true});
+  });
+  return app;
+}
+
+describe('validateAuthenticatedSession with token exchange', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    shopify.api.config.isEmbeddedApp = true;
+    shopify.config.future = {unstable_tokenExchange: true};
+    app = buildApp();
+  });
+
+  it('exchanges a valid session token, stores the session, and runs afterAuth', async () => {
+    const afterAuth = jest.fn();
+    shopify.config.hooks = {afterAuth};
+    const token = await signSessionToken();
+
+    mockShopifyResponse({
+      access_token: 'offline-token',
+      scope: shopify.api.config.scopes.toString(),
+    });
+
+    const response = await request(app)
+      .get('/test/data')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body).toEqual({ok: true});
+
+    const stored = await shopify.config.sessionStorage.loadSession(
+      shopify.api.session.getOfflineId(TEST_SHOP),
+    );
+    expect(stored?.accessToken).toBe('offline-token');
+    expect(afterAuth).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 401 with the retry header for a fetch request with an invalid token', async () => {
+    const badToken = await new SignJWT({
+      aud: shopify.api.config.apiKey,
+      dest: `https://${TEST_SHOP}`,
+      sub: '42',
+    })
+      .setProtectedHeader({alg: 'HS256'})
+      .setExpirationTime('1h')
+      .sign(createSecretKey(Buffer.from('a-different-secret')));
+
+    const response = await request(app)
+      .get('/test/data')
+      .set('Authorization', `Bearer ${badToken}`)
+      .expect(401);
+
+    expect(response.headers[RETRY_INVALID_SESSION_HEADER.toLowerCase()]).toBe(
+      '1',
+    );
+  });
+
+  it('renders App Bridge (bounce) for a document request with an invalid token', async () => {
+    const badToken = await new SignJWT({
+      aud: shopify.api.config.apiKey,
+      dest: `https://${TEST_SHOP}`,
+      sub: '42',
+    })
+      .setProtectedHeader({alg: 'HS256'})
+      .setExpirationTime('1h')
+      .sign(createSecretKey(Buffer.from('a-different-secret')));
+
+    const response = await request(app)
+      .get(`/test/data?id_token=${badToken}`)
+      .expect(200);
+
+    expect(response.text).toContain('app-bridge.js');
+    expect(response.text).toContain(
+      `data-api-key="${shopify.api.config.apiKey}"`,
+    );
+  });
+
+  it('does not use token exchange when the app is not embedded', async () => {
+    shopify.api.config.isEmbeddedApp = false;
+    const token = await signSessionToken();
+    const tokenExchangeSpy = jest.spyOn(shopify.api.auth, 'tokenExchange');
+
+    await request(app)
+      .get('/test/data')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(tokenExchangeSpy).not.toHaveBeenCalled();
+  });
+
+  it('does not use token exchange when the flag is off', async () => {
+    shopify.config.future = {};
+    const token = await signSessionToken();
+    const tokenExchangeSpy = jest.spyOn(shopify.api.auth, 'tokenExchange');
+
+    await request(app)
+      .get('/test/data')
+      .set('Authorization', `Bearer ${token}`);
+
+    expect(tokenExchangeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
@@ -14,7 +14,7 @@ import {RETRY_INVALID_SESSION_HEADER} from '../../const';
 function buildShopify(overrides: Record<string, any> = {}): ShopifyApp {
   return shopifyApp({
     ...testConfig,
-    future: {unstable_tokenExchange: true},
+    future: {tokenExchange: true},
     ...overrides,
   } as any);
 }

--- a/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/__tests__/perform-token-exchange.test.ts
@@ -3,27 +3,45 @@ import {createSecretKey} from 'crypto';
 import request from 'supertest';
 import express, {Express} from 'express';
 import {SignJWT} from 'jose';
+import {RequestedTokenType, Session} from '@shopify/shopify-api';
 
-import {
-  mockShopifyResponse,
-  shopify,
-  TEST_SHOP,
-} from '../../__tests__/test-helper';
+import {shopifyApp, ShopifyApp} from '../../index';
+import {testConfig, TEST_SHOP} from '../../__tests__/test-helper';
 import {RETRY_INVALID_SESSION_HEADER} from '../../const';
 
-async function signSessionToken(overrides: Record<string, any> = {}) {
+// Build a real app instance through shopifyApp() so the future flag goes
+// through the actual config wiring (not mutated after construction).
+function buildShopify(overrides: Record<string, any> = {}): ShopifyApp {
+  return shopifyApp({
+    ...testConfig,
+    future: {unstable_tokenExchange: true},
+    ...overrides,
+  } as any);
+}
+
+async function signSessionToken(shopify: ShopifyApp) {
   return new SignJWT({
     aud: shopify.api.config.apiKey,
     dest: `https://${TEST_SHOP}`,
     sub: '42',
-    ...overrides,
   })
     .setProtectedHeader({alg: 'HS256'})
     .setExpirationTime('1h')
     .sign(createSecretKey(Buffer.from(shopify.api.config.apiSecretKey)));
 }
 
-function buildApp(): Express {
+async function signWithSecret(shopify: ShopifyApp, secret: string) {
+  return new SignJWT({
+    aud: shopify.api.config.apiKey,
+    dest: `https://${TEST_SHOP}`,
+    sub: '42',
+  })
+    .setProtectedHeader({alg: 'HS256'})
+    .setExpirationTime('1h')
+    .sign(createSecretKey(Buffer.from(secret)));
+}
+
+function buildApp(shopify: ShopifyApp): Express {
   const app = express();
   app.use('/test', shopify.validateAuthenticatedSession());
   app.get('/test/data', async (_req, res) => {
@@ -33,30 +51,34 @@ function buildApp(): Express {
 }
 
 describe('validateAuthenticatedSession with token exchange', () => {
-  let app: Express;
-
-  beforeEach(() => {
-    shopify.api.config.isEmbeddedApp = true;
-    shopify.config.future = {unstable_tokenExchange: true};
-    app = buildApp();
-  });
-
-  it('exchanges a valid session token, stores the session, and runs afterAuth', async () => {
+  it('exchanges a valid session token, stores the session, and runs afterAuth once', async () => {
     const afterAuth = jest.fn();
-    shopify.config.hooks = {afterAuth};
-    const token = await signSessionToken();
+    const shopify = buildShopify({hooks: {afterAuth}});
+    const exchange = jest
+      .spyOn(shopify.api.auth, 'tokenExchange')
+      .mockResolvedValue({
+        session: new Session({
+          id: shopify.api.session.getOfflineId(TEST_SHOP),
+          shop: TEST_SHOP,
+          state: '',
+          isOnline: false,
+          accessToken: 'offline-token',
+        }),
+      });
+    const token = await signSessionToken(shopify);
 
-    mockShopifyResponse({
-      access_token: 'offline-token',
-      scope: shopify.api.config.scopes.toString(),
-    });
-
-    const response = await request(app)
+    const response = await request(buildApp(shopify))
       .get('/test/data')
       .set('Authorization', `Bearer ${token}`)
       .expect(200);
 
     expect(response.body).toEqual({ok: true});
+    expect(exchange).toHaveBeenCalledTimes(1);
+    expect(exchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OfflineAccessToken,
+      }),
+    );
 
     const stored = await shopify.config.sessionStorage.loadSession(
       shopify.api.session.getOfflineId(TEST_SHOP),
@@ -65,17 +87,47 @@ describe('validateAuthenticatedSession with token exchange', () => {
     expect(afterAuth).toHaveBeenCalledTimes(1);
   });
 
-  it('returns 401 with the retry header for a fetch request with an invalid token', async () => {
-    const badToken = await new SignJWT({
-      aud: shopify.api.config.apiKey,
-      dest: `https://${TEST_SHOP}`,
-      sub: '42',
-    })
-      .setProtectedHeader({alg: 'HS256'})
-      .setExpirationTime('1h')
-      .sign(createSecretKey(Buffer.from('a-different-secret')));
+  it('exchanges both offline and online tokens when useOnlineTokens is set', async () => {
+    const shopify = buildShopify({useOnlineTokens: true});
+    const exchange = jest
+      .spyOn(shopify.api.auth, 'tokenExchange')
+      .mockImplementation(async ({requestedTokenType}: any) => ({
+        session: new Session({
+          id:
+            requestedTokenType === RequestedTokenType.OnlineAccessToken
+              ? `${TEST_SHOP}_42`
+              : shopify.api.session.getOfflineId(TEST_SHOP),
+          shop: TEST_SHOP,
+          state: '',
+          isOnline: requestedTokenType === RequestedTokenType.OnlineAccessToken,
+          accessToken: 'a-token',
+        }),
+      }));
+    const token = await signSessionToken(shopify);
 
-    const response = await request(app)
+    await request(buildApp(shopify))
+      .get('/test/data')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(exchange).toHaveBeenCalledTimes(2);
+    expect(exchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OfflineAccessToken,
+      }),
+    );
+    expect(exchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requestedTokenType: RequestedTokenType.OnlineAccessToken,
+      }),
+    );
+  });
+
+  it('returns 401 with the retry header for a fetch request with an invalid token', async () => {
+    const shopify = buildShopify();
+    const badToken = await signWithSecret(shopify, 'a-different-secret');
+
+    const response = await request(buildApp(shopify))
       .get('/test/data')
       .set('Authorization', `Bearer ${badToken}`)
       .expect(401);
@@ -86,16 +138,10 @@ describe('validateAuthenticatedSession with token exchange', () => {
   });
 
   it('renders App Bridge (bounce) for a document request with an invalid token', async () => {
-    const badToken = await new SignJWT({
-      aud: shopify.api.config.apiKey,
-      dest: `https://${TEST_SHOP}`,
-      sub: '42',
-    })
-      .setProtectedHeader({alg: 'HS256'})
-      .setExpirationTime('1h')
-      .sign(createSecretKey(Buffer.from('a-different-secret')));
+    const shopify = buildShopify();
+    const badToken = await signWithSecret(shopify, 'a-different-secret');
 
-    const response = await request(app)
+    const response = await request(buildApp(shopify))
       .get(`/test/data?id_token=${badToken}`)
       .expect(200);
 
@@ -105,27 +151,94 @@ describe('validateAuthenticatedSession with token exchange', () => {
     );
   });
 
-  it('does not use token exchange when the app is not embedded', async () => {
-    shopify.api.config.isEmbeddedApp = false;
-    const token = await signSessionToken();
-    const tokenExchangeSpy = jest.spyOn(shopify.api.auth, 'tokenExchange');
+  it('invalidates the stored token and responds 401 without the retry header when the exchange returns 401', async () => {
+    const shopify = buildShopify();
+    // A stored-but-inactive session so token exchange runs and there is a
+    // session to invalidate.
+    const stale = new Session({
+      id: shopify.api.session.getOfflineId(TEST_SHOP),
+      shop: TEST_SHOP,
+      state: '',
+      isOnline: false,
+      accessToken: 'stale-token',
+      expires: new Date(Date.now() - 1000),
+    });
+    await shopify.config.sessionStorage.storeSession(stale);
 
-    await request(app)
+    const {HttpResponseError} = jest.requireActual('@shopify/shopify-api');
+    jest.spyOn(shopify.api.auth, 'tokenExchange').mockRejectedValue(
+      new HttpResponseError({
+        message: 'Unauthorized',
+        code: 401,
+        statusText: 'Unauthorized',
+        body: {},
+        headers: {},
+      }),
+    );
+    const token = await signSessionToken(shopify);
+
+    const response = await request(buildApp(shopify))
       .get('/test/data')
-      .set('Authorization', `Bearer ${token}`);
+      .set('Authorization', `Bearer ${token}`)
+      .expect(401);
 
-    expect(tokenExchangeSpy).not.toHaveBeenCalled();
+    expect(
+      response.headers[RETRY_INVALID_SESSION_HEADER.toLowerCase()],
+    ).toBeUndefined();
+
+    const stored = await shopify.config.sessionStorage.loadSession(
+      shopify.api.session.getOfflineId(TEST_SHOP),
+    );
+    expect(stored?.accessToken).toBeUndefined();
   });
 
   it('does not use token exchange when the flag is off', async () => {
-    shopify.config.future = {};
-    const token = await signSessionToken();
-    const tokenExchangeSpy = jest.spyOn(shopify.api.auth, 'tokenExchange');
+    const shopify = buildShopify({future: {}});
+    const exchange = jest.spyOn(shopify.api.auth, 'tokenExchange');
+    const token = await signSessionToken(shopify);
 
-    await request(app)
+    await request(buildApp(shopify))
       .get('/test/data')
       .set('Authorization', `Bearer ${token}`);
 
-    expect(tokenExchangeSpy).not.toHaveBeenCalled();
+    expect(exchange).not.toHaveBeenCalled();
+  });
+});
+
+describe('OAuth routes under token exchange', () => {
+  it('auth.begin returns an error when token exchange is enabled', async () => {
+    const shopify = buildShopify();
+    const app = express();
+    app.get('/auth', shopify.auth.begin());
+
+    await request(app).get(`/auth?shop=${TEST_SHOP}`).expect(400);
+  });
+
+  it('auth.callback returns an error when token exchange is enabled', async () => {
+    const shopify = buildShopify();
+    const app = express();
+    app.get('/auth/callback', shopify.auth.callback());
+
+    await request(app).get(`/auth/callback?shop=${TEST_SHOP}`).expect(400);
+  });
+});
+
+describe('registerWebhooks', () => {
+  it('registers webhooks for the given session', async () => {
+    const shopify = buildShopify();
+    const register = jest
+      .spyOn(shopify.api.webhooks, 'register')
+      .mockResolvedValue({} as any);
+    const session = new Session({
+      id: shopify.api.session.getOfflineId(TEST_SHOP),
+      shop: TEST_SHOP,
+      state: '',
+      isOnline: false,
+      accessToken: 'a-token',
+    });
+
+    await shopify.registerWebhooks({session});
+
+    expect(register).toHaveBeenCalledWith({session});
   });
 });

--- a/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -34,6 +34,25 @@ export function ensureInstalled({
         return undefined;
       }
 
+      // Under token exchange the app uses Shopify managed installation, so
+      // whether the app is installed is not a session-storage question: a shop
+      // may have no stored session until the first token exchange. Skip the
+      // storage check, make sure the app is embedded, and let the first
+      // authenticated request mint the session via token exchange.
+      if (config.future?.unstable_tokenExchange) {
+        if (req.query.embedded !== '1') {
+          await embedAppIntoShopify(api, config, req, res, shop);
+          return undefined;
+        }
+
+        addCSPHeader(api, req, res);
+        config.logger.debug(
+          'Token exchange enabled, skipping install check and loading app',
+          {shop},
+        );
+        return next();
+      }
+
       config.logger.debug('Checking if shop has installed the app', {shop});
 
       const sessionId = api.session.getOfflineId(shop);

--- a/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/ensure-installed-on-shop.ts
@@ -39,7 +39,7 @@ export function ensureInstalled({
       // may have no stored session until the first token exchange. Skip the
       // storage check, make sure the app is embedded, and let the first
       // authenticated request mint the session via token exchange.
-      if (config.future?.unstable_tokenExchange) {
+      if (config.future?.tokenExchange) {
         if (req.query.embedded !== '1') {
           await embedAppIntoShopify(api, config, req, res, shop);
           return undefined;

--- a/packages/apps/shopify-app-express/src/middlewares/perform-token-exchange.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/perform-token-exchange.ts
@@ -1,0 +1,155 @@
+import {
+  HttpResponseError,
+  InvalidJwtError,
+  RequestedTokenType,
+  Session,
+  Shopify,
+} from '@shopify/shopify-api';
+import {Request, Response, NextFunction} from 'express';
+
+import {AppConfigInterface} from '../config-types';
+import {WITHIN_MILLISECONDS_OF_EXPIRY} from '../helpers/ensure-offline-token-is-not-expired';
+import {respondToInvalidSessionToken} from '../helpers/respond-to-invalid-session-token';
+import {invalidateAccessToken} from '../helpers/invalidate-access-token';
+
+interface PerformTokenExchangeParams {
+  req: Request;
+  res: Response;
+  next: NextFunction;
+  api: Shopify;
+  config: AppConfigInterface;
+  sessionToken: string;
+}
+
+async function exchangeToken(
+  api: Shopify,
+  config: AppConfigInterface,
+  sessionToken: string,
+  shop: string,
+  requestedTokenType: RequestedTokenType,
+): Promise<Session> {
+  const {session} = await api.auth.tokenExchange({
+    sessionToken,
+    shop,
+    requestedTokenType,
+    expiring: config.future?.expiringOfflineAccessTokens,
+  });
+  return session;
+}
+
+async function callAfterAuthHook(
+  config: AppConfigInterface,
+  session: Session,
+  sessionToken: string,
+): Promise<void> {
+  await config.idempotentPromiseHandler.handlePromise({
+    promiseFunction: async () => {
+      await config.hooks?.afterAuth?.({session});
+    },
+    identifier: sessionToken,
+  });
+}
+
+export async function performTokenExchange({
+  req: _req,
+  res,
+  next,
+  api,
+  config,
+  sessionToken,
+}: PerformTokenExchangeParams): Promise<void> {
+  const logger = config.logger;
+  // Hoisted so the outer catch can invalidate a stale access token if needed.
+  let sessionToInvalidate: Session | undefined;
+
+  try {
+    const payload = await api.session.decodeSessionToken(sessionToken);
+    const shop = new URL(payload.dest).hostname;
+    const sub = payload.sub;
+
+    const sessionId = config.useOnlineTokens
+      ? api.session.getJwtSessionId(shop, sub)
+      : api.session.getOfflineId(shop);
+
+    let session: Session | undefined;
+    try {
+      session = await config.sessionStorage.loadSession(sessionId);
+      sessionToInvalidate = session;
+    } catch (error) {
+      logger.error(`Error when loading session from storage: ${error}`);
+      res.status(500).send('Internal Server Error');
+      return;
+    }
+
+    if (session && session.isActive(undefined, WITHIN_MILLISECONDS_OF_EXPIRY)) {
+      logger.debug('Request is valid, session is active', {shop: session.shop});
+      res.locals.shopify = {...res.locals.shopify, session};
+      next();
+      return;
+    }
+
+    logger.info('No valid session found', {shop});
+    logger.info('Requesting offline access token', {shop});
+
+    const offlineSession = await exchangeToken(
+      api,
+      config,
+      sessionToken,
+      shop,
+      RequestedTokenType.OfflineAccessToken,
+    );
+    await config.sessionStorage.storeSession(offlineSession);
+
+    let newSession = offlineSession;
+
+    if (config.useOnlineTokens) {
+      logger.info('Requesting online access token', {shop});
+      const onlineSession = await exchangeToken(
+        api,
+        config,
+        sessionToken,
+        shop,
+        RequestedTokenType.OnlineAccessToken,
+      );
+      await config.sessionStorage.storeSession(onlineSession);
+      newSession = onlineSession;
+    }
+
+    logger.debug('Request is valid, loaded session from session token', {
+      shop: newSession.shop,
+      isOnline: newSession.isOnline,
+    });
+
+    try {
+      await callAfterAuthHook(config, newSession, sessionToken);
+    } catch (error) {
+      logger.error(`Error in afterAuth hook: ${error}`);
+      res.status(500).send('Internal Server Error');
+      return;
+    }
+
+    res.locals.shopify = {...res.locals.shopify, session: newSession};
+    next();
+  } catch (error) {
+    if (
+      error instanceof InvalidJwtError ||
+      (error instanceof HttpResponseError &&
+        error.response.code === 400 &&
+        error.response.body?.error === 'invalid_subject_token')
+    ) {
+      respondToInvalidSessionToken(res, error.message, true);
+      return;
+    }
+
+    if (error instanceof HttpResponseError && error.response.code === 401) {
+      if (sessionToInvalidate?.accessToken) {
+        await invalidateAccessToken(sessionToInvalidate, config);
+      }
+      respondToInvalidSessionToken(res, error.message);
+      return;
+    }
+
+    logger.error(`Unexpected error during token exchange: ${error}`);
+    res.status(500).send('Internal Server Error');
+  }
+}

--- a/packages/apps/shopify-app-express/src/middlewares/perform-token-exchange.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/perform-token-exchange.ts
@@ -51,7 +51,7 @@ async function callAfterAuthHook(
 }
 
 export async function performTokenExchange({
-  req: _req,
+  req,
   res,
   next,
   api,
@@ -137,7 +137,13 @@ export async function performTokenExchange({
         error.response.code === 400 &&
         error.response.body?.error === 'invalid_subject_token')
     ) {
-      respondToInvalidSessionToken(res, error.message, true);
+      respondToInvalidSessionToken({
+        api,
+        req,
+        res,
+        message: error.message,
+        retryRequest: true,
+      });
       return;
     }
 
@@ -145,7 +151,12 @@ export async function performTokenExchange({
       if (sessionToInvalidate?.accessToken) {
         await invalidateAccessToken(sessionToInvalidate, config);
       }
-      respondToInvalidSessionToken(res, error.message);
+      respondToInvalidSessionToken({
+        api,
+        req,
+        res,
+        message: error.message,
+      });
       return;
     }
 

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -5,9 +5,12 @@ import {redirectToAuth} from '../redirect-to-auth';
 import {ApiAndConfigParams} from '../types';
 import {redirectOutOfApp} from '../redirect-out-of-app';
 import {ensureOfflineTokenIsNotExpired} from '../helpers/index';
+import {getSessionToken} from '../helpers/get-session-token';
+import {respondToInvalidSessionToken} from '../helpers/respond-to-invalid-session-token';
 
 import {ValidateAuthenticatedSessionMiddleware} from './types';
 import {hasValidAccessToken} from './has-valid-access-token';
+import {performTokenExchange} from './perform-token-exchange';
 
 type validateAuthenticatedSessionParams = ApiAndConfigParams;
 
@@ -19,127 +22,156 @@ export function validateAuthenticatedSession({
     return async (req: Request, res: Response, next: NextFunction) => {
       config.logger.debug('Running validateAuthenticatedSession');
 
-      let sessionId: string | undefined;
+      // One branch, up front: embedded apps that opted into token exchange use
+      // it; everything else uses the legacy OAuth code flow. The two paths are
+      // fully independent below.
+      const useTokenExchange =
+        config.future?.unstable_tokenExchange && api.config.isEmbeddedApp;
+
+      if (useTokenExchange) {
+        return validateWithTokenExchange({req, res, next, api, config});
+      }
+
+      return validateWithAuthCodeFlow({req, res, next, api, config});
+    };
+  };
+}
+
+interface StrategyParams extends ApiAndConfigParams {
+  req: Request;
+  res: Response;
+  next: NextFunction;
+}
+
+async function validateWithTokenExchange({
+  req,
+  res,
+  next,
+  api,
+  config,
+}: StrategyParams): Promise<void> {
+  const sessionToken = getSessionToken(req);
+
+  if (!sessionToken) {
+    config.logger.debug('No session token found for token exchange');
+    respondToInvalidSessionToken(res, 'No session token found', true);
+    return;
+  }
+
+  await performTokenExchange({req, res, next, api, config, sessionToken});
+}
+
+async function validateWithAuthCodeFlow({
+  req,
+  res,
+  next,
+  api,
+  config,
+}: StrategyParams): Promise<unknown> {
+  let sessionId: string | undefined;
+  try {
+    sessionId = await api.session.getCurrentId({
+      isOnline: config.useOnlineTokens,
+      rawRequest: req,
+      rawResponse: res,
+    });
+  } catch (error) {
+    config.logger.error(`Error when loading session from storage: ${error}`);
+
+    handleSessionError(req, res, error);
+    return undefined;
+  }
+
+  let session: Session | undefined;
+  if (sessionId) {
+    try {
+      session = await config.sessionStorage.loadSession(sessionId);
+    } catch (error) {
+      config.logger.error(`Error when loading session from storage: ${error}`);
+
+      res.status(500);
+      res.send(error.message);
+      return undefined;
+    }
+  }
+
+  let shop = api.utils.sanitizeShop(req.query.shop as string) || session?.shop;
+
+  if (
+    session &&
+    !config.useOnlineTokens &&
+    config.future?.expiringOfflineAccessTokens
+  ) {
+    try {
+      session = await ensureOfflineTokenIsNotExpired({api, config}, session);
+    } catch (error) {
+      config.logger.error(`Failed to refresh offline access token: ${error}`, {
+        shop: session.shop,
+      });
+    }
+  }
+
+  if (session && shop && session.shop !== shop) {
+    config.logger.debug('Found a session for a different shop in the request', {
+      currentShop: session.shop,
+      requestShop: shop,
+    });
+
+    return redirectToAuth({req, res, api, config});
+  }
+
+  if (session) {
+    config.logger.debug('Request session found and loaded', {
+      shop: session.shop,
+    });
+
+    if (session.isActive(api.config.scopes)) {
+      config.logger.debug('Request session exists and is active', {
+        shop: session.shop,
+      });
+
+      let hasValidToken: boolean;
       try {
-        sessionId = await api.session.getCurrentId({
-          isOnline: config.useOnlineTokens,
-          rawRequest: req,
-          rawResponse: res,
-        });
+        hasValidToken = await hasValidAccessToken(api, session);
       } catch (error) {
-        config.logger.error(
-          `Error when loading session from storage: ${error}`,
-        );
-
-        handleSessionError(req, res, error);
-        return undefined;
+        config.logger.error(`Could not check if session was valid: ${error}`, {
+          shop: session.shop,
+        });
+        hasValidToken = false;
       }
 
-      let session: Session | undefined;
-      if (sessionId) {
-        try {
-          session = await config.sessionStorage.loadSession(sessionId);
-        } catch (error) {
-          config.logger.error(
-            `Error when loading session from storage: ${error}`,
-          );
-
-          res.status(500);
-          res.send(error.message);
-          return undefined;
-        }
-      }
-
-      let shop =
-        api.utils.sanitizeShop(req.query.shop as string) || session?.shop;
-
-      if (
-        session &&
-        !config.useOnlineTokens &&
-        config.future?.expiringOfflineAccessTokens
-      ) {
-        try {
-          session = await ensureOfflineTokenIsNotExpired(
-            {api, config},
-            session,
-          );
-        } catch (error) {
-          config.logger.error(
-            `Failed to refresh offline access token: ${error}`,
-            {shop: session.shop},
-          );
-        }
-      }
-
-      if (session && shop && session.shop !== shop) {
-        config.logger.debug(
-          'Found a session for a different shop in the request',
-          {currentShop: session.shop, requestShop: shop},
-        );
-
-        return redirectToAuth({req, res, api, config});
-      }
-
-      if (session) {
-        config.logger.debug('Request session found and loaded', {
+      if (hasValidToken) {
+        config.logger.debug('Request session has a valid access token', {
           shop: session.shop,
         });
 
-        if (session.isActive(api.config.scopes)) {
-          config.logger.debug('Request session exists and is active', {
-            shop: session.shop,
-          });
-
-          let hasValidToken: boolean;
-          try {
-            hasValidToken = await hasValidAccessToken(api, session);
-          } catch (error) {
-            config.logger.error(
-              `Could not check if session was valid: ${error}`,
-              {shop: session.shop},
-            );
-            hasValidToken = false;
-          }
-
-          if (hasValidToken) {
-            config.logger.debug('Request session has a valid access token', {
-              shop: session.shop,
-            });
-
-            res.locals.shopify = {
-              ...res.locals.shopify,
-              session,
-            };
-            return next();
-          }
-        }
+        res.locals.shopify = {
+          ...res.locals.shopify,
+          session,
+        };
+        return next();
       }
+    }
+  }
 
-      const bearerPresent = req.headers.authorization?.match(/Bearer (.*)/);
-      if (bearerPresent) {
-        if (!shop) {
-          shop = await setShopFromSessionOrToken(
-            api,
-            session,
-            bearerPresent[1],
-          );
-        }
-      }
+  const bearerPresent = req.headers.authorization?.match(/Bearer (.*)/);
+  if (bearerPresent) {
+    if (!shop) {
+      shop = await setShopFromSessionOrToken(api, session, bearerPresent[1]);
+    }
+  }
 
-      const redirectUri = `${config.auth.path}?shop=${shop}`;
-      config.logger.info(
-        `Session was not valid. Redirecting to ${redirectUri}`,
-        {shop},
-      );
+  const redirectUri = `${config.auth.path}?shop=${shop}`;
+  config.logger.info(`Session was not valid. Redirecting to ${redirectUri}`, {
+    shop,
+  });
 
-      return redirectOutOfApp({api, config})({
-        req,
-        res,
-        redirectUri,
-        shop: shop!,
-      });
-    };
-  };
+  return redirectOutOfApp({api, config})({
+    req,
+    res,
+    redirectUri,
+    shop: shop!,
+  });
 }
 
 function handleSessionError(_req: Request, res: Response, error: Error) {

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -23,10 +23,10 @@ export function validateAuthenticatedSession({
       config.logger.debug('Running validateAuthenticatedSession');
 
       // One branch, up front: embedded apps that opted into token exchange use
-      // it; everything else uses the legacy OAuth code flow. The two paths are
+      // it; everything else uses the legacy Auth Code flow. The two paths are
       // fully independent below.
       const useTokenExchange =
-        config.future?.unstable_tokenExchange && api.config.isEmbeddedApp;
+        config.future?.tokenExchange && api.config.isEmbeddedApp;
 
       if (useTokenExchange) {
         return validateWithTokenExchange({req, res, next, api, config});

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -54,7 +54,13 @@ async function validateWithTokenExchange({
 
   if (!sessionToken) {
     config.logger.debug('No session token found for token exchange');
-    respondToInvalidSessionToken(res, 'No session token found', true);
+    respondToInvalidSessionToken({
+      api,
+      req,
+      res,
+      message: 'No session token found',
+      retryRequest: true,
+    });
     return;
   }
 

--- a/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
+++ b/packages/apps/shopify-app-express/src/middlewares/validate-authenticated-session.ts
@@ -53,13 +53,15 @@ async function validateWithTokenExchange({
   const sessionToken = getSessionToken(req);
 
   if (!sessionToken) {
+    // No session token means no Authorization header, so this is always a
+    // document request and respondToInvalidSessionToken serves the App Bridge
+    // bounce (retryRequest only applies to fetch requests).
     config.logger.debug('No session token found for token exchange');
     respondToInvalidSessionToken({
       api,
       req,
       res,
       message: 'No session token found',
-      retryRequest: true,
     });
     return;
   }


### PR DESCRIPTION
### WHY are these changes introduced?

Adds token exchange authentication to `shopify-app-express`, bringing it to parity with Remix/React Router. Token exchange lets embedded apps get access tokens without the OAuth redirect flicker, and it's the path needed as expiring offline tokens become mandatory (Jan 1 2027).

Builds on the original work by @mrmarufpro in #3097 (thank you), reworked per review and layered on top of the expiring-offline-token support merged in #3343.

### WHAT is this pull request doing?

Behind the `unstable_tokenExchange` future flag (off by default):

- **Strategy selection, one branch up front.** `validateAuthenticatedSession` decides once: flag on + `isEmbeddedApp` → token exchange; otherwise → the legacy OAuth code flow. The two paths are separate functions.
- **Token exchange middleware**: swaps the session token for an access token (offline, plus online when `useOnlineTokens`), stores it, runs `afterAuth` once (idempotent under concurrency), and handles invalid/revoked tokens.
- **Request-type parity with React Router**: document requests (page loads) with a missing/stale token render the App Bridge shim to fetch a fresh token and reload; fetch requests get a 401 with the retry header only when a retry would help.
- **`hooks.afterAuth`** config option, fired on both the token-exchange and OAuth callback paths.
- **`shopify.registerWebhooks({session})`** helper, since token exchange skips the OAuth callback that registered webhooks.
- **`ensureInstalledOnShop` is token-exchange aware**: under managed installation, install state is not a session-storage question, so when the flag is on it skips the storage check, embeds the app, and lets the first authenticated request mint the session. This avoids a dead-end on a fresh shop (no session yet) where the page load would otherwise redirect into the guarded OAuth routes.
- **OAuth routes guarded**: `auth.begin()` / `auth.callback()` return a clear error when token exchange is active.
- **Startup log** advertising the `unstable_tokenExchange` and `expiringOfflineAccessTokens` flags.
- Reuses the merged expiring-offline-token module's `WITHIN_MILLISECONDS_OF_EXPIRY` constant. Note: the token-exchange path re-exchanges rather than calling the refresh-token helper, so it does not duplicate the expiring-token refresh logic.

### Tests

- Token-exchange middleware tests: valid token → exchange + store + `afterAuth`; invalid token on a fetch request → 401 + retry header; invalid token on a document request → App Bridge bounce; no token exchange when not embedded or flag off.
- All existing tests pass (105 total).

### End-to-end testing

Verified live on a real dev store (`suli-store`) with this branch's build linked into the Node template, across the full embedded/non-embedded x token-exchange/OAuth x online/offline x expiring matrix:

| # | Config | Result |
| --- | --- | --- |
| 1 | embedded, token exchange, offline | token exchange runs, no OAuth redirect, `{"count":18}` from Admin GraphQL |
| 2 | embedded, OAuth, offline | OAuth code flow, renders in admin |
| 3 | embedded, token exchange, online | two exchanges (offline + online), online session |
| 4 | embedded, OAuth, online | two OAuth passes, online session |
| 5 | embedded, token exchange, offline + expiring | refresh token saved (confirmed via storage read-back) |
| 6 | embedded, OAuth, offline + expiring | refresh token saved |
| 7 | non-embedded, OAuth, offline | renders outside admin, Admin GraphQL works |
| 8 | non-embedded, OAuth, online | online session, works |
| 9 | non-embedded, OAuth, offline + expiring | refresh token saved (confirmed via storage read-back) |
| 10 | non-embedded, token exchange on | throws at startup with explicit message (`unstable_tokenExchange requires an embedded app`) |
| 11 | any, hit `/api/auth` while token exchange on | returns a clear error (OAuth routes not used under token exchange) |

Confirmed:
- Token exchange only runs for embedded apps; non-embedded falls back to OAuth, and non-embedded + token exchange throws with explicit feedback.
- Expiring offline tokens store a refresh token on both the token-exchange and OAuth paths (embedded and non-embedded), verified by reading the session back from storage (`hasRefreshToken: true`, `refreshTokenExpires` set).
- Token exchange loads with no OAuth redirect/flicker; the exchanged token makes real Admin GraphQL calls.
- Plus 107 automated tests and green CI.


### Type of change

- [x] Minor: New feature (non-breaking, off by default)

### Checklist

- [x] Changeset added (credits @mrmarufpro)
- [x] Tests for the token-exchange path
- [x] Docs (reference + token-exchange guide)


