### PR TITLE
Redact OAuth credentials from HTTP debug logs

### DIFF
--- a/.changeset/redact-credentials-from-debug-logs.md
+++ b/.changeset/redact-credentials-from-debug-logs.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': patch
+---
+
+Redact OAuth credentials from HTTP debug logs. The request body of OAuth token endpoint calls is no longer written to the debug log, and credential headers (`Authorization`, `Cookie`, `Set-Cookie`, `X-Shopify-Access-Token`, `Shopify-Storefront-Private-Token`, `X-Shopify-Storefront-Access-Token`) are replaced with `****` in API client debug logs.

--- a/packages/apps/shopify-api/docs/guides/logger.md
+++ b/packages/apps/shopify-api/docs/guides/logger.md
@@ -97,11 +97,13 @@ const shopify = shopifyApi({
 This will result in messages like the following examples being logged.
 
 ```text
-[shopify-api/DEBUG] Making HTTP request  -  GET https://my-test-shop.myshopify.com/admin/api/2026-01/products/count.json  -  Headers: {"X-Shopify-Access-Token":["a-really-fake-example-access-token"],"User-Agent":["Shopify API Library v6.0.0 | Node v18.7.0"]}
+[shopify-api/DEBUG] Making HTTP request  -  GET https://my-test-shop.myshopify.com/admin/api/2026-01/products/count.json  -  Headers: {"X-Shopify-Access-Token":["****"],"User-Agent":["Shopify API Library v6.0.0 | Node v18.7.0"]}
 [shopify-api/DEBUG] Completed HTTP request, received 200 OK
 ```
 
 **Note**: Setting `httpRequests: true` will only have effect if the logging level is set to `LogSeverity.Debug`.
+
+**Note**: The library redacts credentials before it writes debug messages. The body of OAuth token endpoint requests is not logged, and credential headers such as `X-Shopify-Access-Token`, `Authorization`, and `Cookie` show `****` instead of their values. Debug logs can still contain other request data, so treat log output as sensitive.
 
 ## Changing the logging function
 

--- a/packages/apps/shopify-api/lib/auth/oauth/__tests__/client-credentials.test.ts
+++ b/packages/apps/shopify-api/lib/auth/oauth/__tests__/client-credentials.test.ts
@@ -3,6 +3,7 @@ import {testConfig} from '../../../__tests__/test-config';
 import {queueMockResponse} from '../../../__tests__/test-helper';
 import * as ShopifyErrors from '../../../error';
 import {DataType} from '../../../clients/types';
+import {LogSeverity} from '../../../types';
 
 describe('clientCredentials', () => {
   const shop = 'test-shop.myshopify.io';
@@ -54,6 +55,33 @@ describe('clientCredentials', () => {
         expectedExpiration,
         1,
       );
+    });
+
+    test('does not log credentials when debug HTTP logging is enabled', async () => {
+      const logFn = jest.fn();
+      const shopify = shopifyApi(
+        testConfig({
+          logger: {log: logFn, level: LogSeverity.Debug, httpRequests: true},
+        }),
+      );
+
+      const successResponse = {
+        access_token: 'some_access_token',
+        scope: 'write_products,read_orders',
+        expires_in: 3600,
+      };
+      queueMockResponse(JSON.stringify(successResponse));
+
+      await shopify.auth.clientCredentials({shop});
+
+      const messages = logFn.mock.calls.map(([_severity, message]) => message);
+      expect(
+        messages.some((message) => message.includes('Making HTTP request')),
+      ).toBe(true);
+      messages.forEach((message) => {
+        expect(message).not.toContain(shopify.config.apiSecretKey);
+        expect(message).not.toContain(successResponse.access_token);
+      });
     });
 
     test('throws error when response is not successful', async () => {

--- a/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
+++ b/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
@@ -348,6 +348,14 @@ describe('clientLoggerFactory', () => {
       },
     });
 
+    function expectNoSecretInAnyDebugCall(secrets: string[]) {
+      expect(mockDebug).toHaveBeenCalledTimes(1);
+      const allLoggedContent = JSON.stringify(mockDebug.mock.calls);
+      secrets.forEach((secret) => {
+        expect(allLoggedContent).not.toContain(secret);
+      });
+    }
+
     it('redacts sensitive headers in tuple-shaped requestParams', () => {
       const loggerFn = clientLoggerFactory(config);
 
@@ -371,13 +379,19 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_secret-admin-token');
+      expectNoSecretInAnyDebugCall(['shpua_secret-admin-token']);
 
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
       const parsed = JSON.parse(loggedParams);
       expect(parsed[1].headers['X-Shopify-Access-Token']).toBe('****');
       expect(parsed[1].headers['Content-Type']).toBe('application/json');
       expect(parsed[1].body).toBe('{"query": "{ shop { name } }"}');
+
+      // The sanitizer must not change the caller's objects.
+      const originalInit = (httpResponseLog.content.requestParams as any)[1];
+      expect(originalInit.headers['X-Shopify-Access-Token']).toBe(
+        'shpua_secret-admin-token',
+      );
     });
 
     it('redacts sensitive headers regardless of case', () => {
@@ -403,11 +417,13 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_lowercase-token');
-      expect(loggedParams).not.toContain('secret-bearer-token');
-      expect(loggedParams).not.toContain('secret-cookie-value');
+      expectNoSecretInAnyDebugCall([
+        'shpua_lowercase-token',
+        'secret-bearer-token',
+        'secret-cookie-value',
+      ]);
 
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
       const parsed = JSON.parse(loggedParams);
       expect(parsed[1].headers['x-shopify-access-token']).toBe('****');
       expect(parsed[1].headers.AUTHORIZATION).toBe('****');
@@ -436,9 +452,10 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpat_private-token');
-      expect(loggedParams).not.toContain('public-storefront-token');
+      expectNoSecretInAnyDebugCall([
+        'shpat_private-token',
+        'public-storefront-token',
+      ]);
     });
 
     it('redacts sensitive headers in object-shaped requestParams', () => {
@@ -461,15 +478,73 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_object-shape-token');
+      expectNoSecretInAnyDebugCall(['shpua_object-shape-token']);
 
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
       const parsed = JSON.parse(loggedParams);
       expect(parsed.headers['X-Shopify-Access-Token']).toBe('****');
       expect(parsed.headers.Accept).toBe('application/json');
     });
 
-    it('redacts sensitive headers passed as a Headers instance', () => {
+    it('redacts sensitive headers with array values', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {
+                'X-Shopify-Access-Token': ['shpua_array-value-token'],
+                'User-Agent': ['test-user-agent'],
+              },
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expectNoSecretInAnyDebugCall(['shpua_array-value-token']);
+
+      const parsed = JSON.parse(mockDebug.mock.calls[0][1].requestParams);
+      expect(parsed[1].headers['X-Shopify-Access-Token']).toBe('****');
+      expect(parsed[1].headers['User-Agent']).toEqual(['test-user-agent']);
+    });
+
+    it('redacts sensitive headers when the object has an entries property', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {
+                entries: 'not-a-function',
+                'X-Shopify-Access-Token': 'shpua_entries-prop-token',
+              },
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      expectNoSecretInAnyDebugCall(['shpua_entries-prop-token']);
+
+      const parsed = JSON.parse(mockDebug.mock.calls[0][1].requestParams);
+      expect(parsed[1].headers['X-Shopify-Access-Token']).toBe('****');
+      expect(parsed[1].headers.entries).toBe('not-a-function');
+    });
+
+    it('keeps request Headers instances opaque in debug logs', () => {
       const loggerFn = clientLoggerFactory(config);
 
       const httpResponseLog: LogContent = {
@@ -481,6 +556,7 @@ describe('clientLoggerFactory', () => {
               method: 'POST',
               headers: new Headers({
                 'X-Shopify-Access-Token': 'shpua_headers-instance-token',
+                'X-API-Key': 'custom-credential-value',
                 'Content-Type': 'application/json',
               }),
             },
@@ -491,10 +567,15 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_headers-instance-token');
-      expect(loggedParams).toContain('****');
-      expect(loggedParams).toContain('application/json');
+      // A Headers instance has no own enumerable properties. It must stay
+      // opaque, so unlisted credential headers do not become visible.
+      expectNoSecretInAnyDebugCall([
+        'shpua_headers-instance-token',
+        'custom-credential-value',
+      ]);
+
+      const parsed = JSON.parse(mockDebug.mock.calls[0][1].requestParams);
+      expect(parsed[1].headers).toEqual({});
     });
 
     it('redacts sensitive headers passed as an array of pairs', () => {
@@ -546,9 +627,39 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpRetryLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_retry-token');
-      expect(loggedParams).toContain('****');
+      expectNoSecretInAnyDebugCall(['shpua_retry-token']);
+      expect(mockDebug.mock.calls[0][1].requestParams).toContain('****');
+    });
+
+    it('redacts sensitive response headers in HTTP-Retry events', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpRetryLog: LogContent = {
+        type: 'HTTP-Retry',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {method: 'POST'},
+          ],
+          retryAttempt: 1,
+          maxRetries: 3,
+          lastResponse: new Response('{}', {
+            status: 429,
+            headers: {
+              'set-cookie': 'session=secret-retry-cookie',
+              'retry-after': '2',
+            },
+          }),
+        },
+      };
+
+      loggerFn(httpRetryLog);
+
+      expectNoSecretInAnyDebugCall(['secret-retry-cookie']);
+
+      const parsed = JSON.parse(mockDebug.mock.calls[0][1].response);
+      expect(parsed.headers['set-cookie']).toBe('****');
+      expect(parsed.headers['retry-after']).toBe('2');
     });
 
     it('redacts sensitive headers in GraphQL deprecation notice events', () => {
@@ -570,9 +681,8 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(graphqlDeprecationLog);
 
-      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
-      expect(loggedParams).not.toContain('shpua_deprecation-token');
-      expect(loggedParams).toContain('****');
+      expectNoSecretInAnyDebugCall(['shpua_deprecation-token']);
+      expect(mockDebug.mock.calls[0][1].requestParams).toContain('****');
     });
 
     it('redacts sensitive response headers', () => {
@@ -597,10 +707,9 @@ describe('clientLoggerFactory', () => {
 
       loggerFn(httpResponseLog);
 
-      const loggedResponse = mockDebug.mock.calls[0][1].response;
-      expect(loggedResponse).not.toContain('secret-session-value');
+      expectNoSecretInAnyDebugCall(['secret-session-value']);
 
-      const parsed = JSON.parse(loggedResponse);
+      const parsed = JSON.parse(mockDebug.mock.calls[0][1].response);
       expect(parsed.headers['set-cookie']).toBe('****');
       expect(parsed.headers['content-type']).toBe('application/json');
     });

--- a/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
+++ b/packages/apps/shopify-api/lib/clients/__tests__/common.test.ts
@@ -341,6 +341,271 @@ describe('clientLoggerFactory', () => {
     });
   });
 
+  describe('credential redaction in debug logs', () => {
+    const config = testConfig({
+      logger: {
+        httpRequests: true,
+      },
+    });
+
+    it('redacts sensitive headers in tuple-shaped requestParams', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {
+                'X-Shopify-Access-Token': 'shpua_secret-admin-token',
+                'Content-Type': 'application/json',
+              },
+              body: '{"query": "{ shop { name } }"}',
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_secret-admin-token');
+
+      const parsed = JSON.parse(loggedParams);
+      expect(parsed[1].headers['X-Shopify-Access-Token']).toBe('****');
+      expect(parsed[1].headers['Content-Type']).toBe('application/json');
+      expect(parsed[1].body).toBe('{"query": "{ shop { name } }"}');
+    });
+
+    it('redacts sensitive headers regardless of case', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {
+                'x-shopify-access-token': 'shpua_lowercase-token',
+                AUTHORIZATION: 'Bearer secret-bearer-token',
+                Cookie: 'session=secret-cookie-value',
+              },
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_lowercase-token');
+      expect(loggedParams).not.toContain('secret-bearer-token');
+      expect(loggedParams).not.toContain('secret-cookie-value');
+
+      const parsed = JSON.parse(loggedParams);
+      expect(parsed[1].headers['x-shopify-access-token']).toBe('****');
+      expect(parsed[1].headers.AUTHORIZATION).toBe('****');
+      expect(parsed[1].headers.Cookie).toBe('****');
+    });
+
+    it('redacts storefront token headers', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {
+                'Shopify-Storefront-Private-Token': 'shpat_private-token',
+                'X-Shopify-Storefront-Access-Token': 'public-storefront-token',
+              },
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpat_private-token');
+      expect(loggedParams).not.toContain('public-storefront-token');
+    });
+
+    it('redacts sensitive headers in object-shaped requestParams', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: {
+            url: 'https://test-shop.myshopify.io/admin/api/2023-10/products.json',
+            method: 'GET',
+            headers: {
+              'X-Shopify-Access-Token': 'shpua_object-shape-token',
+              Accept: 'application/json',
+            },
+          },
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_object-shape-token');
+
+      const parsed = JSON.parse(loggedParams);
+      expect(parsed.headers['X-Shopify-Access-Token']).toBe('****');
+      expect(parsed.headers.Accept).toBe('application/json');
+    });
+
+    it('redacts sensitive headers passed as a Headers instance', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: new Headers({
+                'X-Shopify-Access-Token': 'shpua_headers-instance-token',
+                'Content-Type': 'application/json',
+              }),
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_headers-instance-token');
+      expect(loggedParams).toContain('****');
+      expect(loggedParams).toContain('application/json');
+    });
+
+    it('redacts sensitive headers passed as an array of pairs', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: [
+                ['X-Shopify-Access-Token', 'shpua_array-shape-token'],
+                ['Content-Type', 'application/json'],
+              ],
+            },
+          ],
+          response: new Response('{}', {status: 200}),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_array-shape-token');
+      expect(loggedParams).toContain('****');
+      expect(loggedParams).toContain('application/json');
+    });
+
+    it('redacts sensitive headers in HTTP-Retry events', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpRetryLog: LogContent = {
+        type: 'HTTP-Retry',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {'X-Shopify-Access-Token': 'shpua_retry-token'},
+            },
+          ],
+          retryAttempt: 1,
+          maxRetries: 3,
+          lastResponse: undefined,
+        },
+      };
+
+      loggerFn(httpRetryLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_retry-token');
+      expect(loggedParams).toContain('****');
+    });
+
+    it('redacts sensitive headers in GraphQL deprecation notice events', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const graphqlDeprecationLog: LogContent = {
+        type: 'HTTP-Response-GraphQL-Deprecation-Notice',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {
+              method: 'POST',
+              headers: {'X-Shopify-Access-Token': 'shpua_deprecation-token'},
+            },
+          ],
+          deprecationNotice: 'Field is deprecated',
+        },
+      };
+
+      loggerFn(graphqlDeprecationLog);
+
+      const loggedParams = mockDebug.mock.calls[0][1].requestParams;
+      expect(loggedParams).not.toContain('shpua_deprecation-token');
+      expect(loggedParams).toContain('****');
+    });
+
+    it('redacts sensitive response headers', () => {
+      const loggerFn = clientLoggerFactory(config);
+
+      const httpResponseLog: LogContent = {
+        type: 'HTTP-Response',
+        content: {
+          requestParams: [
+            'https://test-shop.myshopify.io/admin/api/2023-10/graphql.json',
+            {method: 'POST'},
+          ],
+          response: new Response('{}', {
+            status: 200,
+            headers: {
+              'set-cookie': 'session=secret-session-value',
+              'content-type': 'application/json',
+            },
+          }),
+        },
+      };
+
+      loggerFn(httpResponseLog);
+
+      const loggedResponse = mockDebug.mock.calls[0][1].response;
+      expect(loggedResponse).not.toContain('secret-session-value');
+
+      const parsed = JSON.parse(loggedResponse);
+      expect(parsed.headers['set-cookie']).toBe('****');
+      expect(parsed.headers['content-type']).toBe('application/json');
+    });
+  });
+
   describe('when httpRequests logging is disabled', () => {
     const config = testConfig({
       logger: {

--- a/packages/apps/shopify-api/lib/clients/common.ts
+++ b/packages/apps/shopify-api/lib/clients/common.ts
@@ -43,6 +43,9 @@ function sanitizeHeaderValue(name: string, value: unknown): unknown {
     : value;
 }
 
+// Keep the original serialized shape of request headers. A Headers instance
+// has no own enumerable properties, so it stays opaque here, the same as
+// JSON.stringify shows it.
 function sanitizeHeaders(headers: any): any {
   if (!headers || typeof headers !== 'object') {
     return headers;
@@ -56,7 +59,18 @@ function sanitizeHeaders(headers: any): any {
     );
   }
 
-  if (typeof headers.entries === 'function') {
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      sanitizeHeaderValue(name, value),
+    ]),
+  );
+}
+
+// Response headers were always enumerated in the log, so keep that and
+// redact the credential values.
+function sanitizeEnumerableHeaders(headers: any): any {
+  if (typeof headers?.entries === 'function' && !Array.isArray(headers)) {
     return Object.fromEntries(
       [...headers.entries()].map(([name, value]: [string, string]) => [
         name,
@@ -65,12 +79,7 @@ function sanitizeHeaders(headers: any): any {
     );
   }
 
-  return Object.fromEntries(
-    Object.entries(headers).map(([name, value]) => [
-      name,
-      sanitizeHeaderValue(name, value),
-    ]),
-  );
+  return sanitizeHeaders(headers);
 }
 
 function sanitizeRequestParams<T>(requestParams: T): T {
@@ -114,7 +123,7 @@ function serializeResponse(response: Response | any) {
     };
 
     if (headers) {
-      serialized.headers = sanitizeHeaders(headers);
+      serialized.headers = sanitizeEnumerableHeaders(headers);
     }
 
     return serialized;

--- a/packages/apps/shopify-api/lib/clients/common.ts
+++ b/packages/apps/shopify-api/lib/clients/common.ts
@@ -25,6 +25,77 @@ export function getUserAgent(config: ConfigInterface): string {
   return userAgentPrefix;
 }
 
+const REDACTED_LOG_VALUE = '****';
+
+// These headers carry reusable credentials and must not reach the logs.
+const SENSITIVE_LOG_HEADERS = new Set([
+  'authorization',
+  'cookie',
+  'set-cookie',
+  'shopify-storefront-private-token',
+  'x-shopify-access-token',
+  'x-shopify-storefront-access-token',
+]);
+
+function sanitizeHeaderValue(name: string, value: unknown): unknown {
+  return SENSITIVE_LOG_HEADERS.has(name.toLowerCase())
+    ? REDACTED_LOG_VALUE
+    : value;
+}
+
+function sanitizeHeaders(headers: any): any {
+  if (!headers || typeof headers !== 'object') {
+    return headers;
+  }
+
+  if (Array.isArray(headers)) {
+    return headers.map((header) =>
+      Array.isArray(header)
+        ? [header[0], sanitizeHeaderValue(header[0], header[1])]
+        : header,
+    );
+  }
+
+  if (typeof headers.entries === 'function') {
+    return Object.fromEntries(
+      [...headers.entries()].map(([name, value]: [string, string]) => [
+        name,
+        sanitizeHeaderValue(name, value),
+      ]),
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(headers).map(([name, value]) => [
+      name,
+      sanitizeHeaderValue(name, value),
+    ]),
+  );
+}
+
+function sanitizeRequestParams<T>(requestParams: T): T {
+  if (Array.isArray(requestParams)) {
+    return requestParams.map((param) =>
+      param && typeof param === 'object' && 'headers' in param
+        ? {...param, headers: sanitizeHeaders(param.headers)}
+        : param,
+    ) as T;
+  }
+
+  if (
+    requestParams &&
+    typeof requestParams === 'object' &&
+    'headers' in requestParams
+  ) {
+    return {
+      ...requestParams,
+      headers: sanitizeHeaders((requestParams as {headers: any}).headers),
+    };
+  }
+
+  return requestParams;
+}
+
 function serializeResponse(response: Response | any) {
   if (!response) {
     return {error: 'No response object provided'};
@@ -42,10 +113,8 @@ function serializeResponse(response: Response | any) {
       url,
     };
 
-    if (headers?.entries) {
-      serialized.headers = Object.fromEntries(headers.entries());
-    } else if (headers) {
-      serialized.headers = headers;
+    if (headers) {
+      serialized.headers = sanitizeHeaders(headers);
     }
 
     return serialized;
@@ -61,7 +130,9 @@ export function clientLoggerFactory(config: ConfigInterface) {
         case 'HTTP-Response': {
           const responseLog: HTTPResponseLog['content'] = logContent.content;
           logger(config).debug('Received response for HTTP request', {
-            requestParams: JSON.stringify(responseLog.requestParams),
+            requestParams: JSON.stringify(
+              sanitizeRequestParams(responseLog.requestParams),
+            ),
             response: JSON.stringify(serializeResponse(responseLog.response)),
           });
           break;
@@ -69,7 +140,9 @@ export function clientLoggerFactory(config: ConfigInterface) {
         case 'HTTP-Retry': {
           const responseLog: HTTPRetryLog['content'] = logContent.content;
           logger(config).debug('Retrying HTTP request', {
-            requestParams: JSON.stringify(responseLog.requestParams),
+            requestParams: JSON.stringify(
+              sanitizeRequestParams(responseLog.requestParams),
+            ),
             retryAttempt: responseLog.retryAttempt,
             maxRetries: responseLog.maxRetries,
             response: responseLog.lastResponse
@@ -84,7 +157,9 @@ export function clientLoggerFactory(config: ConfigInterface) {
           logger(config).debug(
             'Received response containing Deprecated GraphQL Notice',
             {
-              requestParams: JSON.stringify(responseLog.requestParams),
+              requestParams: JSON.stringify(
+                sanitizeRequestParams(responseLog.requestParams),
+              ),
               deprecationNotice: responseLog.deprecationNotice,
             },
           );

--- a/packages/apps/shopify-api/lib/utils/__tests__/fetch-request.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/fetch-request.test.ts
@@ -159,6 +159,33 @@ describe('fetchRequest', () => {
     }).toMatchMadeHttpRequest();
   });
 
+  it('omits the body from debug logs when the URL does not parse', async () => {
+    // GIVEN
+    const logFn = jest.fn();
+    const config = testConfig({
+      logger: {log: logFn, level: LogSeverity.Debug, httpRequests: true},
+    });
+
+    // WHEN
+    const relativeUrl = 'admin/oauth/access_token';
+    await expect(
+      fetchRequestFactory(config)(relativeUrl, {
+        method: 'POST',
+        body: JSON.stringify({client_secret: 'test-client-secret-value'}),
+      }),
+    ).rejects.toThrow();
+
+    // THEN
+    expect(logFn).toHaveBeenNthCalledWith(
+      1,
+      LogSeverity.Debug,
+      `[shopify-api/DEBUG] Making HTTP request | {method: POST, url: ${relativeUrl}}`,
+    );
+    logFn.mock.calls.forEach(([_severity, message]) => {
+      expect(message).not.toContain('test-client-secret-value');
+    });
+  });
+
   it('logs non-200 response codes', async () => {
     // GIVEN
     const logFn = jest.fn();

--- a/packages/apps/shopify-api/lib/utils/__tests__/fetch-request.test.ts
+++ b/packages/apps/shopify-api/lib/utils/__tests__/fetch-request.test.ts
@@ -113,6 +113,52 @@ describe('fetchRequest', () => {
     }).toMatchMadeHttpRequest();
   });
 
+  it('omits the body from debug logs for OAuth token endpoint requests', async () => {
+    // GIVEN
+    const logFn = jest.fn();
+    const config = testConfig({
+      logger: {log: logFn, level: LogSeverity.Debug, httpRequests: true},
+    });
+
+    queueMockResponse(JSON.stringify(successResponse));
+
+    // WHEN
+    const requestBody = {
+      client_id: 'test-api-key',
+      client_secret: 'test-client-secret-value',
+      code: 'test-authorization-code',
+    };
+    const tokenUrl = `https://${domain}/admin/oauth/access_token`;
+    const response = await fetchRequestFactory(config)(tokenUrl, {
+      method: 'POST',
+      body: JSON.stringify(requestBody),
+    });
+    const responseBody = await response.json();
+
+    // THEN
+    expect(logFn).toHaveBeenNthCalledWith(
+      1,
+      LogSeverity.Debug,
+      `[shopify-api/DEBUG] Making HTTP request | {method: POST, url: ${tokenUrl}}`,
+    );
+    expect(logFn).toHaveBeenNthCalledWith(
+      2,
+      LogSeverity.Debug,
+      `[shopify-api/DEBUG] HTTP request completed | {method: POST, url: ${tokenUrl}, status: 200}`,
+    );
+    logFn.mock.calls.forEach(([_severity, message]) => {
+      expect(message).not.toContain('test-client-secret-value');
+      expect(message).not.toContain('test-authorization-code');
+    });
+    expect(responseBody).toEqual(successResponse);
+    expect({
+      method: 'POST',
+      domain,
+      path: '/admin/oauth/access_token',
+      data: requestBody,
+    }).toMatchMadeHttpRequest();
+  });
+
   it('logs non-200 response codes', async () => {
     // GIVEN
     const logFn = jest.fn();

--- a/packages/apps/shopify-api/lib/utils/fetch-request.ts
+++ b/packages/apps/shopify-api/lib/utils/fetch-request.ts
@@ -3,6 +3,17 @@ import {LogSeverity} from '../types';
 import {abstractFetch} from '../../runtime';
 import {ConfigInterface} from '../base-types';
 
+const OAUTH_TOKEN_ENDPOINT_PATH = '/admin/oauth/access_token';
+
+// Token endpoint bodies carry OAuth secrets, so they must not reach the logs.
+function isOAuthTokenEndpoint(url: string): boolean {
+  try {
+    return new URL(url).pathname === OAUTH_TOKEN_ENDPOINT_PATH;
+  } catch {
+    return false;
+  }
+}
+
 export function fetchRequestFactory(config: ConfigInterface) {
   return async function fetchRequest(
     url: string,
@@ -16,7 +27,8 @@ export function fetchRequestFactory(config: ConfigInterface) {
       log.debug('Making HTTP request', {
         method: options?.method || 'GET',
         url,
-        ...(options?.body && {body: options?.body}),
+        ...(options?.body &&
+          !isOAuthTokenEndpoint(url) && {body: options.body}),
       });
     }
 

--- a/packages/apps/shopify-api/lib/utils/fetch-request.ts
+++ b/packages/apps/shopify-api/lib/utils/fetch-request.ts
@@ -6,9 +6,10 @@ import {ConfigInterface} from '../base-types';
 const OAUTH_TOKEN_ENDPOINT_PATH = '/admin/oauth/access_token';
 
 // Token endpoint bodies carry OAuth secrets, so they must not reach the logs.
-function isOAuthTokenEndpoint(url: string): boolean {
+// When the URL does not parse, fail closed and keep the body out of the logs.
+function canLogRequestBody(url: string): boolean {
   try {
-    return new URL(url).pathname === OAUTH_TOKEN_ENDPOINT_PATH;
+    return new URL(url).pathname !== OAUTH_TOKEN_ENDPOINT_PATH;
   } catch {
     return false;
   }
@@ -27,8 +28,7 @@ export function fetchRequestFactory(config: ConfigInterface) {
       log.debug('Making HTTP request', {
         method: options?.method || 'GET',
         url,
-        ...(options?.body &&
-          !isOAuthTokenEndpoint(url) && {body: options.body}),
+        ...(options?.body && canLogRequestBody(url) && {body: options.body}),
       });
     }
 


### PR DESCRIPTION
### WHY are these changes introduced?

Fixes two internally tracked AppSec findings (`41ecfa92-9a6f-43a9-824a-9565156ca500`, `17821c14-965e-450c-beb9-0cc5a516096b`).

With `logger.level: Debug` and `logger.httpRequests: true`, the library wrote reusable credentials to the log sink:

- `fetchRequestFactory` logged the full request body of OAuth token endpoint calls (`client_secret`, `code`, `subject_token`, `refresh_token`, client-credentials grants).
- `clientLoggerFactory` logged `requestParams` verbatim, including `X-Shopify-Access-Token`, `Shopify-Storefront-Private-Token`, and other credential headers, in all three debug branches.

Requested by Ariel Caplan <ariel.caplan@shopify.com>.

### WHAT is this pull request doing?

- `lib/utils/fetch-request.ts`: omit the request body from the debug log when the URL path is `/admin/oauth/access_token`, or when the URL does not parse (fail closed). Method, URL, and response status are still logged. Non-OAuth request logging is unchanged.
- `lib/clients/common.ts`: pass `requestParams` through a header sanitizer in the `HTTP-Response`, `HTTP-Retry`, and `HTTP-Response-GraphQL-Deprecation-Notice` branches. The sanitizer matches header names case-insensitively and replaces the values of `Authorization`, `Cookie`, `Set-Cookie`, `X-Shopify-Access-Token`, `Shopify-Storefront-Private-Token`, and `X-Shopify-Storefront-Access-Token` with `****`. Plain-object and array-of-pairs header shapes are redacted in place; request `Headers` instances stay opaque (they serialized as `{}` before, and enumerating them would expose unlisted credential headers). Serialized response headers go through the same redaction.
- Regression tests that fail if these credentials reach the debug log again (verified against the unfixed code).
- `docs/guides/logger.md`: document the redaction behavior and remove the access-token value from the example output.

## Type of change

- [x] Patch: Bug (non-breaking change which fixes an issue)
- [ ] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

