### PR TITLE
Fix 500 responses from authenticate.webhook when refreshing an expired offline token fails

### DIFF
--- a/.changeset/webhook-refresh-failure.md
+++ b/.changeset/webhook-refresh-failure.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-remix': patch
+---
+
+Deliver webhooks without a session instead of responding with a 500 when refreshing an expired offline access token fails. With the `expiringOfflineAccessTokens` future flag enabled, the stored offline token is typically expired by the time `APP_UNINSTALLED` or the mandatory GDPR webhooks arrive, and Shopify rejects the refresh attempt because the app is no longer installed — so `authenticate.webhook` threw a 500 and Shopify kept retrying the delivery indefinitely.

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/__tests__/authenticate.test.ts
@@ -10,6 +10,8 @@ import {
   expectTokenRefresh,
   getHmac,
   getThrownResponse,
+  mockExternalRequest,
+  setUpValidSession,
   testConfig,
 } from '../../../__test-helpers';
 import {TestOverridesArg} from '../../../test-helpers/test-config';
@@ -242,6 +244,51 @@ describe('Webhook validation', () => {
 
       // THEN
       expect(response.status).toBe(401);
+    });
+  });
+
+  describe('Offline token refresh failures', () => {
+    it('returns a context without a session when refreshing the expired token fails', async () => {
+      // GIVEN
+      const sessionStorage = new MemorySessionStorage();
+      const oneSecondAgo = new Date(Date.now() - 1000);
+      const thirtyDaysFromNow = new Date(Date.now() + 1000 * 3600 * 24 * 30);
+
+      await setUpValidSession(sessionStorage, {
+        expires: oneSecondAgo,
+        refreshToken: 'test-refresh-token',
+        refreshTokenExpires: thirtyDaysFromNow,
+      });
+
+      const shopify = shopifyApp(testConfig({sessionStorage}));
+
+      // After an uninstall Shopify rejects the refresh request
+      await mockExternalRequest({
+        request: new Request(`https://${TEST_SHOP}/admin/oauth/access_token`, {
+          method: 'POST',
+        }),
+        response: new Response(undefined, {status: 401}),
+      });
+
+      const body = {some: 'data'};
+      const bodyString = JSON.stringify(body);
+
+      // WHEN
+      const {session, admin, shop, topic, payload} =
+        await shopify.authenticate.webhook(
+          new Request(`${APP_URL}/webhooks`, {
+            method: 'POST',
+            body: bodyString,
+            headers: webhookHeaders(bodyString),
+          }),
+        );
+
+      // THEN
+      expect(session).toBeUndefined();
+      expect(admin).toBeUndefined();
+      expect(shop).toBe(TEST_SHOP);
+      expect(topic).toBe('APP_UNINSTALLED');
+      expect(payload).toEqual(body);
     });
   });
 

--- a/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
+++ b/packages/apps/shopify-app-remix/src/server/authenticate/webhooks/authenticate.ts
@@ -1,4 +1,8 @@
-import {WebhookValidationErrorReason, WebhookType} from '@shopify/shopify-api';
+import {
+  Session,
+  WebhookValidationErrorReason,
+  WebhookType,
+} from '@shopify/shopify-api';
 
 import type {BasicParams} from '../../types';
 import {adminClientFactory} from '../../clients';
@@ -49,7 +53,26 @@ export function authenticateWebhookFactory<Topics extends string>(
         throw new Response(undefined, {status: 400, statusText: 'Bad Request'});
       }
     }
-    const session = await ensureValidOfflineSession(params, check.domain);
+    let session: Session | undefined;
+    try {
+      session = await ensureValidOfflineSession(params, check.domain);
+    } catch (error) {
+      // Refreshing an expired offline token can fail after the merchant
+      // uninstalls the app, since Shopify rejects the refresh request. The
+      // HMAC has already been validated at this point and webhook contexts
+      // support a missing session, so deliver the webhook without one rather
+      // than responding with a 500 — that would make Shopify retry mandatory
+      // webhooks (e.g. APP_UNINSTALLED, GDPR topics) indefinitely.
+      if (error instanceof Response) {
+        logger.debug(
+          'Failed to load a valid offline session for webhook request, continuing without a session',
+          {shop: check.domain, topic: check.topic},
+        );
+        session = undefined;
+      } else {
+        throw error;
+      }
+    }
 
     let webhookContext: WebhookContextWithoutSession<Topics>;
 


### PR DESCRIPTION
### WHY are these changes introduced?

With the `expiringOfflineAccessTokens` future flag enabled, `authenticate.webhook` calls `ensureValidOfflineSession`, which attempts to refresh the stored offline token when it is expired. After a merchant uninstalls the app the stored token is typically expired by the time `APP_UNINSTALLED` (and later the mandatory GDPR webhooks) arrive, and Shopify rejects the refresh request because the app is no longer installed. The `refreshToken` helper then throws `Response(500)`, so the webhook delivery fails — silently, since thrown `Response`s are not logged — and Shopify keeps retrying it indefinitely. The app never gets a chance to run its uninstall cleanup, and every retry repeats the doomed refresh request.

Observed in production: every `app/uninstalled` delivery for a shop whose offline token had expired responded 500 on retry, forever, including for app-review stores.

### WHAT is this pull request doing?

At the point where the session is loaded, the request's HMAC has already been validated, and webhook contexts explicitly support a missing session ("webhooks can arrive after the app was uninstalled"). So `authenticate.webhook` now catches the `Response` thrown by the session refresh, logs a debug message, and delivers the webhook with `session: undefined` instead of failing the delivery. Non-`Response` errors (e.g. session storage failures) still propagate so those deliveries are retried.

Includes a regression test covering an expired offline session whose refresh request is rejected by Shopify, and a changeset.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [ ] I have documented new APIs/updated the documentation for modified APIs (for public APIs)