### PR TITLE
test: fix session storage container readiness

### DIFF
--- a/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/__tests__/mongodb.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-mongodb/src/__tests__/mongodb.test.ts
@@ -3,9 +3,8 @@ import {promisify} from 'util';
 
 import {
   batteryOfTests,
-  poll,
+  waitForContainerLog,
 } from '@shopify/shopify-app-session-storage-test-utils';
-import * as mongodb from 'mongodb';
 
 import {MongoDBSessionStorage} from '../mongodb';
 
@@ -20,34 +19,35 @@ const dbName = 'shopitest';
 
 describe('MongoDBSessionStorage', () => {
   let storage: MongoDBSessionStorage;
-  let containerId: string;
+  let containerId: string | undefined;
   beforeAll(async () => {
     const runCommand = await exec(
-      "podman run -d -e MONGO_INITDB_DATABASE=shopitest -e MONGO_INITDB_ROOT_USERNAME='shop&fy' -e MONGO_INITDB_ROOT_PASSWORD='passify$#' -p 27017:27017 mongo:5",
+      "podman run -d --network=host -e MONGO_INITDB_DATABASE=shopitest -e MONGO_INITDB_ROOT_USERNAME='shop&fy' -e MONGO_INITDB_ROOT_PASSWORD='passify$#' mongo:5",
       {encoding: 'utf8'},
     );
     containerId = runCommand.stdout.trim();
 
-    await poll(
+    await waitForContainerLog(
       async () => {
-        try {
-          const client = new (mongodb as any).MongoClient(dbURL.toString());
-          await client.connect();
-          await client.db().command({ping: 1});
-          client.close();
-        } catch {
-          return false;
-        }
-        return true;
+        const {stdout, stderr} = await exec(`podman logs ${containerId}`);
+        const logs = `${stdout}\n${stderr}`;
+        const initCompleteLog =
+          'MongoDB init process complete; ready for start up.';
+        const initCompleteIndex = logs.lastIndexOf(initCompleteLog);
+
+        return initCompleteIndex >= 0 ? logs.slice(initCompleteIndex) : '';
       },
-      {interval: 500, timeout: 60000},
+      'Waiting for connections',
+      {interval: 500, timeout: 120000},
     );
+
     storage = new MongoDBSessionStorage(dbURL, dbName);
-  });
+    await storage.ready;
+  }, 180000);
 
   afterAll(async () => {
-    await storage.disconnect();
-    await exec(`podman rm -f ${containerId}`);
+    if (storage) await storage.disconnect();
+    if (containerId) await exec(`podman rm -f ${containerId}`);
   });
 
   batteryOfTests(async () => storage);

--- a/packages/apps/session-storage/shopify-app-session-storage-redis/jest.config.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-redis/jest.config.ts
@@ -5,7 +5,7 @@ import baseConfig from '../../../../config/tests/jest.config';
 
 const config: Config = {
   ...baseConfig,
-  testTimeout: 50000,
+  testTimeout: 70000,
 };
 
 export default config;

--- a/packages/apps/session-storage/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-redis/src/__tests__/redis.test.ts
@@ -6,6 +6,7 @@ import {createClient} from 'redis';
 import {
   batteryOfTests,
   wait,
+  waitForContainerLog,
 } from '@shopify/shopify-app-session-storage-test-utils';
 import {Session} from '@shopify/shopify-api';
 
@@ -29,13 +30,19 @@ describe('RedisSessionStorage', () => {
   beforeAll(async () => {
     const configPath = resolve(__dirname, './redis.conf');
     const runCommand = await exec(
-      `podman run -d -p 6379:6379 -v ${configPath}:/redis.conf redis:6 redis-server /redis.conf`,
+      `podman run -d --network=host -v ${configPath}:/redis.conf redis:6 redis-server /redis.conf`,
       {encoding: 'utf8'},
     );
     containerId = runCommand.stdout.trim();
 
-    // Give the container a lot of time to set up since polling is ineffective with podman
-    await wait(10000);
+    await waitForContainerLog(
+      async () => {
+        const {stdout, stderr} = await exec(`podman logs ${containerId}`);
+        return `${stdout}\n${stderr}`;
+      },
+      'Ready to accept connections',
+      {interval: 500, timeout: 60000},
+    );
   });
 
   afterAll(async () => {

--- a/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/__tests__/session-test-utils.test.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/__tests__/session-test-utils.test.ts
@@ -1,6 +1,46 @@
 import {Session} from '@shopify/shopify-api';
 
 import {sessionArraysEqual} from '../session-test-utils';
+import {waitForContainerLog} from '../utils';
+
+describe('waitForContainerLog', () => {
+  it('waits until the expected log appears', async () => {
+    const getLogs = jest
+      .fn()
+      .mockResolvedValueOnce('starting')
+      .mockResolvedValueOnce('Ready to accept connections');
+
+    await waitForContainerLog(getLogs, 'Ready to accept connections', {
+      interval: 1,
+      timeout: 100,
+    });
+
+    expect(getLogs).toHaveBeenCalledTimes(2);
+  });
+  it('retries when reading logs fails', async () => {
+    const getLogs = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('container is starting'))
+      .mockResolvedValueOnce('Ready to accept connections');
+
+    await waitForContainerLog(getLogs, 'Ready to accept connections', {
+      interval: 1,
+      timeout: 100,
+    });
+
+    expect(getLogs).toHaveBeenCalledTimes(2);
+  });
+  it('includes the last logs when readiness times out', async () => {
+    const getLogs = jest.fn().mockResolvedValue('starting\nstill starting');
+
+    await expect(
+      waitForContainerLog(getLogs, 'Ready to accept connections', {
+        interval: 1,
+        timeout: 20,
+      }),
+    ).rejects.toThrow('Last container logs:\nstarting\nstill starting');
+  });
+});
 
 describe('test sessionArraysEqual', () => {
   it('returns true for two identically ordered arrays', () => {

--- a/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/utils.ts
+++ b/packages/apps/session-storage/shopify-app-session-storage-test-utils/src/utils.ts
@@ -24,6 +24,28 @@ export async function poll(
     await wait(interval);
   }
 }
+export async function waitForContainerLog(
+  getLogs: () => Promise<string>,
+  expectedLog: string,
+  options?: {interval?: number; timeout?: number},
+): Promise<void> {
+  let lastLogs = '';
+
+  try {
+    await poll(async () => {
+      try {
+        lastLogs = await getLogs();
+        return lastLogs.includes(expectedLog);
+      } catch (error) {
+        lastLogs = error instanceof Error ? error.message : String(error);
+        return false;
+      }
+    }, options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}\nLast container logs:\n${lastLogs}`);
+  }
+}
 
 export function waitForData(socket: Socket): Promise<string> {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Fixes

The session storage CI matrix failed in `shopify-app-session-storage-mongodb` with `write ECONNRESET`. Failed setup then produced `TypeError: Cannot read properties of undefined (reading 'disconnect')` in `afterAll`.

The Redis test also used a fixed ten-second sleep instead of checking readiness.

### Why it happened

The Ubuntu 24.04 runner image `ubuntu24/20260810.271` upgraded Podman from `4.9.3` to `5.8.4`.

Podman 5 uses `pasta` for rootless networking. MongoDB's published port accepted connections during the `mongo:5` entrypoint's temporary initialization server, then reset them when that server stopped.

The existing ping treated that temporary server as ready. The session storage client then connected during the transition, so the failure appeared later as `write ECONNRESET`.

The August 11 failure was a separate Redis timing failure on the old runner image. Persistent MongoDB failures started after the Podman upgrade.

### Changes

- Add shared `waitForContainerLog` polling coverage.
- Wait for MongoDB's initialization-complete marker, then its final `Waiting for connections` log.
- Use host networking for MongoDB and Redis tests to avoid the Podman 5 port-forwarding failure.
- Replace Redis's fixed sleep with a `Ready to accept connections` check.
- Include stdout and stderr in readiness checks.
- Include the last container logs when readiness times out.
- Guard MongoDB cleanup when setup fails.
- Apply the extended timeout only to the MongoDB `beforeAll` hook.

This test-only change carries the `Skip Changelog` label and does not require a package release.

### Verification

The previous head passed the full CI matrix in run [32980350161](https://github.com/Shopify/shopify-app-js/actions/runs/32980350161). This squashed update triggers a fresh CI run.

Local checks:

- `pnpm --filter @shopify/shopify-app-session-storage-test-utils test --runInBand` — 7 tests passed.
- TypeScript checks for the test utilities, MongoDB, and Redis packages.
- Lint and Prettier checks for all changed files.
