### PR TITLE
Require Node.js 22 or later

### DIFF
--- a/.changeset/bright-cats-smile.md
+++ b/.changeset/bright-cats-smile.md
@@ -1,0 +1,10 @@
+---
+'@shopify/api-codegen-preset': major
+'@shopify/shopify-app-session-storage-mongodb': major
+'@shopify/shopify-api': major
+'@shopify/shopify-app-express': major
+'@shopify/shopify-app-react-router': major
+'@shopify/shopify-app-remix': major
+---
+
+Require Node.js 22 or later. Node.js 20 is no longer supported. Upgrade your runtime to Node.js 22 or newer before updating.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20.x
+          node-version: 22.x
 
       - name: Check for Changeset
         run: npx @changesets/cli status --since="origin/main"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           cache: 'pnpm'
-          node-version: 20
+          node-version: 22
 
       - name: Install
         run: pnpm install --frozen-lockfile
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.10.0, 22, 24]
+        version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.10.0, 22, 24]
+        version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [20.10.0, 22, 24]
+        version: [22, 24]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0

--- a/.github/workflows/publish-experimental-build.yml
+++ b/.github/workflows/publish-experimental-build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ type: node
 
 up:
   - node:
-      version: v20.10.0
+      version: v22.0.0
       package_manager: pnpm@10.16.1
       packages:
         - .

--- a/packages/api-clients/api-codegen-preset/package.json
+++ b/packages/api-clients/api-codegen-preset/package.json
@@ -5,7 +5,7 @@
   "author": "Shopify",
   "license": "MIT",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "homepage": "https://github.com/Shopify/shopify-app-js/tree/main/packages/api-clients/api-codegen-preset#readme",
   "repository": {

--- a/packages/apps/session-storage/shopify-app-session-storage-mongodb/package.json
+++ b/packages/apps/session-storage/shopify-app-session-storage-mongodb/package.json
@@ -14,7 +14,7 @@
   "author": "Shopify Inc.",
   "license": "MIT",
   "engines": {
-    "node": ">=20.19.0"
+    "node": ">=22.0.0"
   },
   "main": "./dist/cjs/mongodb.js",
   "module": "./dist/esm/mongodb.mjs",

--- a/packages/apps/shopify-api/adapters/__e2etests__/node-localhost-fetch.ts
+++ b/packages/apps/shopify-api/adapters/__e2etests__/node-localhost-fetch.ts
@@ -4,7 +4,7 @@ import type {OutgoingHttpHeaders} from 'http';
 
 /**
  * A fetch replacement that uses Node's http/https modules for localhost requests
- * to work around Node v20 fetch localhost issues.
+ * because built-in fetch rejects the test server's port (6666) as unsafe.
  * Real apps would not encounter these issues since real apps don't make localhost requests.
  * They request to Shopify instead, which isn't running on localhost.
  * In our E2E tests we make requests to localhost to simulate Shopify.

--- a/packages/apps/shopify-api/package.json
+++ b/packages/apps/shopify-api/package.json
@@ -6,7 +6,7 @@
   "module": "./dist/esm/lib/index.mjs",
   "main": "./dist/cjs/lib/index.js",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "exports": {
     ".": {

--- a/packages/apps/shopify-app-express/package.json
+++ b/packages/apps/shopify-app-express/package.json
@@ -3,7 +3,7 @@
   "version": "7.0.1",
   "description": "Shopify Express Middleware - to simplify the building of Shopify Apps with Express",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/apps/shopify-app-react-router/package.json
+++ b/packages/apps/shopify-app-react-router/package.json
@@ -3,7 +3,7 @@
   "name": "@shopify/shopify-app-react-router",
   "version": "1.2.1",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/apps/shopify-app-remix/package.json
+++ b/packages/apps/shopify-app-remix/package.json
@@ -3,7 +3,7 @@
   "version": "4.2.1",
   "description": "Shopify Remix - to simplify the building of Shopify Apps with Remix",
   "engines": {
-    "node": ">=20.10.0"
+    "node": ">=22.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- raise the minimum supported Node.js version to 22 for every published package that currently declares a Node 20 engine requirement
- remove Node 20 from the test matrix and move lint, changelog, experimental publishing, and local development setup to Node 22
- add a major changeset that calls out the required runtime upgrade
- clarify why the Node adapter E2E tests still need their localhost fetch helper

## Breaking change

Node.js 20 is no longer supported by the affected packages. Consumers must upgrade to Node.js 22 or newer before updating.

## Validation

- `pnpm lint` on Node.js 22.22.0
- `pnpm prettier`
- `pnpm build` on Node.js 22.2.0 (20/20 tasks)
- `pnpm test:ci` on Node.js 22.2.0 (8/8 tasks, including adapter E2E tests)
- `pnpm changeset status` on Node.js 22.22.0
- JSON/YAML syntax checks and `git diff --check`

The full local session-storage integration suite requires Podman, which was unavailable locally; those jobs remain covered by CI.

## Repository configuration follow-up

The `main` branch currently requires these Node 20 check contexts, but this PR intentionally stops creating them:

- `Test_ApiClients_Node_20.10.0`
- `Test_App_Packages_Node_20.10.0`
- `Test_Session_Storage_Node_20.10.0`

These required checks need to be removed from branch protection when this change lands. The existing Node 22 and Node 24 required check names are preserved.
