### PR TITLE
Allows the user to pass in the polaris url for rc builds

### DIFF
--- a/.changeset/young-zoos-jump.md
+++ b/.changeset/young-zoos-jump.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-app-react-router': minor
+---
+
+Added the ability to specify the polaris.js version you want to use

--- a/packages/apps/shopify-app-react-router/src/react/components/AppProvider/AppProvider.tsx
+++ b/packages/apps/shopify-app-react-router/src/react/components/AppProvider/AppProvider.tsx
@@ -21,6 +21,13 @@ export interface AppProviderProps {
    * loader to the component.
    */
   apiKey: string;
+
+  /**
+   * The URL to load the Polaris web components script from.
+   *
+   * Defaults to the Shopify CDN URL. Only override this if you need to test an upcoming Polaris release.
+   */
+  polarisUrl?: string;
 }
 
 /**
@@ -59,10 +66,11 @@ export interface AppProviderProps {
  * ```
  */
 export function AppProvider(props: AppProviderProps) {
+  const {polarisUrl = POLARIS_URL} = props;
   return (
     <>
       <AppBridge apiKey={props.apiKey} />
-      <script src={POLARIS_URL} />
+      <script src={polarisUrl} />
       {props.children}
     </>
   );

--- a/packages/apps/shopify-app-react-router/src/react/components/AppProvider/__tests__/AppProvider.test.tsx
+++ b/packages/apps/shopify-app-react-router/src/react/components/AppProvider/__tests__/AppProvider.test.tsx
@@ -63,6 +63,22 @@ describe('<AppProvider />', () => {
     });
   });
 
