### PR TITLE
Fix Retry-After delay parsing

### DIFF
--- a/.changeset/calm-clocks-wait.md
+++ b/.changeset/calm-clocks-wait.md
@@ -1,0 +1,5 @@
+---
+'@shopify/graphql-client': patch
+---
+
+Handle `Retry-After` seconds and HTTP-date delays correctly when retrying requests.

--- a/packages/api-clients/admin-api-client/src/rest/tests/client.test.ts
+++ b/packages/api-clients/admin-api-client/src/rest/tests/client.test.ts
@@ -482,17 +482,16 @@ describe('REST Admin API Client', () => {
     });
 
     it('waits for the amount of time defined by the Retry-After header', async () => {
-      // Default to 10 seconds to ensure the test will timeout if this fails
-      (constants as any).DEFAULT_RETRY_WAIT_TIME = 10000;
-
       // GIVEN
+      jest
+        .spyOn(global, 'setTimeout')
+        .mockImplementation(jest.fn((resolve) => resolve() as any));
       const client = createAdminRestApiClient(config);
 
-      const realWaitTime = 0.05;
       const errorResponse = new Response('Something went wrong!', {
         status: 503,
         statusText: 'Did not work',
-        headers: {'Retry-After': realWaitTime.toString()},
+        headers: {'Retry-After': '0.05'},
       });
 
       fetchMock.mockResolvedValue(errorResponse);
@@ -503,6 +502,8 @@ describe('REST Admin API Client', () => {
       // THEN
       expect(response.status).toBe(503);
       expect(fetch).toHaveBeenCalledTimes(2);
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), 50);
       await assertRequest({
         request: new Request(apiUrl('/url/path'), {method: 'GET', headers}),
       });

--- a/packages/api-clients/graphql-client/src/graphql-client/http-fetch.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/http-fetch.ts
@@ -2,6 +2,8 @@ import {CLIENT, RETRIABLE_STATUS_CODES, RETRY_WAIT_TIME} from './constants';
 import {CustomFetchApi, GraphQLClient, Logger} from './types';
 import {formatErrorMessage, getErrorMessage} from './utilities';
 
+const MAX_TIMER_DELAY_MS = 2_147_483_647;
+
 interface GenerateHttpFetchOptions {
   clientLogger: Logger;
   customFetchApi?: CustomFetchApi;
@@ -61,9 +63,7 @@ export function generateHttpFetch({
     } catch (error) {
       if (nextCount <= maxTries) {
         const retryAfter = response?.headers.get('Retry-After');
-        await sleep(
-          retryAfter ? parseInt(retryAfter, 10) : defaultRetryWaitTime,
-        );
+        await sleep(parseRetryAfter(retryAfter, defaultRetryWaitTime));
 
         clientLogger({
           type: 'HTTP-Retry',
@@ -92,6 +92,38 @@ export function generateHttpFetch({
   };
 
   return httpFetch;
+}
+
+function parseRetryAfter(
+  retryAfter: string | null | undefined,
+  defaultRetryWaitTime: number,
+): number {
+  const value = retryAfter?.trim();
+  if (!value) {
+    return defaultRetryWaitTime;
+  }
+
+  // RFC Retry-After delay-seconds are integers, but Shopify APIs can return
+  // fractional seconds, so accept them for compatibility.
+  if (/^(?:\d+(?:\.\d+)?|\.\d+)$/.test(value)) {
+    const delay = Math.ceil(Number(value) * 1_000);
+    return Math.min(delay, MAX_TIMER_DELAY_MS);
+  }
+
+  if (!Number.isNaN(Number(value))) {
+    return defaultRetryWaitTime;
+  }
+
+  if (!/[a-z]/i.test(value)) {
+    return defaultRetryWaitTime;
+  }
+
+  const date = Date.parse(value);
+  if (Number.isNaN(date)) {
+    return defaultRetryWaitTime;
+  }
+
+  return Math.min(Math.max(date - Date.now(), 0), MAX_TIMER_DELAY_MS);
 }
 
 async function sleep(waitTime: number): Promise<void> {

--- a/packages/api-clients/graphql-client/src/graphql-client/tests/http-fetch.test.ts
+++ b/packages/api-clients/graphql-client/src/graphql-client/tests/http-fetch.test.ts
@@ -426,6 +426,91 @@ describe('httpFetch utility', () => {
             }),
           });
 
+          describe('Retry-After header', () => {
+            const now = Date.parse('Wed, 21 Oct 2015 07:27:00 GMT');
+
+            beforeEach(() => {
+              jest.spyOn(Date, 'now').mockReturnValue(now);
+            });
+
+            it.each([
+              {
+                description: 'converts numeric seconds to milliseconds',
+                retryAfter: '60',
+                expectedDelay: 60_000,
+              },
+              {
+                description: 'supports fractional numeric seconds',
+                retryAfter: '0.05',
+                expectedDelay: 50,
+              },
+              {
+                description: 'supports leading-dot fractional numeric seconds',
+                retryAfter: '.05',
+                expectedDelay: 50,
+              },
+              {
+                description: 'allows zero numeric seconds',
+                retryAfter: '0',
+                expectedDelay: 0,
+              },
+              {
+                description: 'uses the exact delay for a future HTTP-date',
+                retryAfter: 'Wed, 21 Oct 2015 07:28:00 GMT',
+                expectedDelay: 60_000,
+              },
+              {
+                description: 'does not delay for a past HTTP-date',
+                retryAfter: 'Wed, 21 Oct 2015 07:26:00 GMT',
+                expectedDelay: 0,
+              },
+              {
+                description: 'uses the default for a malformed value',
+                retryAfter: 'not a date',
+                expectedDelay: 1_000,
+              },
+              {
+                description:
+                  'uses the default for malformed numeric punctuation',
+                retryAfter: '1.2.3',
+                expectedDelay: 1_000,
+              },
+              {
+                description: 'uses the default for a negative value',
+                retryAfter: '-1',
+                expectedDelay: 1_000,
+              },
+              {
+                description: 'clamps a huge numeric value',
+                retryAfter: '9'.repeat(400),
+                expectedDelay: 2_147_483_647,
+              },
+              {
+                description: 'clamps a far-future HTTP-date',
+                retryAfter: 'Fri, 31 Dec 9999 23:59:59 GMT',
+                expectedDelay: 2_147_483_647,
+              },
+            ])('$description', async ({retryAfter, expectedDelay}) => {
+              const responseWithRetryAfter = new Response(JSON.stringify({}), {
+                status,
+                headers: new Headers({
+                  'Content-Type': 'application/json',
+                  'Retry-After': retryAfter,
+                }),
+              });
+              fetchMock.mockResolvedValue(responseWithRetryAfter);
+
+              const response = await httpFetch([operation], 1, 1);
+
+              expect(response.status).toBe(status);
+              expect(setTimeout).toHaveBeenCalledTimes(1);
+              expect(setTimeout).toHaveBeenCalledWith(
+                expect.any(Function),
+                expectedDelay,
+              );
+            });
+          });
+
           it('calls the global fetch 1 time and returns the failed http response when the client default retries value is 0', async () => {
             fetchMock.mockResolvedValue(mockedFailedResponse);
             const response = await httpFetch([operation], 1, 0);


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes #3364

`Retry-After` numeric values are expressed in seconds, but the shared retry helper passed them directly to millisecond-based `setTimeout`. This caused retries to run roughly 1,000 times too early. HTTP-date values also became `NaN` and retried almost immediately.

### WHAT is this pull request doing?

- Converts numeric `Retry-After` values, including fractional Shopify values, from seconds to milliseconds.
- Supports HTTP-date delays and falls back to the existing retry delay for malformed values.
- Caps parsed delays at the maximum safe JavaScript timer value to avoid overflow into an immediate retry.
- Adds deterministic shared-client and Admin REST regression coverage.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (no public API changes)

## Verification

- API-client build and test suites
- GraphQL and Admin API client typechecks
- Shopify API Admin/Storefront client tests
- Prettier and `git diff --check`
