### PR TITLE
Test supported packages on Node.js 26

### DIFF
--- a/.changeset/node-26-ci.md
+++ b/.changeset/node-26-ci.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test supported packages on Node.js 26.

--- a/.changeset/node-26-ci.md
+++ b/.changeset/node-26-ci.md
@@ -1,4 +1,0 @@
----
----
-
-Test supported packages on Node.js 26.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [22, 24]
+        version: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [22, 24]
+        version: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: [22, 24]
+        version: [22, 24, 26]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0


### PR DESCRIPTION
## Summary

- add Node.js 26 to the API client, app package, and session-storage CI matrices
- retain Node.js 22 and 24 coverage

This restores the three-version test matrix after Node.js 20 support was removed.

## Validation

Run locally on Node.js 26.1.0:

- `pnpm lint`
- `pnpm build` (20/20 tasks)
- `pnpm test:ci` (8/8 tasks, including adapter E2E tests)
- workflow YAML parsing and `git diff --check`

The full session-storage integration suite, including the Node.js 26 matrix job, passed in CI.

## Repository configuration follow-up

Add these required branch-protection contexts:

- `Test_ApiClients_Node_26`
- `Test_App_Packages_Node_26`
- `Test_Session_Storage_Node_26`