+  it('renders a custom Polaris script URL when provided', () => {
+    // GIVEN
+    const polarisUrl = 'https://cdn.shopify.com/shopifycloud/polaris-1.1-rc.js';
+
+    // WHEN
+    const component = mountWithRouter(
+      <AppProvider apiKey="test-api-key" polarisUrl={polarisUrl}>
+        <div>Hello world</div>
+      </AppProvider>,
+    );
+
+    // THEN
+    expect(component).toContainReactComponent('script', {src: polarisUrl});
+    expect(component).not.toContainReactComponent('script', {src: POLARIS_URL});
+  });
+
   it('sets up navigation event listener', () => {
     // GIVEN
     const apiKey = 'test-api-key';

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/render-app-bridge.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/admin/helpers/render-app-bridge.ts
@@ -37,7 +37,12 @@ export function renderAppBridge(
   const shop = api.utils.sanitizeShop(
     new URL(request.url).searchParams.get('shop')!,
   );
-  addDocumentResponseHeaders(responseHeaders, isEmbeddedApp, shop);
+  addDocumentResponseHeaders(
+    responseHeaders,
+    isEmbeddedApp,
+    shop,
+    config.polarisUrl,
+  );
 
   throw new Response(
     `

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/__tests__/add-response-headers.test.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/__tests__/add-response-headers.test.ts
@@ -1,4 +1,5 @@
 import {shopifyApp} from '../../..';
+import {APP_BRIDGE_URL, CDN_URL} from '../../const';
 import {
   APP_URL,
   TEST_SHOP,
@@ -18,5 +19,21 @@ describe('addDocumentResponseHeaders', () => {
 
     // THEN
     expectDocumentRequestHeaders(response, true);
+  });
+
+  it('uses a custom polarisUrl in the preload Link header when configured', () => {
+    // GIVEN
+    const polarisUrl = 'https://cdn.shopify.com/shopifycloud/polaris-1.1-rc.js';
+    const shopify = shopifyApp(testConfig({polarisUrl}));
+    const request = new Request(`${APP_URL}?shop=${TEST_SHOP}`);
+    const response = new Response();
+
+    // WHEN
+    shopify.addDocumentResponseHeaders(request, response.headers);
+
+    // THEN
+    expect(response.headers.get('Link')).toEqual(
+      `<${CDN_URL}>; rel="preconnect", <${APP_BRIDGE_URL}>; rel="preload"; as="script", <${polarisUrl}>; rel="preload"; as="script"`,
+    );
   });
 });

--- a/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/add-response-headers.ts
+++ b/packages/apps/shopify-app-react-router/src/server/authenticate/helpers/add-response-headers.ts
@@ -17,7 +17,7 @@ export function addDocumentResponseHeadersFactory(
     const shop = api.utils.sanitizeShop(searchParams.get('shop')!);
 
     const isEmbeddedApp = config.distribution !== AppDistribution.ShopifyAdmin;
-    addDocumentResponseHeaders(headers, isEmbeddedApp, shop);
+    addDocumentResponseHeaders(headers, isEmbeddedApp, shop, config.polarisUrl);
   };
 }
 
@@ -25,11 +25,12 @@ export function addDocumentResponseHeaders(
   headers: Headers,
   isEmbeddedApp: boolean,
   shop: string | null | undefined,
+  polarisUrl: string = POLARIS_URL,
 ) {
   if (shop) {
     headers.set(
       'Link',
-      `<${CDN_URL}>; rel="preconnect", <${APP_BRIDGE_URL}>; rel="preload"; as="script", <${POLARIS_URL}>; rel="preload"; as="script"`,
+      `<${CDN_URL}>; rel="preconnect", <${APP_BRIDGE_URL}>; rel="preload"; as="script", <${polarisUrl}>; rel="preload"; as="script"`,
     );
   }
 

--- a/packages/apps/shopify-app-react-router/src/server/config-types.ts
+++ b/packages/apps/shopify-app-react-router/src/server/config-types.ts
@@ -22,7 +22,8 @@ import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promis
 
 export interface BillingConfigWithLineItems {
   [plan: string]:
-    BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan;
+    | BillingConfigOneTimePlan
+    | BillingConfigSubscriptionLineItemPlan;
 }
 
 type ReactRouterManagedApiConfigOptions<Future extends FutureFlagOptions> =
@@ -113,11 +114,11 @@ export interface AppConfigArg<
 
   /**
    * The config for the shop-specific webhooks your app needs.
-   * 
+   *
    * Use this to configure shop-specific webhooks. In many cases defining app-specific webhooks in the `shopify.app.toml` will be sufficient and easier to manage.  Please see:
-   * 
+   *
    * {@link https://shopify.dev/docs/apps/build/webhooks/subscribe#app-specific-vs-shop-specific-subscriptions}
-   * 
+   *
    * You should only use this if you need shop-specific webhooks. If you do need shop-specific webhooks this can be in used in conjunction with the afterAuth hook, loaders or processes such as background jobs.
    *
    * @example
@@ -146,7 +147,7 @@ export interface AppConfigArg<
    * export default shopify;
    * export const authenticate = shopify.authenticate;
    * ```
-   * 
+   *
    * @example
    * <caption>Registering app-specific webhooks (Recommended)</caption>
    * ```toml
@@ -157,9 +158,9 @@ export interface AppConfigArg<
    *   [[webhooks.subscriptions]]
    *   topics = ["products/create"]
    *   uri = "/webhooks/products/create"
-   * 
+   *
    * ```
-   * 
+   *
    * @example
    * <caption>Authenticating a webhook request</caption>
    *
@@ -171,13 +172,13 @@ export interface AppConfigArg<
    *
    * export const action = async ({ request }: ActionFunctionArgs) => {
    *   const { topic, shop, session, payload } = await authenticate.webhook(request);
-   * 
+   *
    *   // Webhook requests can trigger after an app is uninstalled
    *   // If the app is already uninstalled, the session may be undefined.
    *   if (!session) {
    *     throw new Response();
    *   }
-   * 
+   *
    *   // Handle the webhook
    *   console.log(`${TOPIC} webhook received with`, JSON.stringify(payload))
    *
@@ -279,6 +280,14 @@ export interface AppConfigArg<
    * releases in advance and provide feedback on the new features.
    */
   future?: Future;
+
+  /**
+   * The URL to load the Polaris web components script from.
+   *
+   * This is used to add a preload `Link` header to document responses. It should match the `polarisUrl` you pass to the
+   * `AppProvider` component. Defaults to the Shopify CDN URL. Only override this if you need to load a Polaris release candidate.
+   */
+  polarisUrl?: string;
 }
 
 export interface AppConfig<
@@ -294,6 +303,7 @@ export interface AppConfig<
   idempotentPromiseHandler: IdempotentPromiseHandler;
   distribution: AppDistribution;
   billing?: BillingConfigWithLineItems;
+  polarisUrl: string;
 }
 
 export interface AuthConfig {

--- a/packages/apps/shopify-app-react-router/src/server/config-types.ts
+++ b/packages/apps/shopify-app-react-router/src/server/config-types.ts
@@ -22,8 +22,7 @@ import {IdempotentPromiseHandler} from './authenticate/helpers/idempotent-promis
 
 export interface BillingConfigWithLineItems {
   [plan: string]:
-    | BillingConfigOneTimePlan
-    | BillingConfigSubscriptionLineItemPlan;
+    BillingConfigOneTimePlan | BillingConfigSubscriptionLineItemPlan;
 }
 
 type ReactRouterManagedApiConfigOptions<Future extends FutureFlagOptions> =

--- a/packages/apps/shopify-app-react-router/src/server/shopify-app.ts
+++ b/packages/apps/shopify-app-react-router/src/server/shopify-app.ts
@@ -22,6 +22,7 @@ import {authStrategyFactory} from './authenticate/admin/authenticate';
 import {authenticateWebhookFactory} from './authenticate/webhooks/authenticate';
 import {overrideLogger} from './override-logger';
 import {addDocumentResponseHeadersFactory} from './authenticate/helpers';
+import {POLARIS_URL} from './authenticate/const';
 import {loginFactory} from './authenticate/login/login';
 import {unauthenticatedAdminContextFactory} from './unauthenticated/admin';
 import {authenticatePublicFactory} from './authenticate/public';
@@ -203,6 +204,7 @@ function deriveConfig<Storage extends SessionStorage>(
     hooks: appConfig.hooks ?? {},
     sessionStorage: appConfig.sessionStorage as Storage,
     future: appConfig.future ?? {},
+    polarisUrl: appConfig.polarisUrl ?? POLARIS_URL,
     auth: {
       path: authPathPrefix,
       callbackPath: `${authPathPrefix}/callback`,


### PR DESCRIPTION
### WHY are these changes introduced?

This allows developers to try out polaris's rc builds before they are released to the public.

Here is proof that it is making its way into the script tag:
<img width="381" height="246" alt="image" src="https://github.com/user-attachments/assets/9bc76ad5-6ca4-470a-889d-11cdf8f31b8c" />

Here is proof that it is making its way to the preload Link header:
<img width="350" height="147" alt="image" src="https://github.com/user-attachments/assets/4eadd5d7-93b9-49c0-905c-4dad77584dee" />

### WHAT is this pull request doing?

Adds a configurable Polaris script URL, exposed in two aligned places so both the rendered `<script>` and the preload hint stay in sync:

- `<AppProvider polarisUrl={...} />` — controls the `<script src>` rendered on the page.
- `shopifyApp({ polarisUrl: ... })` — controls the `<...>; rel="preload"; as="script"` segment of the document `Link` header.

Both default to the existing Shopify CDN URL, so this is fully backwards compatible — apps that don't set it behave exactly as before. Developers overriding it should set both to the same value, otherwise the preload hint points at a different URL than the script that actually loads.

Scope note: only the Polaris URL is configurable. The App Bridge and CDN URLs are intentionally left hardcoded.

### Testing

- `cd packages/apps/shopify-app-react-router && npx jest AppProvider add-response-headers`
- Client override: pass `polarisUrl="https://.../custom-polaris.js"` to `AppProvider`, load the embedded app, and confirm the rendered `<script src>` (see first screenshot).
- Server override: set `polarisUrl` in `shopifyApp({...})` and check the document response `Link` header, e.g. `curl -sI "<app-url>/?shop=<shop>.myshopify.com" | grep -i '^link:'` (see second screenshot).

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `pnpm changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` files manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)

<details>
<summary>Implementation details (for AI agents)</summary>

- New optional `polarisUrl` prop on `AppProviderProps` (client) and new optional `polarisUrl` on `AppConfigArg` (server), both defaulting to the shared `POLARIS_URL` constant.
- Server default is applied in `deriveConfig` (`shopify-app.ts`) so the derived `AppConfig.polarisUrl` is always a concrete string; consumers read `config.polarisUrl` rather than the constant.
- `addDocumentResponseHeaders` takes `polarisUrl` as a trailing param defaulting to `POLARIS_URL`, so the existing direct callers/tests remain backwards compatible. Both call sites (`addDocumentResponseHeadersFactory` and `renderAppBridge`) now thread `config.polarisUrl` through.
- The App Bridge URL and `CDN_URL` preconnect are deliberately not parameterized — only the Polaris preload/script URL is configurable.

</details>
